### PR TITLE
feat: Label Printing Desktop Bridge (PCO-style) (#44)

### DIFF
--- a/src/web/src/components/checkin/CheckinConfirmation.tsx
+++ b/src/web/src/components/checkin/CheckinConfirmation.tsx
@@ -6,6 +6,9 @@ export interface CheckinConfirmationProps {
   attendances: AttendanceResultDto[];
   onDone: () => void;
   onPrintLabels?: () => void;
+  printStatus?: 'idle' | 'printing' | 'success' | 'error';
+  printError?: string | null;
+  printerAvailable?: boolean;
 }
 
 /**
@@ -15,6 +18,9 @@ export function CheckinConfirmation({
   attendances,
   onDone,
   onPrintLabels,
+  printStatus = 'idle',
+  printError = null,
+  printerAvailable = false,
 }: CheckinConfirmationProps) {
   return (
     <div className="max-w-4xl mx-auto">
@@ -73,6 +79,47 @@ export function CheckinConfirmation({
         ))}
       </div>
 
+      {/* Print Status */}
+      {printStatus === 'printing' && (
+        <div className="mb-4">
+          <Card className="bg-blue-50 border-blue-200">
+            <div className="flex items-center gap-3">
+              <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600"></div>
+              <p className="text-blue-800 text-sm">Printing labels...</p>
+            </div>
+          </Card>
+        </div>
+      )}
+
+      {printStatus === 'success' && (
+        <div className="mb-4">
+          <Card className="bg-green-50 border-green-200">
+            <div className="flex items-center gap-2">
+              <svg className="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+              <p className="text-green-800 text-sm font-medium">Labels printed successfully!</p>
+            </div>
+          </Card>
+        </div>
+      )}
+
+      {printStatus === 'error' && printError && (
+        <div className="mb-4">
+          <Card className="bg-red-50 border-red-200">
+            <div className="flex items-center gap-2">
+              <svg className="w-5 h-5 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+              <div>
+                <p className="text-red-800 text-sm font-medium">Print failed</p>
+                <p className="text-red-700 text-xs">{printError}</p>
+              </div>
+            </div>
+          </Card>
+        </div>
+      )}
+
       {/* Action Buttons */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {onPrintLabels && (
@@ -81,8 +128,10 @@ export function CheckinConfirmation({
             variant="secondary"
             size="lg"
             className="text-xl"
+            disabled={printStatus === 'printing'}
+            loading={printStatus === 'printing'}
           >
-            Print Labels
+            {printStatus === 'success' ? 'Reprint Labels' : 'Print Labels'}
           </Button>
         )}
         <Button
@@ -100,7 +149,12 @@ export function CheckinConfirmation({
         <ul className="text-blue-800 space-y-1">
           <li>• Keep your security code to pick up your child</li>
           <li>• Present your code at the check-out desk</li>
-          <li>• Labels will be available at the printer</li>
+          {printerAvailable && printStatus === 'success' && (
+            <li>• Collect your printed labels from the printer</li>
+          )}
+          {!printerAvailable && (
+            <li>• Labels can be printed later from the welcome desk</li>
+          )}
         </ul>
       </div>
     </div>

--- a/src/web/src/components/checkin/PrintStatus.tsx
+++ b/src/web/src/components/checkin/PrintStatus.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from 'react';
+import { printBridgeClient, type PrinterInfo } from '@/services/printing/PrintBridgeClient';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+
+export interface PrintStatusProps {
+  onPrinterAvailable?: (printer: PrinterInfo) => void;
+  onPrinterUnavailable?: () => void;
+}
+
+/**
+ * Component that shows the current print bridge and printer status.
+ * Checks if print bridge is running and if a Zebra printer is available.
+ */
+export function PrintStatus({ onPrinterAvailable, onPrinterUnavailable }: PrintStatusProps) {
+  const [status, setStatus] = useState<'checking' | 'available' | 'unavailable' | 'no-printer'>('checking');
+  const [printer, setPrinter] = useState<PrinterInfo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const checkPrintBridge = async () => {
+    setStatus('checking');
+    setError(null);
+
+    // Check health first
+    const healthResult = await printBridgeClient.checkHealth();
+
+    if (!healthResult.success) {
+      setStatus('unavailable');
+      setError(healthResult.error);
+      onPrinterUnavailable?.();
+      return;
+    }
+
+    // Get default Zebra printer
+    const printerResult = await printBridgeClient.getDefaultZebraPrinter();
+
+    if (!printerResult.success) {
+      setStatus('unavailable');
+      setError(printerResult.error);
+      onPrinterUnavailable?.();
+      return;
+    }
+
+    if (printerResult.data === null) {
+      setStatus('no-printer');
+      setError('No Zebra thermal printer found. Please install a Zebra printer.');
+      onPrinterUnavailable?.();
+      return;
+    }
+
+    setStatus('available');
+    setPrinter(printerResult.data);
+    onPrinterAvailable?.(printerResult.data);
+  };
+
+  useEffect(() => {
+    checkPrintBridge();
+
+    // Refresh status every 30 seconds
+    const interval = setInterval(checkPrintBridge, 30000);
+
+    return () => clearInterval(interval);
+  }, []);
+
+  if (status === 'checking') {
+    return (
+      <Card className="bg-blue-50 border-blue-200">
+        <div className="flex items-center gap-3">
+          <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-blue-600"></div>
+          <p className="text-blue-800 text-sm">Checking print bridge status...</p>
+        </div>
+      </Card>
+    );
+  }
+
+  if (status === 'unavailable') {
+    return (
+      <Card className="bg-yellow-50 border-yellow-200">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <svg className="w-5 h-5 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+              <p className="text-yellow-800 text-sm font-medium">Print bridge unavailable</p>
+            </div>
+            <Button onClick={checkPrintBridge} variant="secondary" size="sm">
+              Retry
+            </Button>
+          </div>
+          <p className="text-yellow-700 text-xs">{error}</p>
+          <p className="text-yellow-700 text-xs">
+            Labels will not print automatically. Please start the Koinon Print Bridge application.
+          </p>
+        </div>
+      </Card>
+    );
+  }
+
+  if (status === 'no-printer') {
+    return (
+      <Card className="bg-yellow-50 border-yellow-200">
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <svg className="w-5 h-5 text-yellow-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+              </svg>
+              <p className="text-yellow-800 text-sm font-medium">No thermal printer found</p>
+            </div>
+            <Button onClick={checkPrintBridge} variant="secondary" size="sm">
+              Retry
+            </Button>
+          </div>
+          <p className="text-yellow-700 text-xs">{error}</p>
+        </div>
+      </Card>
+    );
+  }
+
+  // status === 'available'
+  return (
+    <Card className="bg-green-50 border-green-200">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <svg className="w-5 h-5 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+          </svg>
+          <div>
+            <p className="text-green-800 text-sm font-medium">Printer ready</p>
+            <p className="text-green-700 text-xs">{printer?.name}</p>
+          </div>
+        </div>
+        <Button onClick={checkPrintBridge} variant="secondary" size="sm">
+          Refresh
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/src/web/src/components/checkin/index.ts
+++ b/src/web/src/components/checkin/index.ts
@@ -15,3 +15,6 @@ export type { CheckinConfirmationProps } from './CheckinConfirmation';
 
 export { IdleWarningModal } from './IdleWarningModal';
 export type { IdleWarningModalProps } from './IdleWarningModal';
+
+export { PrintStatus } from './PrintStatus';
+export type { PrintStatusProps } from './PrintStatus';

--- a/src/web/src/services/printing/PrintBridgeClient.ts
+++ b/src/web/src/services/printing/PrintBridgeClient.ts
@@ -1,0 +1,251 @@
+/**
+ * Client for communicating with the Koinon Print Bridge desktop application.
+ * The print bridge runs locally on Windows and provides label printing via localhost:9632.
+ */
+
+const PRINT_BRIDGE_URL = 'http://localhost:9632';
+
+export interface PrinterInfo {
+  name: string;
+  status: string;
+  isDefault: boolean;
+  isZebraPrinter: boolean;
+  driverName: string;
+  portName: string;
+}
+
+export interface PrintersResponse {
+  printers: PrinterInfo[];
+  count: number;
+  zebraCount: number;
+}
+
+export interface PrintResponse {
+  success: boolean;
+  message: string;
+  printerName: string;
+  labelCount?: number;
+}
+
+export interface HealthResponse {
+  status: string;
+  version: string;
+  timestamp: string;
+}
+
+export interface ErrorResponse {
+  error: string;
+  message: string;
+  printerName?: string;
+}
+
+export type PrintBridgeResponse<T> =
+  | { success: true; data: T }
+  | { success: false; error: string };
+
+/**
+ * Print Bridge Client for label printing operations.
+ */
+export class PrintBridgeClient {
+  private baseUrl: string;
+
+  constructor(baseUrl: string = PRINT_BRIDGE_URL) {
+    this.baseUrl = baseUrl;
+  }
+
+  /**
+   * Checks if the print bridge is available and healthy.
+   */
+  async checkHealth(): Promise<PrintBridgeResponse<HealthResponse>> {
+    try {
+      const response = await fetch(`${this.baseUrl}/health`, {
+        method: 'GET',
+        signal: AbortSignal.timeout(3000), // 3 second timeout
+      });
+
+      if (!response.ok) {
+        return { success: false, error: 'Print bridge returned error status' };
+      }
+
+      const data = await response.json() as HealthResponse;
+      return { success: true, data };
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.name === 'AbortError') {
+          return { success: false, error: 'Print bridge connection timeout - is it running?' };
+        }
+        return { success: false, error: `Cannot connect to print bridge: ${error.message}` };
+      }
+      return { success: false, error: 'Cannot connect to print bridge' };
+    }
+  }
+
+  /**
+   * Gets all available printers from the print bridge.
+   */
+  async getPrinters(): Promise<PrintBridgeResponse<PrintersResponse>> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/printers`, {
+        method: 'GET',
+        signal: AbortSignal.timeout(10000), // 10 second timeout
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json() as ErrorResponse;
+        return { success: false, error: errorData.message || 'Failed to get printers' };
+      }
+
+      const data = await response.json() as PrintersResponse;
+      return { success: true, data };
+    } catch (error) {
+      if (error instanceof Error) {
+        return { success: false, error: `Failed to get printers: ${error.message}` };
+      }
+      return { success: false, error: 'Failed to get printers' };
+    }
+  }
+
+  /**
+   * Refreshes the printer cache.
+   */
+  async refreshPrinters(): Promise<PrintBridgeResponse<{ message: string; count: number }>> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/printers/refresh`, {
+        method: 'POST',
+        signal: AbortSignal.timeout(10000), // 10 second timeout
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json() as ErrorResponse;
+        return { success: false, error: errorData.message || 'Failed to refresh printers' };
+      }
+
+      const data = await response.json() as { message: string; count: number };
+      return { success: true, data };
+    } catch (error) {
+      if (error instanceof Error) {
+        return { success: false, error: `Failed to refresh printers: ${error.message}` };
+      }
+      return { success: false, error: 'Failed to refresh printers' };
+    }
+  }
+
+  /**
+   * Prints a test label to verify printer functionality.
+   */
+  async printTestLabel(printerName: string): Promise<PrintBridgeResponse<PrintResponse>> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/print/test`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ printerName }),
+        signal: AbortSignal.timeout(10000), // 10 second timeout
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json() as ErrorResponse;
+        return { success: false, error: errorData.message || 'Failed to print test label' };
+      }
+
+      const data = await response.json() as PrintResponse;
+      return { success: true, data };
+    } catch (error) {
+      if (error instanceof Error) {
+        return { success: false, error: `Failed to print test label: ${error.message}` };
+      }
+      return { success: false, error: 'Failed to print test label' };
+    }
+  }
+
+  /**
+   * Prints a single ZPL label.
+   */
+  async printLabel(printerName: string, zplContent: string): Promise<PrintBridgeResponse<PrintResponse>> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/print`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ printerName, zplContent }),
+        signal: AbortSignal.timeout(10000), // 10 second timeout
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json() as ErrorResponse;
+        return { success: false, error: errorData.message || 'Failed to print label' };
+      }
+
+      const data = await response.json() as PrintResponse;
+      return { success: true, data };
+    } catch (error) {
+      if (error instanceof Error) {
+        return { success: false, error: `Failed to print label: ${error.message}` };
+      }
+      return { success: false, error: 'Failed to print label' };
+    }
+  }
+
+  /**
+   * Prints multiple ZPL labels in batch.
+   */
+  async printBatch(printerName: string, zplContents: string[]): Promise<PrintBridgeResponse<PrintResponse>> {
+    try {
+      const response = await fetch(`${this.baseUrl}/api/print/batch`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ printerName, zplContents }),
+        signal: AbortSignal.timeout(10000), // 10 second timeout
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json() as ErrorResponse;
+        return { success: false, error: errorData.message || 'Failed to print labels' };
+      }
+
+      const data = await response.json() as PrintResponse;
+      return { success: true, data };
+    } catch (error) {
+      if (error instanceof Error) {
+        return { success: false, error: `Failed to print labels: ${error.message}` };
+      }
+      return { success: false, error: 'Failed to print labels' };
+    }
+  }
+
+  /**
+   * Gets the default Zebra printer, if available.
+   */
+  async getDefaultZebraPrinter(): Promise<PrintBridgeResponse<PrinterInfo | null>> {
+    const printersResult = await this.getPrinters();
+
+    if (!printersResult.success) {
+      return { success: false, error: printersResult.error };
+    }
+
+    // Try to find default Zebra printer first
+    const defaultZebra = printersResult.data.printers.find(
+      p => p.isDefault && p.isZebraPrinter
+    );
+
+    if (defaultZebra) {
+      return { success: true, data: defaultZebra };
+    }
+
+    // Otherwise, return first Zebra printer
+    const firstZebra = printersResult.data.printers.find(p => p.isZebraPrinter);
+
+    if (firstZebra) {
+      return { success: true, data: firstZebra };
+    }
+
+    return { success: true, data: null };
+  }
+}
+
+// Export singleton instance
+export const printBridgeClient = new PrintBridgeClient();

--- a/tools/print-bridge/BUILD.md
+++ b/tools/print-bridge/BUILD.md
@@ -1,0 +1,53 @@
+# Building Koinon Print Bridge
+
+## Platform Requirements
+
+The Koinon Print Bridge is a **Windows-only** application that requires:
+- Windows 10 or later
+- .NET 8.0 SDK
+- Visual Studio 2022 (recommended) or Visual Studio Code with C# extension
+
+## Building on Windows
+
+```bash
+# Build the application
+dotnet build tools/print-bridge/Koinon.PrintBridge/Koinon.PrintBridge.csproj
+
+# Run the application
+dotnet run --project tools/print-bridge/Koinon.PrintBridge/Koinon.PrintBridge.csproj
+
+# Run tests
+dotnet test tools/print-bridge/Koinon.PrintBridge.Tests/Koinon.PrintBridge.Tests.csproj
+
+# Publish for distribution
+dotnet publish tools/print-bridge/Koinon.PrintBridge/Koinon.PrintBridge.csproj -c Release -r win-x64 --self-contained
+```
+
+## Building on Linux/macOS
+
+**This project cannot be built on Linux or macOS** because it uses:
+- Windows Forms for system tray integration
+- Windows Printing APIs (winspool.dll)
+- Windows Management Instrumentation (WMI)
+
+If you're developing on Linux/macOS, you can:
+1. Use a Windows VM or remote Windows machine for building
+2. Set up a CI/CD pipeline that builds on Windows runners
+3. Skip building the print bridge and focus on other components
+
+## Why Windows-Only?
+
+The print bridge requires direct access to Windows printer drivers and system APIs:
+- `System.Drawing.Printing` - Windows printing subsystem
+- `System.Management` - WMI for printer discovery
+- `winspool.dll` - Raw printer communication
+- `System.Windows.Forms` - System tray integration
+
+These APIs are not available on Linux/macOS.
+
+## Cross-Platform Alternatives
+
+If cross-platform printing is needed in the future, consider:
+- CUPS (Common Unix Printing System) for Linux/macOS
+- IPP (Internet Printing Protocol) for network printers
+- Web-based print services with platform-specific agents

--- a/tools/print-bridge/Koinon.PrintBridge.Tests/Koinon.PrintBridge.Tests.csproj
+++ b/tools/print-bridge/Koinon.PrintBridge.Tests/Koinon.PrintBridge.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Koinon.PrintBridge\Koinon.PrintBridge.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/print-bridge/Koinon.PrintBridge.Tests/PrinterDiscoveryServiceTests.cs
+++ b/tools/print-bridge/Koinon.PrintBridge.Tests/PrinterDiscoveryServiceTests.cs
@@ -1,0 +1,86 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.PrintBridge.Tests;
+
+public class PrinterDiscoveryServiceTests
+{
+    private readonly Mock<ILogger<PrinterDiscoveryService>> _mockLogger;
+    private readonly PrinterDiscoveryService _service;
+
+    public PrinterDiscoveryServiceTests()
+    {
+        _mockLogger = new Mock<ILogger<PrinterDiscoveryService>>();
+        _service = new PrinterDiscoveryService(_mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_CompletesSuccessfully()
+    {
+        // Act
+        var act = async () => await _service.InitializeAsync();
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task GetAvailablePrintersAsync_ReturnsNonNullList()
+    {
+        // Act
+        var printers = await _service.GetAvailablePrintersAsync();
+
+        // Assert
+        printers.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task GetAvailablePrintersAsync_ReturnsSameResultsWhenCached()
+    {
+        // Act
+        var firstCall = await _service.GetAvailablePrintersAsync();
+        var secondCall = await _service.GetAvailablePrintersAsync();
+
+        // Assert
+        firstCall.Should().BeSameAs(secondCall, "results should be cached");
+    }
+
+    [Fact]
+    public async Task RefreshPrintersAsync_InvalidatesCache()
+    {
+        // Arrange
+        var firstCall = await _service.GetAvailablePrintersAsync();
+
+        // Act
+        await _service.RefreshPrintersAsync();
+        var secondCall = await _service.GetAvailablePrintersAsync();
+
+        // Assert
+        firstCall.Should().NotBeSameAs(secondCall, "cache should be invalidated after refresh");
+    }
+
+    [Fact]
+    public void GetPrinterInfo_WithValidPrinterName_ReturnsInfo()
+    {
+        // Arrange - Get first available printer from system
+        var printers = _service.GetAvailablePrintersAsync().Result;
+
+        if (printers.Count == 0)
+        {
+            // Skip test if no printers available
+            return;
+        }
+
+        var printerName = printers[0].Name;
+
+        // Act
+        var info = _service.GetPrinterInfo(printerName);
+
+        // Assert
+        info.Should().NotBeNull();
+        info.Name.Should().Be(printerName);
+        info.Status.Should().NotBeNullOrEmpty();
+    }
+}

--- a/tools/print-bridge/Koinon.PrintBridge.Tests/ZplPrintServiceTests.cs
+++ b/tools/print-bridge/Koinon.PrintBridge.Tests/ZplPrintServiceTests.cs
@@ -1,0 +1,162 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.PrintBridge.Tests;
+
+public class ZplPrintServiceTests
+{
+    private readonly Mock<ILogger<ZplPrintService>> _mockLogger;
+    private readonly ZplPrintService _service;
+
+    public ZplPrintServiceTests()
+    {
+        _mockLogger = new Mock<ILogger<ZplPrintService>>();
+        _service = new ZplPrintService(_mockLogger.Object);
+    }
+
+    [Fact]
+    public void ValidateZpl_WithValidZpl_ReturnsTrue()
+    {
+        // Arrange
+        var validZpl = @"^XA
+^FO50,50^A0N,50,50^FDTest Label^FS
+^XZ";
+
+        // Act
+        var result = _service.ValidateZpl(validZpl);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateZpl_WithInvalidZpl_ReturnsFalse()
+    {
+        // Arrange
+        var invalidZpl = "This is not ZPL";
+
+        // Act
+        var result = _service.ValidateZpl(invalidZpl);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateZpl_WithEmptyString_ReturnsFalse()
+    {
+        // Arrange
+        var emptyZpl = "";
+
+        // Act
+        var result = _service.ValidateZpl(emptyZpl);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateZpl_WithWhitespace_ReturnsFalse()
+    {
+        // Arrange
+        var whitespaceZpl = "   ";
+
+        // Act
+        var result = _service.ValidateZpl(whitespaceZpl);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateZpl_WithMissingStartCommand_ReturnsFalse()
+    {
+        // Arrange
+        var invalidZpl = @"^FO50,50^A0N,50,50^FDTest Label^FS
+^XZ";
+
+        // Act
+        var result = _service.ValidateZpl(invalidZpl);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateZpl_WithMissingEndCommand_ReturnsFalse()
+    {
+        // Arrange
+        var invalidZpl = @"^XA
+^FO50,50^A0N,50,50^FDTest Label^FS";
+
+        // Act
+        var result = _service.ValidateZpl(invalidZpl);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void ValidateZpl_WithExtraWhitespace_ReturnsTrue()
+    {
+        // Arrange
+        var validZpl = @"
+
+        ^XA
+^FO50,50^A0N,50,50^FDTest Label^FS
+^XZ
+
+        ";
+
+        // Act
+        var result = _service.ValidateZpl(validZpl);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ValidateZpl_WithCaseInsensitiveCommands_ReturnsTrue()
+    {
+        // Arrange
+        var validZpl = @"^xa
+^FO50,50^A0N,50,50^FDTest Label^FS
+^xz";
+
+        // Act
+        var result = _service.ValidateZpl(validZpl);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task PrintZplAsync_WithEmptyPrinterName_ThrowsArgumentException()
+    {
+        // Arrange
+        var validZpl = "^XA^FO50,50^A0N,50,50^FDTest^FS^XZ";
+
+        // Act
+        Func<Task> act = async () => await _service.PrintZplAsync("", validZpl);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Printer name cannot be empty*");
+    }
+
+    [Fact]
+    public async Task PrintZplAsync_WithEmptyZpl_ThrowsArgumentException()
+    {
+        // Arrange
+        var printerName = "TestPrinter";
+
+        // Act
+        Func<Task> act = async () => await _service.PrintZplAsync(printerName, "");
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*ZPL content cannot be empty*");
+    }
+}

--- a/tools/print-bridge/Koinon.PrintBridge/DiagnosticsController.cs
+++ b/tools/print-bridge/Koinon.PrintBridge/DiagnosticsController.cs
@@ -1,0 +1,300 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace Koinon.PrintBridge;
+
+/// <summary>
+/// API controller for diagnostics, health checks, and printing operations.
+/// </summary>
+[ApiController]
+[Route("api")]
+public class DiagnosticsController : ControllerBase
+{
+    private readonly PrinterDiscoveryService _printerDiscovery;
+    private readonly ZplPrintService _printService;
+    private readonly ILogger<DiagnosticsController> _logger;
+
+    public DiagnosticsController(
+        PrinterDiscoveryService printerDiscovery,
+        ZplPrintService printService,
+        ILogger<DiagnosticsController> logger)
+    {
+        _printerDiscovery = printerDiscovery;
+        _printService = printService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Health check endpoint.
+    /// </summary>
+    [HttpGet("health")]
+    public IActionResult GetHealth()
+    {
+        return Ok(new
+        {
+            status = "healthy",
+            version = "1.0.0",
+            timestamp = DateTime.UtcNow
+        });
+    }
+
+    /// <summary>
+    /// Gets all available printers on the system.
+    /// </summary>
+    [HttpGet("printers")]
+    public async Task<IActionResult> GetPrinters()
+    {
+        try
+        {
+            var printers = await _printerDiscovery.GetAvailablePrintersAsync();
+
+            return Ok(new
+            {
+                printers = printers.Select(p => new
+                {
+                    name = p.Name,
+                    status = p.Status,
+                    isDefault = p.IsDefault,
+                    isZebraPrinter = p.IsZebraPrinter,
+                    driverName = p.DriverName,
+                    portName = p.PortName
+                }),
+                count = printers.Count,
+                zebraCount = printers.Count(p => p.IsZebraPrinter)
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to retrieve printers");
+            return StatusCode(500, new
+            {
+                error = "Failed to retrieve printers",
+                message = ex.Message
+            });
+        }
+    }
+
+    /// <summary>
+    /// Refreshes the printer cache.
+    /// </summary>
+    [HttpPost("printers/refresh")]
+    public async Task<IActionResult> RefreshPrinters()
+    {
+        try
+        {
+            await _printerDiscovery.RefreshPrintersAsync();
+            var printers = await _printerDiscovery.GetAvailablePrintersAsync();
+
+            return Ok(new
+            {
+                message = "Printer cache refreshed",
+                count = printers.Count
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to refresh printers");
+            return StatusCode(500, new
+            {
+                error = "Failed to refresh printers",
+                message = ex.Message
+            });
+        }
+    }
+
+    /// <summary>
+    /// Prints a test label to verify printer functionality.
+    /// </summary>
+    [HttpPost("print/test")]
+    public async Task<IActionResult> PrintTestLabel([FromBody] TestPrintRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.PrinterName))
+        {
+            return BadRequest(new { error = "Printer name is required" });
+        }
+
+        try
+        {
+            // Generate test label
+            var testZpl = @"^XA
+^FO50,50^A0N,50,50^FDTest Label^FS
+^FO50,120^A0N,30,30^FD" + DateTime.Now.ToString("g") + @"^FS
+^FO50,160^A0N,25,25^FDKoinon Print Bridge^FS
+^XZ";
+
+            await _printService.PrintZplAsync(request.PrinterName, testZpl);
+
+            _logger.LogInformation("Test label printed successfully to {PrinterName}", request.PrinterName);
+
+            return Ok(new
+            {
+                success = true,
+                message = $"Test label sent to {request.PrinterName}",
+                printerName = request.PrinterName
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to print test label to {PrinterName}", request.PrinterName);
+            return StatusCode(500, new
+            {
+                error = "Failed to print test label",
+                message = ex.Message,
+                printerName = request.PrinterName
+            });
+        }
+    }
+
+    /// <summary>
+    /// Prints ZPL content to a specified printer.
+    /// </summary>
+    [HttpPost("print")]
+    public async Task<IActionResult> Print([FromBody] PrintRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.PrinterName))
+        {
+            return BadRequest(new { error = "Printer name is required" });
+        }
+
+        if (string.IsNullOrWhiteSpace(request.ZplContent))
+        {
+            return BadRequest(new { error = "ZPL content is required" });
+        }
+
+        // Validate ZPL content with comprehensive security checks
+        var validationResult = _printService.ValidateZplWithSecurity(request.ZplContent);
+        if (!validationResult.IsValid)
+        {
+            return BadRequest(new
+            {
+                error = "Invalid or potentially dangerous ZPL content",
+                message = validationResult.ErrorMessage
+            });
+        }
+
+        try
+        {
+            await _printService.PrintZplAsync(request.PrinterName, request.ZplContent);
+
+            _logger.LogInformation("Label printed successfully to {PrinterName}", request.PrinterName);
+
+            return Ok(new
+            {
+                success = true,
+                message = $"Label sent to {request.PrinterName}",
+                printerName = request.PrinterName
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to print label to {PrinterName}", request.PrinterName);
+            return StatusCode(500, new
+            {
+                error = "Failed to print label",
+                message = ex.Message,
+                printerName = request.PrinterName
+            });
+        }
+    }
+
+    // Maximum batch size to prevent DoS attacks
+    private const int MaxBatchSize = 50;
+
+    /// <summary>
+    /// Prints multiple ZPL labels in batch.
+    /// </summary>
+    [HttpPost("print/batch")]
+    public async Task<IActionResult> PrintBatch([FromBody] BatchPrintRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.PrinterName))
+        {
+            return BadRequest(new { error = "Printer name is required" });
+        }
+
+        if (request.ZplContents == null || request.ZplContents.Count == 0)
+        {
+            return BadRequest(new { error = "At least one ZPL content is required" });
+        }
+
+        // Rate limiting: max 50 labels per batch to prevent DoS
+        if (request.ZplContents.Count > MaxBatchSize)
+        {
+            return BadRequest(new
+            {
+                error = "Batch size exceeded",
+                message = $"Maximum {MaxBatchSize} labels per batch. Received {request.ZplContents.Count}."
+            });
+        }
+
+        // Validate all ZPL content with security checks
+        var invalidLabels = new List<string>();
+        for (int i = 0; i < request.ZplContents.Count; i++)
+        {
+            var validationResult = _printService.ValidateZplWithSecurity(request.ZplContents[i]);
+            if (!validationResult.IsValid)
+            {
+                invalidLabels.Add($"Label {i}: {validationResult.ErrorMessage}");
+            }
+        }
+
+        if (invalidLabels.Count > 0)
+        {
+            return BadRequest(new
+            {
+                error = "Invalid or potentially dangerous ZPL content",
+                message = string.Join("; ", invalidLabels)
+            });
+        }
+
+        try
+        {
+            await _printService.PrintBatchZplAsync(request.PrinterName, request.ZplContents);
+
+            _logger.LogInformation("Batch of {Count} labels printed successfully to {PrinterName}",
+                request.ZplContents.Count, request.PrinterName);
+
+            return Ok(new
+            {
+                success = true,
+                message = $"{request.ZplContents.Count} labels sent to {request.PrinterName}",
+                printerName = request.PrinterName,
+                labelCount = request.ZplContents.Count
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to print batch of labels to {PrinterName}", request.PrinterName);
+            return StatusCode(500, new
+            {
+                error = "Failed to print batch",
+                message = ex.Message,
+                printerName = request.PrinterName
+            });
+        }
+    }
+}
+
+/// <summary>
+/// Request model for test print.
+/// </summary>
+public class TestPrintRequest
+{
+    public required string PrinterName { get; init; }
+}
+
+/// <summary>
+/// Request model for printing a single label.
+/// </summary>
+public class PrintRequest
+{
+    public required string PrinterName { get; init; }
+    public required string ZplContent { get; init; }
+}
+
+/// <summary>
+/// Request model for batch printing.
+/// </summary>
+public class BatchPrintRequest
+{
+    public required string PrinterName { get; init; }
+    public required List<string> ZplContents { get; init; }
+}

--- a/tools/print-bridge/Koinon.PrintBridge/Koinon.PrintBridge.csproj
+++ b/tools/print-bridge/Koinon.PrintBridge/Koinon.PrintBridge.csproj
@@ -1,0 +1,23 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
+    <AssemblyName>Koinon.PrintBridge</AssemblyName>
+    <RootNamespace>Koinon.PrintBridge</RootNamespace>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <!-- NuGet Packages -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.1" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.10" />
+  </ItemGroup>
+
+</Project>

--- a/tools/print-bridge/Koinon.PrintBridge/PrinterDiscoveryService.cs
+++ b/tools/print-bridge/Koinon.PrintBridge/PrinterDiscoveryService.cs
@@ -1,0 +1,217 @@
+using System.Drawing.Printing;
+using System.Management;
+
+namespace Koinon.PrintBridge;
+
+/// <summary>
+/// Discovers and manages printer information.
+/// Identifies Zebra thermal printers and verifies driver installation.
+/// </summary>
+public class PrinterDiscoveryService
+{
+    private readonly ILogger<PrinterDiscoveryService> _logger;
+    private List<PrinterInfo> _cachedPrinters = new();
+    private DateTime _lastDiscovery = DateTime.MinValue;
+    private static readonly TimeSpan CacheExpiration = TimeSpan.FromMinutes(5);
+
+    public PrinterDiscoveryService(ILogger<PrinterDiscoveryService> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Initialize the service and perform initial printer discovery.
+    /// </summary>
+    public async Task InitializeAsync()
+    {
+        _logger.LogInformation("Initializing printer discovery service...");
+        var printers = await GetAvailablePrintersAsync();
+        _logger.LogInformation("Discovered {Count} printers", printers.Count);
+
+        var zebraPrinters = printers.Where(p => p.IsZebraPrinter).ToList();
+        if (zebraPrinters.Count == 0)
+        {
+            _logger.LogWarning("No Zebra thermal printers found. Label printing will not be available.");
+        }
+        else
+        {
+            _logger.LogInformation("Found {Count} Zebra thermal printer(s): {Printers}",
+                zebraPrinters.Count,
+                string.Join(", ", zebraPrinters.Select(p => p.Name)));
+        }
+    }
+
+    /// <summary>
+    /// Gets all available printers on the system.
+    /// Results are cached for 5 minutes to improve performance.
+    /// </summary>
+    public Task<List<PrinterInfo>> GetAvailablePrintersAsync()
+    {
+        // Return cached results if still valid
+        if (DateTime.UtcNow - _lastDiscovery < CacheExpiration && _cachedPrinters.Count > 0)
+        {
+            _logger.LogDebug("Returning cached printer list ({Count} printers)", _cachedPrinters.Count);
+            return Task.FromResult(_cachedPrinters);
+        }
+
+        return Task.Run(() =>
+        {
+            var printers = new List<PrinterInfo>();
+
+            try
+            {
+                // Get all installed printers using PrinterSettings
+                foreach (string printerName in PrinterSettings.InstalledPrinters)
+                {
+                    try
+                    {
+                        var info = GetPrinterInfo(printerName);
+                        printers.Add(info);
+                        _logger.LogDebug("Discovered printer: {Name} (Zebra: {IsZebra})",
+                            info.Name, info.IsZebraPrinter);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogWarning(ex, "Failed to get info for printer: {PrinterName}", printerName);
+                    }
+                }
+
+                _cachedPrinters = printers;
+                _lastDiscovery = DateTime.UtcNow;
+
+                _logger.LogInformation("Printer discovery complete: {Count} printers found", printers.Count);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Printer discovery failed");
+            }
+
+            return printers;
+        });
+    }
+
+    /// <summary>
+    /// Gets detailed information about a specific printer.
+    /// </summary>
+    public PrinterInfo GetPrinterInfo(string printerName)
+    {
+        var settings = new PrinterSettings { PrinterName = printerName };
+
+        var info = new PrinterInfo
+        {
+            Name = printerName,
+            Status = settings.IsValid ? "Ready" : "Offline",
+            IsDefault = settings.IsDefaultPrinter,
+            IsZebraPrinter = IsZebraPrinter(printerName),
+            DriverName = GetDriverName(printerName),
+            PortName = GetPortName(printerName)
+        };
+
+        return info;
+    }
+
+    /// <summary>
+    /// Forces a refresh of the printer cache.
+    /// </summary>
+    public async Task RefreshPrintersAsync()
+    {
+        _logger.LogInformation("Forcing printer refresh...");
+        _lastDiscovery = DateTime.MinValue;
+        await GetAvailablePrintersAsync();
+    }
+
+    /// <summary>
+    /// Determines if a printer is a Zebra thermal printer based on name and driver.
+    /// </summary>
+    private static bool IsZebraPrinter(string printerName)
+    {
+        // Check printer name
+        var nameLower = printerName.ToLowerInvariant();
+        if (nameLower.Contains("zebra") || nameLower.Contains("zpl"))
+        {
+            return true;
+        }
+
+        // Check driver name
+        var driver = GetDriverName(printerName);
+        if (!string.IsNullOrEmpty(driver))
+        {
+            var driverLower = driver.ToLowerInvariant();
+            if (driverLower.Contains("zebra") || driverLower.Contains("zpl"))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the driver name for a printer using WMI.
+    /// </summary>
+    private static string GetDriverName(string printerName)
+    {
+        try
+        {
+            var query = $"SELECT DriverName FROM Win32_Printer WHERE Name = '{printerName.Replace("'", "''")}'";
+            using var searcher = new ManagementObjectSearcher(query);
+            using var results = searcher.Get();
+
+            foreach (ManagementObject printer in results)
+            {
+                var driverName = printer["DriverName"]?.ToString();
+                if (!string.IsNullOrEmpty(driverName))
+                {
+                    return driverName;
+                }
+            }
+        }
+        catch
+        {
+            // WMI queries can fail in some environments - this is non-critical
+        }
+
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// Gets the port name for a printer using WMI.
+    /// </summary>
+    private static string GetPortName(string printerName)
+    {
+        try
+        {
+            var query = $"SELECT PortName FROM Win32_Printer WHERE Name = '{printerName.Replace("'", "''")}'";
+            using var searcher = new ManagementObjectSearcher(query);
+            using var results = searcher.Get();
+
+            foreach (ManagementObject printer in results)
+            {
+                var portName = printer["PortName"]?.ToString();
+                if (!string.IsNullOrEmpty(portName))
+                {
+                    return portName;
+                }
+            }
+        }
+        catch
+        {
+            // WMI queries can fail in some environments - this is non-critical
+        }
+
+        return string.Empty;
+    }
+}
+
+/// <summary>
+/// Information about a discovered printer.
+/// </summary>
+public class PrinterInfo
+{
+    public required string Name { get; init; }
+    public required string Status { get; init; }
+    public required bool IsDefault { get; init; }
+    public required bool IsZebraPrinter { get; init; }
+    public required string DriverName { get; init; }
+    public required string PortName { get; init; }
+}

--- a/tools/print-bridge/Koinon.PrintBridge/Program.cs
+++ b/tools/print-bridge/Koinon.PrintBridge/Program.cs
@@ -1,0 +1,258 @@
+using System.Drawing;
+using System.Windows.Forms;
+using Koinon.PrintBridge;
+using Serilog;
+
+// Configure Serilog
+Log.Logger = new LoggerConfiguration()
+    .WriteTo.Console()
+    .WriteTo.File(
+        Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Koinon",
+            "PrintBridge",
+            "logs",
+            "printbridge-.log"
+        ),
+        rollingInterval: RollingInterval.Day,
+        retainedFileCountLimit: 7
+    )
+    .CreateLogger();
+
+try
+{
+    Log.Information("Koinon Print Bridge starting...");
+
+    var builder = WebApplication.CreateBuilder(args);
+
+    // Configure Kestrel to listen on localhost only
+    // Port can be configured via appsettings.json or environment variable PRINT_BRIDGE_PORT
+    var port = builder.Configuration.GetValue<int>("PrintBridge:Port", 9632);
+    builder.WebHost.ConfigureKestrel(options =>
+    {
+        options.ListenLocalhost(port);
+    });
+
+    // Add services
+    builder.Services.AddSingleton<PrinterDiscoveryService>();
+    builder.Services.AddSingleton<ZplPrintService>();
+    builder.Services.AddControllers();
+    builder.Services.AddCors(options =>
+    {
+        options.AddPolicy("AllowKiosk", policy =>
+        {
+            // SECURITY: Only allow requests from localhost web app (Vite dev server)
+            // NEVER allow production origins - this is a localhost-only print bridge
+            policy.WithOrigins("http://localhost:5173", "http://127.0.0.1:5173")
+                  .AllowAnyHeader()
+                  .AllowAnyMethod();
+        });
+    });
+
+    // Add Serilog
+    builder.Host.UseSerilog();
+
+    var app = builder.Build();
+
+    app.UseCors("AllowKiosk");
+    app.MapControllers();
+
+    // Health check endpoint
+    app.MapGet("/health", () => new
+    {
+        status = "healthy",
+        version = "1.0.0",
+        timestamp = DateTime.UtcNow
+    });
+
+    // Initialize services
+    var printerDiscovery = app.Services.GetRequiredService<PrinterDiscoveryService>();
+    await printerDiscovery.InitializeAsync();
+
+    // Start the system tray application in the background
+    var trayIcon = new SystemTrayIcon(app.Services);
+    Application.EnableVisualStyles();
+    Application.SetCompatibleTextRenderingDefault(false);
+
+    // Start web server in background thread
+    var webServerTask = Task.Run(async () => await app.RunAsync());
+
+    Log.Information("Koinon Print Bridge started successfully on port 9632");
+
+    // Run Windows Forms message loop (keeps tray icon alive)
+    Application.Run(new HiddenForm(trayIcon));
+
+    // Wait for web server to complete
+    await webServerTask;
+}
+catch (Exception ex)
+{
+    Log.Fatal(ex, "Application terminated unexpectedly");
+    throw;
+}
+finally
+{
+    Log.CloseAndFlush();
+}
+
+// Hidden form to keep the application running
+internal class HiddenForm : Form
+{
+    public HiddenForm(SystemTrayIcon trayIcon)
+    {
+        WindowState = FormWindowState.Minimized;
+        ShowInTaskbar = false;
+        Opacity = 0;
+        FormBorderStyle = FormBorderStyle.None;
+
+        // Prevent closing via form events - only allow exit via tray icon
+        FormClosing += (s, e) =>
+        {
+            if (e.CloseReason == CloseReason.UserClosing)
+            {
+                e.Cancel = true;
+            }
+        };
+    }
+}
+
+// System tray icon implementation
+internal class SystemTrayIcon
+{
+    private readonly NotifyIcon _notifyIcon;
+    private readonly IServiceProvider _services;
+
+    public SystemTrayIcon(IServiceProvider services)
+    {
+        _services = services;
+
+        _notifyIcon = new NotifyIcon
+        {
+            Icon = CreateIcon(),
+            Visible = true,
+            Text = "Koinon Print Bridge"
+        };
+
+        var contextMenu = new ContextMenuStrip();
+        contextMenu.Items.Add("Test Print", null, OnTestPrint);
+        contextMenu.Items.Add("View Printers", null, OnViewPrinters);
+        contextMenu.Items.Add(new ToolStripSeparator());
+        contextMenu.Items.Add("Exit", null, OnExit);
+
+        _notifyIcon.ContextMenuStrip = contextMenu;
+
+        // Double-click to show printers
+        _notifyIcon.DoubleClick += OnViewPrinters;
+
+        _notifyIcon.BalloonTipTitle = "Koinon Print Bridge";
+        _notifyIcon.BalloonTipText = "Print bridge is running and ready to print labels";
+        _notifyIcon.ShowBalloonTip(3000);
+    }
+
+    private static Icon CreateIcon()
+    {
+        // Create a simple icon with a "P" for printer
+        var bitmap = new Bitmap(32, 32);
+        using (var g = Graphics.FromImage(bitmap))
+        {
+            g.Clear(Color.White);
+            g.FillEllipse(Brushes.DodgerBlue, 2, 2, 28, 28);
+            g.DrawString("P", new Font("Arial", 16, FontStyle.Bold), Brushes.White, 8, 4);
+        }
+
+        return Icon.FromHandle(bitmap.GetHicon());
+    }
+
+    private async void OnTestPrint(object? sender, EventArgs e)
+    {
+        try
+        {
+            var printService = _services.GetRequiredService<ZplPrintService>();
+            var printerDiscovery = _services.GetRequiredService<PrinterDiscoveryService>();
+
+            var printers = await printerDiscovery.GetAvailablePrintersAsync();
+            var zebraPrinter = printers.FirstOrDefault(p => p.IsZebraPrinter);
+
+            if (zebraPrinter == null)
+            {
+                MessageBox.Show(
+                    "No Zebra printer found. Please ensure a Zebra thermal printer is installed and turned on.",
+                    "No Printer Found",
+                    MessageBoxButtons.OK,
+                    MessageBoxIcon.Warning
+                );
+                return;
+            }
+
+            // Generate test label
+            var testZpl = @"^XA
+^FO50,50^A0N,50,50^FDTest Label^FS
+^FO50,120^A0N,30,30^FD" + DateTime.Now.ToString("g") + @"^FS
+^FO50,160^A0N,25,25^FDKoinon Print Bridge^FS
+^XZ";
+
+            await printService.PrintZplAsync(zebraPrinter.Name, testZpl);
+
+            _notifyIcon.ShowBalloonTip(
+                3000,
+                "Test Print Sent",
+                $"Test label sent to {zebraPrinter.Name}",
+                ToolTipIcon.Info
+            );
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Test print failed");
+            MessageBox.Show(
+                $"Test print failed: {ex.Message}",
+                "Print Error",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error
+            );
+        }
+    }
+
+    private async void OnViewPrinters(object? sender, EventArgs e)
+    {
+        try
+        {
+            var printerDiscovery = _services.GetRequiredService<PrinterDiscoveryService>();
+            var printers = await printerDiscovery.GetAvailablePrintersAsync();
+
+            var message = "Available Printers:\n\n";
+            if (printers.Count == 0)
+            {
+                message += "No printers found.";
+            }
+            else
+            {
+                foreach (var printer in printers)
+                {
+                    message += $"• {printer.Name}\n";
+                    message += $"  Type: {(printer.IsZebraPrinter ? "Zebra Thermal" : "Other")}\n";
+                    message += $"  Status: {printer.Status}\n\n";
+                }
+            }
+
+            MessageBox.Show(message, "Koinon Print Bridge - Printers", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+        catch (Exception ex)
+        {
+            Log.Error(ex, "Failed to retrieve printers");
+            MessageBox.Show(
+                $"Failed to retrieve printers: {ex.Message}",
+                "Error",
+                MessageBoxButtons.OK,
+                MessageBoxIcon.Error
+            );
+        }
+    }
+
+    private void OnExit(object? sender, EventArgs e)
+    {
+        _notifyIcon.Visible = false;
+        _notifyIcon.Dispose();
+        Application.Exit();
+        Environment.Exit(0);
+    }
+}

--- a/tools/print-bridge/Koinon.PrintBridge/ZplPrintService.cs
+++ b/tools/print-bridge/Koinon.PrintBridge/ZplPrintService.cs
@@ -1,0 +1,256 @@
+using System.Drawing.Printing;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Koinon.PrintBridge;
+
+/// <summary>
+/// Service for printing ZPL (Zebra Programming Language) labels to thermal printers.
+/// Handles raw printer communication for direct ZPL output.
+/// </summary>
+public class ZplPrintService
+{
+    private readonly ILogger<ZplPrintService> _logger;
+
+    public ZplPrintService(ILogger<ZplPrintService> logger)
+    {
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Prints ZPL content to a specified printer.
+    /// </summary>
+    /// <param name="printerName">Name of the printer (must be installed on the system)</param>
+    /// <param name="zplContent">ZPL content to print</param>
+    public async Task PrintZplAsync(string printerName, string zplContent)
+    {
+        if (string.IsNullOrWhiteSpace(printerName))
+        {
+            throw new ArgumentException("Printer name cannot be empty", nameof(printerName));
+        }
+
+        if (string.IsNullOrWhiteSpace(zplContent))
+        {
+            throw new ArgumentException("ZPL content cannot be empty", nameof(zplContent));
+        }
+
+        _logger.LogInformation("Printing ZPL to printer: {PrinterName}", printerName);
+        _logger.LogDebug("ZPL Content:\n{ZplContent}", zplContent);
+
+        await Task.Run(() =>
+        {
+            try
+            {
+                // Send raw ZPL data directly to printer
+                if (!RawPrinterHelper.SendStringToPrinter(printerName, zplContent))
+                {
+                    throw new InvalidOperationException($"Failed to send ZPL to printer '{printerName}'");
+                }
+
+                _logger.LogInformation("Successfully sent ZPL to printer: {PrinterName}", printerName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Failed to print ZPL to printer: {PrinterName}", printerName);
+                throw;
+            }
+        });
+    }
+
+    /// <summary>
+    /// Prints multiple ZPL labels to a printer in batch.
+    /// </summary>
+    public async Task PrintBatchZplAsync(string printerName, IEnumerable<string> zplContents)
+    {
+        _logger.LogInformation("Printing {Count} ZPL labels to printer: {PrinterName}",
+            zplContents.Count(), printerName);
+
+        foreach (var zpl in zplContents)
+        {
+            await PrintZplAsync(printerName, zpl);
+
+            // Small delay between labels to prevent overwhelming the printer
+            await Task.Delay(100);
+        }
+
+        _logger.LogInformation("Batch print complete: {Count} labels sent to {PrinterName}",
+            zplContents.Count(), printerName);
+    }
+
+    /// <summary>
+    /// Validates ZPL content for basic syntax errors.
+    /// </summary>
+    public bool ValidateZpl(string zplContent)
+    {
+        if (string.IsNullOrWhiteSpace(zplContent))
+        {
+            return false;
+        }
+
+        // Basic ZPL validation - must start with ^XA and end with ^XZ
+        var trimmed = zplContent.Trim();
+        return trimmed.StartsWith("^XA", StringComparison.OrdinalIgnoreCase) &&
+               trimmed.EndsWith("^XZ", StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Validates ZPL content with security checks to prevent dangerous firmware commands.
+    /// </summary>
+    /// <param name="zplContent">ZPL content to validate</param>
+    /// <returns>Tuple indicating if content is valid and error message if invalid</returns>
+    public (bool IsValid, string? ErrorMessage) ValidateZplWithSecurity(string zplContent)
+    {
+        if (string.IsNullOrWhiteSpace(zplContent))
+        {
+            return (false, "ZPL content cannot be empty");
+        }
+
+        // Check content length (max 100KB per label)
+        const int maxLengthBytes = 100 * 1024; // 100KB
+        var contentLength = Encoding.UTF8.GetByteCount(zplContent);
+        if (contentLength > maxLengthBytes)
+        {
+            return (false, $"ZPL content exceeds maximum size of {maxLengthBytes} bytes (current: {contentLength} bytes)");
+        }
+
+        // Basic ZPL validation - must start with ^XA and end with ^XZ
+        var trimmed = zplContent.Trim();
+        if (!trimmed.StartsWith("^XA", StringComparison.OrdinalIgnoreCase))
+        {
+            return (false, "ZPL content must start with ^XA");
+        }
+
+        if (!trimmed.EndsWith("^XZ", StringComparison.OrdinalIgnoreCase))
+        {
+            return (false, "ZPL content must end with ^XZ");
+        }
+
+        // Block dangerous ZPL firmware commands that can brick printers
+        var dangerousCommands = new[]
+        {
+            "^JU", // Upload firmware
+            "^JF", // Flash firmware
+            "~JR", // Reset printer
+            "^MC", // Map clear
+            "~MT", // Transfer memory
+            "~HS"  // Host status
+        };
+
+        foreach (var command in dangerousCommands)
+        {
+            if (trimmed.Contains(command, StringComparison.OrdinalIgnoreCase))
+            {
+                return (false, $"ZPL content contains prohibited command: {command}");
+            }
+        }
+
+        return (true, null);
+    }
+}
+
+/// <summary>
+/// Helper class for sending raw data to a printer using Windows API.
+/// Based on Microsoft documentation for raw printer access.
+/// </summary>
+internal static class RawPrinterHelper
+{
+    // Structure and API declarations for raw printer communication
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+    private class DOCINFOA
+    {
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string? pDocName;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string? pOutputFile;
+        [MarshalAs(UnmanagedType.LPStr)]
+        public string? pDataType;
+    }
+
+    [DllImport("winspool.Drv", EntryPoint = "OpenPrinterA", SetLastError = true, CharSet = CharSet.Ansi, ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
+    private static extern bool OpenPrinter([MarshalAs(UnmanagedType.LPStr)] string szPrinter, out IntPtr hPrinter, IntPtr pd);
+
+    [DllImport("winspool.Drv", EntryPoint = "ClosePrinter", SetLastError = true, ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
+    private static extern bool ClosePrinter(IntPtr hPrinter);
+
+    [DllImport("winspool.Drv", EntryPoint = "StartDocPrinterA", SetLastError = true, CharSet = CharSet.Ansi, ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
+    private static extern bool StartDocPrinter(IntPtr hPrinter, int level, [In, MarshalAs(UnmanagedType.LPStruct)] DOCINFOA di);
+
+    [DllImport("winspool.Drv", EntryPoint = "EndDocPrinter", SetLastError = true, ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
+    private static extern bool EndDocPrinter(IntPtr hPrinter);
+
+    [DllImport("winspool.Drv", EntryPoint = "StartPagePrinter", SetLastError = true, ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
+    private static extern bool StartPagePrinter(IntPtr hPrinter);
+
+    [DllImport("winspool.Drv", EntryPoint = "EndPagePrinter", SetLastError = true, ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
+    private static extern bool EndPagePrinter(IntPtr hPrinter);
+
+    [DllImport("winspool.Drv", EntryPoint = "WritePrinter", SetLastError = true, ExactSpelling = true, CallingConvention = CallingConvention.StdCall)]
+    private static extern bool WritePrinter(IntPtr hPrinter, IntPtr pBytes, int dwCount, out int dwWritten);
+
+    /// <summary>
+    /// Sends a string to a printer using raw printer communication.
+    /// </summary>
+    public static bool SendStringToPrinter(string printerName, string stringToSend)
+    {
+        var hPrinter = IntPtr.Zero;
+        var pBytes = IntPtr.Zero;
+
+        try
+        {
+            // Open the printer
+            if (!OpenPrinter(printerName.Normalize(), out hPrinter, IntPtr.Zero))
+            {
+                return false;
+            }
+
+            // Start a document
+            var di = new DOCINFOA
+            {
+                pDocName = "Koinon Label",
+                pDataType = "RAW" // RAW data type for direct ZPL
+            };
+
+            if (!StartDocPrinter(hPrinter, 1, di))
+            {
+                return false;
+            }
+
+            // Start a page
+            if (!StartPagePrinter(hPrinter))
+            {
+                EndDocPrinter(hPrinter);
+                return false;
+            }
+
+            // Convert string to bytes
+            var bytes = Encoding.UTF8.GetBytes(stringToSend);
+            var dwCount = bytes.Length;
+
+            // Allocate unmanaged memory
+            pBytes = Marshal.AllocCoTaskMem(dwCount);
+            Marshal.Copy(bytes, 0, pBytes, dwCount);
+
+            // Send the data to the printer
+            var success = WritePrinter(hPrinter, pBytes, dwCount, out var dwWritten);
+
+            // End the page and document
+            EndPagePrinter(hPrinter);
+            EndDocPrinter(hPrinter);
+
+            return success && dwWritten == dwCount;
+        }
+        finally
+        {
+            // Clean up
+            if (pBytes != IntPtr.Zero)
+            {
+                Marshal.FreeCoTaskMem(pBytes);
+            }
+
+            if (hPrinter != IntPtr.Zero)
+            {
+                ClosePrinter(hPrinter);
+            }
+        }
+    }
+}

--- a/tools/print-bridge/README.md
+++ b/tools/print-bridge/README.md
@@ -1,0 +1,205 @@
+# Koinon Print Bridge
+
+A lightweight Windows desktop application that enables local label printing for the Koinon RMS kiosk system.
+
+## Overview
+
+The Print Bridge runs as a Windows system tray application and provides a local web server (localhost:9632) that the kiosk web app can communicate with to print ZPL labels on Zebra thermal printers.
+
+## Features
+
+- **Automatic printer discovery** - Finds and identifies Zebra thermal printers
+- **System tray integration** - Minimal footprint, runs in background
+- **ZPL printing** - Direct support for Zebra Programming Language
+- **Health monitoring** - Built-in diagnostics and test print utility
+- **CORS-enabled API** - Secure localhost-only communication
+
+## Requirements
+
+- Windows 10 or later
+- .NET 8.0 Runtime
+- Zebra thermal printer with ZPL driver installed
+
+## Installation
+
+1. Build the application:
+   ```bash
+   dotnet build tools/print-bridge/Koinon.PrintBridge/Koinon.PrintBridge.csproj
+   ```
+
+2. Run the application:
+   ```bash
+   dotnet run --project tools/print-bridge/Koinon.PrintBridge/Koinon.PrintBridge.csproj
+   ```
+
+3. The application will start in the system tray with a blue "P" icon.
+
+## Usage
+
+### System Tray Menu
+
+Right-click the tray icon to access:
+- **Test Print** - Print a test label to verify printer functionality
+- **View Printers** - Show all discovered printers
+- **Exit** - Close the application
+
+### API Endpoints
+
+The print bridge exposes the following endpoints on `http://localhost:9632`:
+
+#### GET /health
+Check if the print bridge is running.
+
+**Response:**
+```json
+{
+  "status": "healthy",
+  "version": "1.0.0",
+  "timestamp": "2024-12-06T22:00:00Z"
+}
+```
+
+#### GET /api/printers
+Get all available printers.
+
+**Response:**
+```json
+{
+  "printers": [
+    {
+      "name": "Zebra ZP450",
+      "status": "Ready",
+      "isDefault": true,
+      "isZebraPrinter": true,
+      "driverName": "ZDesigner ZP 450-203dpi ZPL",
+      "portName": "USB001"
+    }
+  ],
+  "count": 1,
+  "zebraCount": 1
+}
+```
+
+#### POST /api/printers/refresh
+Force refresh the printer cache.
+
+**Response:**
+```json
+{
+  "message": "Printer cache refreshed",
+  "count": 1
+}
+```
+
+#### POST /api/print/test
+Print a test label.
+
+**Request:**
+```json
+{
+  "printerName": "Zebra ZP450"
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Test label sent to Zebra ZP450",
+  "printerName": "Zebra ZP450"
+}
+```
+
+#### POST /api/print
+Print a single ZPL label.
+
+**Request:**
+```json
+{
+  "printerName": "Zebra ZP450",
+  "zplContent": "^XA^FO50,50^A0N,50,50^FDTest^FS^XZ"
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "Label sent to Zebra ZP450",
+  "printerName": "Zebra ZP450"
+}
+```
+
+#### POST /api/print/batch
+Print multiple ZPL labels in batch.
+
+**Request:**
+```json
+{
+  "printerName": "Zebra ZP450",
+  "zplContents": [
+    "^XA^FO50,50^A0N,50,50^FDLabel 1^FS^XZ",
+    "^XA^FO50,50^A0N,50,50^FDLabel 2^FS^XZ"
+  ]
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "2 labels sent to Zebra ZP450",
+  "printerName": "Zebra ZP450",
+  "labelCount": 2
+}
+```
+
+## Architecture
+
+The application consists of three main components:
+
+1. **PrinterDiscoveryService** - Discovers printers and identifies Zebra thermal printers
+2. **ZplPrintService** - Handles raw ZPL printing to thermal printers
+3. **DiagnosticsController** - Provides REST API for health checks and printing operations
+
+## Development
+
+### Running Tests
+
+```bash
+dotnet test tools/print-bridge/Koinon.PrintBridge.Tests/Koinon.PrintBridge.Tests.csproj
+```
+
+### Building for Distribution
+
+```bash
+dotnet publish tools/print-bridge/Koinon.PrintBridge/Koinon.PrintBridge.csproj -c Release -r win-x64 --self-contained
+```
+
+## Troubleshooting
+
+### No printers found
+- Ensure Zebra printer is connected and turned on
+- Verify printer drivers are installed in Windows
+- Check printer appears in Windows "Printers & Scanners"
+
+### Print fails
+- Verify ZPL content is valid (starts with ^XA, ends with ^XZ)
+- Check printer status in system tray menu
+- Try test print from system tray menu
+
+### Can't connect from web app
+- Ensure Print Bridge is running (check system tray)
+- Verify web app is accessing `http://localhost:9632`
+- Check Windows Firewall is not blocking localhost connections
+
+## Security
+
+- Print Bridge only listens on localhost (127.0.0.1)
+- CORS is configured to only allow requests from local web app
+- No external network access required
+- No sensitive data is stored or transmitted
+
+## License
+
+Part of the Koinon RMS project.


### PR DESCRIPTION
## Summary
- Implement PCO-style lightweight Windows desktop app for local label printing via localhost:9632
- Add .NET 8 Windows app with Kestrel minimal API and system tray
- Add printer discovery and ZPL support for Zebra thermal printers
- Add React frontend integration with PrintStatus component
- Comprehensive security validation to block firmware attacks

## Changes
### Backend (.NET 8 Windows Application)
- `tools/print-bridge/Koinon.PrintBridge/Program.cs` - Main entry with Kestrel, system tray
- `tools/print-bridge/Koinon.PrintBridge/PrinterDiscoveryService.cs` - Printer discovery via WMI
- `tools/print-bridge/Koinon.PrintBridge/ZplPrintService.cs` - ZPL printing with security validation
- `tools/print-bridge/Koinon.PrintBridge/DiagnosticsController.cs` - REST API endpoints

### Frontend (React/TypeScript)
- `src/web/src/services/printing/PrintBridgeClient.ts` - TypeScript client with timeouts
- `src/web/src/components/checkin/PrintStatus.tsx` - Printer availability component
- `src/web/src/pages/CheckinPage.tsx` - Integration with print bridge
- `src/web/src/components/checkin/CheckinConfirmation.tsx` - Print button and status

### Security Features
- CORS restricted to localhost only
- ZPL validation blocks dangerous firmware commands (^JU, ^JF, ~JR, ^MC, ~MT, ~HS)
- 100KB max label size, 50 labels max per batch
- 10s timeouts on all fetch calls
- No auto-print - requires explicit user action

## Test plan
- [ ] Build print bridge on Windows
- [ ] Verify printer discovery finds Zebra printers
- [ ] Test print button in check-in confirmation
- [ ] Verify labels print correctly to Zebra thermal printer
- [ ] Test error handling when printer unavailable
- [ ] Verify security validation blocks malicious ZPL

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)