### PR TITLE
feat: Add Groups API controller with tests (#67)

### DIFF
--- a/src/Koinon.Api/Controllers/GroupsController.cs
+++ b/src/Koinon.Api/Controllers/GroupsController.cs
@@ -1,0 +1,562 @@
+using Koinon.Api.Helpers;
+using Koinon.Application.Common;
+using Koinon.Application.DTOs;
+using Koinon.Application.DTOs.Requests;
+using Koinon.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Koinon.Api.Controllers;
+
+/// <summary>
+/// Controller for group management operations.
+/// Provides endpoints for searching, creating, updating, and managing groups and their members.
+/// </summary>
+[ApiController]
+[Route("api/v1/[controller]")]
+[Authorize]
+public class GroupsController(
+    IGroupService groupService,
+    ILogger<GroupsController> logger) : ControllerBase
+{
+    /// <summary>
+    /// Searches for groups with optional filters and pagination.
+    /// </summary>
+    /// <param name="query">Full-text search query</param>
+    /// <param name="groupTypeId">Filter by group type IdKey</param>
+    /// <param name="campusId">Filter by campus IdKey</param>
+    /// <param name="parentGroupId">Filter by parent group IdKey</param>
+    /// <param name="includeInactive">Include inactive groups</param>
+    /// <param name="includeArchived">Include archived groups</param>
+    /// <param name="page">Page number (1-based, default: 1)</param>
+    /// <param name="pageSize">Items per page (default: 25, max: 100)</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Paginated list of groups</returns>
+    /// <response code="200">Returns paginated list of groups</response>
+    [HttpGet]
+    [ProducesResponseType(typeof(PagedResult<GroupSummaryDto>), StatusCodes.Status200OK)]
+    public async Task<IActionResult> Search(
+        [FromQuery] string? query,
+        [FromQuery] string? groupTypeId,
+        [FromQuery] string? campusId,
+        [FromQuery] string? parentGroupId,
+        [FromQuery] bool includeInactive = false,
+        [FromQuery] bool includeArchived = false,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 25,
+        CancellationToken ct = default)
+    {
+        // Validate optional IdKey parameters
+        if (!string.IsNullOrWhiteSpace(groupTypeId) && !IdKeyValidator.IsValid(groupTypeId))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid IdKey format",
+                Detail = IdKeyValidator.GetErrorMessage("groupTypeId"),
+                Status = StatusCodes.Status400BadRequest,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        if (!string.IsNullOrWhiteSpace(campusId) && !IdKeyValidator.IsValid(campusId))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid IdKey format",
+                Detail = IdKeyValidator.GetErrorMessage("campusId"),
+                Status = StatusCodes.Status400BadRequest,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        if (!string.IsNullOrWhiteSpace(parentGroupId) && !IdKeyValidator.IsValid(parentGroupId))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid IdKey format",
+                Detail = IdKeyValidator.GetErrorMessage("parentGroupId"),
+                Status = StatusCodes.Status400BadRequest,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        var parameters = new GroupSearchParameters
+        {
+            Query = query,
+            GroupTypeId = groupTypeId,
+            CampusId = campusId,
+            ParentGroupId = parentGroupId,
+            IncludeInactive = includeInactive,
+            IncludeArchived = includeArchived,
+            Page = page,
+            PageSize = pageSize
+        };
+
+        var result = await groupService.SearchAsync(parameters, ct);
+
+        logger.LogInformation(
+            "Group search completed: Query={Query}, Page={Page}, PageSize={PageSize}, TotalCount={TotalCount}",
+            query, result.Page, result.PageSize, result.TotalCount);
+
+        return Ok(result);
+    }
+
+    /// <summary>
+    /// Gets a group by its IdKey with full details including members and child groups.
+    /// </summary>
+    /// <param name="idKey">The group's IdKey</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Group details</returns>
+    /// <response code="200">Returns group details</response>
+    /// <response code="404">Group not found</response>
+    [HttpGet("{idKey}")]
+    [ProducesResponseType(typeof(GroupDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetByIdKey(string idKey, CancellationToken ct = default)
+    {
+        if (!IdKeyValidator.IsValid(idKey))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid IdKey format",
+                Detail = IdKeyValidator.GetErrorMessage("idKey"),
+                Status = StatusCodes.Status400BadRequest,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        var group = await groupService.GetByIdKeyAsync(idKey, ct);
+
+        if (group == null)
+        {
+            logger.LogWarning("Group not found: IdKey={IdKey}", idKey);
+
+            return NotFound(new ProblemDetails
+            {
+                Title = "Group not found",
+                Detail = $"No group found with IdKey '{idKey}'",
+                Status = StatusCodes.Status404NotFound,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        logger.LogInformation("Group retrieved: IdKey={IdKey}, Name={Name}", idKey, group.Name);
+
+        return Ok(group);
+    }
+
+    /// <summary>
+    /// Creates a new group.
+    /// </summary>
+    /// <param name="request">Group creation details</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Created group details</returns>
+    /// <response code="201">Group created successfully</response>
+    /// <response code="400">Validation failed</response>
+    /// <response code="422">Business rule violation</response>
+    [HttpPost]
+    [ProducesResponseType(typeof(GroupDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Create([FromBody] CreateGroupRequest request, CancellationToken ct = default)
+    {
+        var result = await groupService.CreateAsync(request, ct);
+
+        if (result.IsFailure)
+        {
+            logger.LogWarning(
+                "Failed to create group: Code={Code}, Message={Message}",
+                result.Error!.Code, result.Error.Message);
+
+            return result.Error.Code switch
+            {
+                "VALIDATION_ERROR" => BadRequest(new ProblemDetails
+                {
+                    Title = result.Error.Message,
+                    Detail = result.Error.Details != null
+                        ? string.Join("; ", result.Error.Details.SelectMany(kvp => kvp.Value))
+                        : null,
+                    Status = StatusCodes.Status400BadRequest,
+                    Instance = HttpContext.Request.Path,
+                    Extensions = { ["errors"] = result.Error.Details }
+                }),
+                _ => UnprocessableEntity(new ProblemDetails
+                {
+                    Title = result.Error.Code,
+                    Detail = result.Error.Message,
+                    Status = StatusCodes.Status422UnprocessableEntity,
+                    Instance = HttpContext.Request.Path
+                })
+            };
+        }
+
+        var group = result.Value!;
+
+        logger.LogInformation(
+            "Group created successfully: IdKey={IdKey}, Name={Name}",
+            group.IdKey, group.Name);
+
+        return CreatedAtAction(
+            nameof(GetByIdKey),
+            new { idKey = group.IdKey },
+            group);
+    }
+
+    /// <summary>
+    /// Updates an existing group.
+    /// </summary>
+    /// <param name="idKey">The group's IdKey</param>
+    /// <param name="request">Group update details</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Updated group details</returns>
+    /// <response code="200">Group updated successfully</response>
+    /// <response code="400">Validation failed</response>
+    /// <response code="404">Group not found</response>
+    /// <response code="422">Business rule violation</response>
+    [HttpPut("{idKey}")]
+    [ProducesResponseType(typeof(GroupDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Update(
+        string idKey,
+        [FromBody] UpdateGroupRequest request,
+        CancellationToken ct = default)
+    {
+        if (!IdKeyValidator.IsValid(idKey))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid IdKey format",
+                Detail = IdKeyValidator.GetErrorMessage("idKey"),
+                Status = StatusCodes.Status400BadRequest,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        var result = await groupService.UpdateAsync(idKey, request, ct);
+
+        if (result.IsFailure)
+        {
+            logger.LogWarning(
+                "Failed to update group: IdKey={IdKey}, Code={Code}, Message={Message}",
+                idKey, result.Error!.Code, result.Error.Message);
+
+            return result.Error.Code switch
+            {
+                "NOT_FOUND" => NotFound(new ProblemDetails
+                {
+                    Title = "Group not found",
+                    Detail = result.Error.Message,
+                    Status = StatusCodes.Status404NotFound,
+                    Instance = HttpContext.Request.Path
+                }),
+                "VALIDATION_ERROR" => BadRequest(new ProblemDetails
+                {
+                    Title = result.Error.Message,
+                    Detail = result.Error.Details != null
+                        ? string.Join("; ", result.Error.Details.SelectMany(kvp => kvp.Value))
+                        : null,
+                    Status = StatusCodes.Status400BadRequest,
+                    Instance = HttpContext.Request.Path,
+                    Extensions = { ["errors"] = result.Error.Details }
+                }),
+                _ => UnprocessableEntity(new ProblemDetails
+                {
+                    Title = result.Error.Code,
+                    Detail = result.Error.Message,
+                    Status = StatusCodes.Status422UnprocessableEntity,
+                    Instance = HttpContext.Request.Path
+                })
+            };
+        }
+
+        var group = result.Value!;
+
+        logger.LogInformation(
+            "Group updated successfully: IdKey={IdKey}, Name={Name}",
+            group.IdKey, group.Name);
+
+        return Ok(group);
+    }
+
+    /// <summary>
+    /// Soft-deletes a group (archives it).
+    /// </summary>
+    /// <param name="idKey">The group's IdKey</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>No content</returns>
+    /// <response code="204">Group archived successfully</response>
+    /// <response code="404">Group not found</response>
+    /// <response code="422">Business rule violation</response>
+    [HttpDelete("{idKey}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Delete(string idKey, CancellationToken ct = default)
+    {
+        if (!IdKeyValidator.IsValid(idKey))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid IdKey format",
+                Detail = IdKeyValidator.GetErrorMessage("idKey"),
+                Status = StatusCodes.Status400BadRequest,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        var result = await groupService.DeleteAsync(idKey, ct);
+
+        if (result.IsFailure)
+        {
+            logger.LogWarning(
+                "Failed to archive group: IdKey={IdKey}, Code={Code}, Message={Message}",
+                idKey, result.Error!.Code, result.Error.Message);
+
+            return result.Error.Code switch
+            {
+                "NOT_FOUND" => NotFound(new ProblemDetails
+                {
+                    Title = "Group not found",
+                    Detail = result.Error.Message,
+                    Status = StatusCodes.Status404NotFound,
+                    Instance = HttpContext.Request.Path
+                }),
+                _ => UnprocessableEntity(new ProblemDetails
+                {
+                    Title = result.Error.Code,
+                    Detail = result.Error.Message,
+                    Status = StatusCodes.Status422UnprocessableEntity,
+                    Instance = HttpContext.Request.Path
+                })
+            };
+        }
+
+        logger.LogInformation("Group archived successfully: IdKey={IdKey}", idKey);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Gets all members of a group.
+    /// </summary>
+    /// <param name="idKey">The group's IdKey</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of group members</returns>
+    /// <response code="200">Returns list of group members</response>
+    /// <response code="400">Invalid IdKey format</response>
+    [HttpGet("{idKey}/members")]
+    [ProducesResponseType(typeof(IReadOnlyList<GroupMemberDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetMembers(string idKey, CancellationToken ct = default)
+    {
+        if (!IdKeyValidator.IsValid(idKey))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid IdKey format",
+                Detail = IdKeyValidator.GetErrorMessage("idKey"),
+                Status = StatusCodes.Status400BadRequest,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        var members = await groupService.GetMembersAsync(idKey, ct);
+
+        logger.LogInformation(
+            "Group members retrieved: IdKey={IdKey}, MemberCount={MemberCount}",
+            idKey, members.Count);
+
+        return Ok(members);
+    }
+
+    /// <summary>
+    /// Adds a person as a group member with a specific role.
+    /// </summary>
+    /// <param name="idKey">The group's IdKey</param>
+    /// <param name="request">Member addition details</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Created group member details</returns>
+    /// <response code="201">Member added successfully</response>
+    /// <response code="400">Validation failed</response>
+    /// <response code="404">Group or person not found</response>
+    /// <response code="422">Business rule violation</response>
+    [HttpPost("{idKey}/members")]
+    [ProducesResponseType(typeof(GroupMemberDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> AddMember(
+        string idKey,
+        [FromBody] AddGroupMemberRequest request,
+        CancellationToken ct = default)
+    {
+        if (!IdKeyValidator.IsValid(idKey))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid IdKey format",
+                Detail = IdKeyValidator.GetErrorMessage("idKey"),
+                Status = StatusCodes.Status400BadRequest,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        var result = await groupService.AddMemberAsync(idKey, request, ct);
+
+        if (result.IsFailure)
+        {
+            logger.LogWarning(
+                "Failed to add member to group: GroupIdKey={GroupIdKey}, Code={Code}, Message={Message}",
+                idKey, result.Error!.Code, result.Error.Message);
+
+            return result.Error.Code switch
+            {
+                "NOT_FOUND" => NotFound(new ProblemDetails
+                {
+                    Title = "Resource not found",
+                    Detail = result.Error.Message,
+                    Status = StatusCodes.Status404NotFound,
+                    Instance = HttpContext.Request.Path
+                }),
+                "VALIDATION_ERROR" => BadRequest(new ProblemDetails
+                {
+                    Title = result.Error.Message,
+                    Detail = result.Error.Details != null
+                        ? string.Join("; ", result.Error.Details.SelectMany(kvp => kvp.Value))
+                        : null,
+                    Status = StatusCodes.Status400BadRequest,
+                    Instance = HttpContext.Request.Path,
+                    Extensions = { ["errors"] = result.Error.Details }
+                }),
+                _ => UnprocessableEntity(new ProblemDetails
+                {
+                    Title = result.Error.Code,
+                    Detail = result.Error.Message,
+                    Status = StatusCodes.Status422UnprocessableEntity,
+                    Instance = HttpContext.Request.Path
+                })
+            };
+        }
+
+        var member = result.Value!;
+
+        logger.LogInformation(
+            "Member added to group successfully: GroupIdKey={GroupIdKey}, PersonIdKey={PersonIdKey}",
+            idKey, member.Person.IdKey);
+
+        return CreatedAtAction(
+            nameof(GetMembers),
+            new { idKey },
+            member);
+    }
+
+    /// <summary>
+    /// Removes a person from a group.
+    /// </summary>
+    /// <param name="idKey">The group's IdKey</param>
+    /// <param name="personIdKey">The person's IdKey</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>No content</returns>
+    /// <response code="204">Member removed successfully</response>
+    /// <response code="400">Invalid IdKey format</response>
+    /// <response code="404">Group or member not found</response>
+    [HttpDelete("{idKey}/members/{personIdKey}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> RemoveMember(
+        string idKey,
+        string personIdKey,
+        CancellationToken ct = default)
+    {
+        if (!IdKeyValidator.IsValid(idKey))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid IdKey format",
+                Detail = IdKeyValidator.GetErrorMessage("idKey"),
+                Status = StatusCodes.Status400BadRequest,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        if (!IdKeyValidator.IsValid(personIdKey))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid IdKey format",
+                Detail = IdKeyValidator.GetErrorMessage("personIdKey"),
+                Status = StatusCodes.Status400BadRequest,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        var result = await groupService.RemoveMemberAsync(idKey, personIdKey, ct);
+
+        if (result.IsFailure)
+        {
+            logger.LogWarning(
+                "Failed to remove member from group: GroupIdKey={GroupIdKey}, PersonIdKey={PersonIdKey}, Code={Code}, Message={Message}",
+                idKey, personIdKey, result.Error!.Code, result.Error.Message);
+
+            return result.Error.Code switch
+            {
+                "NOT_FOUND" => NotFound(new ProblemDetails
+                {
+                    Title = "Resource not found",
+                    Detail = result.Error.Message,
+                    Status = StatusCodes.Status404NotFound,
+                    Instance = HttpContext.Request.Path
+                }),
+                _ => UnprocessableEntity(new ProblemDetails
+                {
+                    Title = result.Error.Code,
+                    Detail = result.Error.Message,
+                    Status = StatusCodes.Status422UnprocessableEntity,
+                    Instance = HttpContext.Request.Path
+                })
+            };
+        }
+
+        logger.LogInformation(
+            "Member removed from group successfully: GroupIdKey={GroupIdKey}, PersonIdKey={PersonIdKey}",
+            idKey, personIdKey);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Gets all child groups (subgroups) of a group.
+    /// </summary>
+    /// <param name="idKey">The group's IdKey</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of child groups</returns>
+    /// <response code="200">Returns list of child groups</response>
+    /// <response code="400">Invalid IdKey format</response>
+    [HttpGet("{idKey}/children")]
+    [ProducesResponseType(typeof(IReadOnlyList<GroupSummaryDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetChildren(string idKey, CancellationToken ct = default)
+    {
+        if (!IdKeyValidator.IsValid(idKey))
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Invalid IdKey format",
+                Detail = IdKeyValidator.GetErrorMessage("idKey"),
+                Status = StatusCodes.Status400BadRequest,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        var childGroups = await groupService.GetChildGroupsAsync(idKey, ct);
+
+        logger.LogInformation(
+            "Child groups retrieved: IdKey={IdKey}, ChildCount={ChildCount}",
+            idKey, childGroups.Count);
+
+        return Ok(childGroups);
+    }
+}

--- a/tests/Koinon.Api.Tests/Controllers/GroupsControllerTests.cs
+++ b/tests/Koinon.Api.Tests/Controllers/GroupsControllerTests.cs
@@ -1,0 +1,863 @@
+using FluentAssertions;
+using Koinon.Api.Controllers;
+using Koinon.Application.Common;
+using Koinon.Application.DTOs;
+using Koinon.Application.DTOs.Requests;
+using Koinon.Application.Interfaces;
+using Koinon.Domain.Data;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Api.Tests.Controllers;
+
+public class GroupsControllerTests
+{
+    private readonly Mock<IGroupService> _groupServiceMock;
+    private readonly Mock<ILogger<GroupsController>> _loggerMock;
+    private readonly GroupsController _controller;
+
+    // Valid IdKeys for testing (using IdKeyHelper.Encode)
+    private readonly string _groupIdKey = IdKeyHelper.Encode(123);
+    private readonly string _group2IdKey = IdKeyHelper.Encode(456);
+    private readonly string _personIdKey = IdKeyHelper.Encode(789);
+    private readonly string _groupTypeIdKey = IdKeyHelper.Encode(10);
+    private readonly string _campusIdKey = IdKeyHelper.Encode(5);
+    private readonly string _parentGroupIdKey = IdKeyHelper.Encode(100);
+    private readonly string _roleIdKey = IdKeyHelper.Encode(15);
+    private readonly string _newGroupIdKey = IdKeyHelper.Encode(999);
+
+    public GroupsControllerTests()
+    {
+        _groupServiceMock = new Mock<IGroupService>();
+        _loggerMock = new Mock<ILogger<GroupsController>>();
+        _controller = new GroupsController(_groupServiceMock.Object, _loggerMock.Object);
+
+        // Setup HttpContext for controller
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+    }
+
+    #region Search Tests
+
+    [Fact]
+    public async Task Search_WithValidParameters_ReturnsOkWithPagedResult()
+    {
+        // Arrange
+        var expectedResult = new PagedResult<GroupSummaryDto>(
+            new List<GroupSummaryDto>
+            {
+                new() { IdKey = _groupIdKey, Name = "Youth Group", Description = "Middle school youth", IsActive = true, MemberCount = 15, GroupTypeName = "Serving Team" },
+                new() { IdKey = _group2IdKey, Name = "Worship Team", Description = "Sunday worship", IsActive = true, MemberCount = 8, GroupTypeName = "Serving Team" }
+            },
+            totalCount: 2,
+            page: 1,
+            pageSize: 25
+        );
+
+        _groupServiceMock
+            .Setup(s => s.SearchAsync(It.IsAny<GroupSearchParameters>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResult);
+
+        // Act
+        var result = await _controller.Search(
+            query: "Youth",
+            groupTypeId: null,
+            campusId: null,
+            parentGroupId: null,
+            includeInactive: false,
+            includeArchived: false,
+            page: 1,
+            pageSize: 25);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var pagedResult = okResult.Value.Should().BeOfType<PagedResult<GroupSummaryDto>>().Subject;
+        pagedResult.Items.Should().HaveCount(2);
+        pagedResult.TotalCount.Should().Be(2);
+        pagedResult.Page.Should().Be(1);
+        pagedResult.PageSize.Should().Be(25);
+    }
+
+    [Fact]
+    public async Task Search_WithFilters_PassesFiltersToService()
+    {
+        // Arrange
+        var expectedResult = new PagedResult<GroupSummaryDto>(
+            new List<GroupSummaryDto>(),
+            totalCount: 0,
+            page: 1,
+            pageSize: 25
+        );
+
+        GroupSearchParameters? capturedParameters = null;
+        _groupServiceMock
+            .Setup(s => s.SearchAsync(It.IsAny<GroupSearchParameters>(), It.IsAny<CancellationToken>()))
+            .Callback<GroupSearchParameters, CancellationToken>((p, _) => capturedParameters = p)
+            .ReturnsAsync(expectedResult);
+
+        // Act
+        await _controller.Search(
+            query: "test",
+            groupTypeId: _groupTypeIdKey,
+            campusId: _campusIdKey,
+            parentGroupId: _parentGroupIdKey,
+            includeInactive: true,
+            includeArchived: true,
+            page: 2,
+            pageSize: 50);
+
+        // Assert
+        capturedParameters.Should().NotBeNull();
+        capturedParameters!.Query.Should().Be("test");
+        capturedParameters.GroupTypeId.Should().Be(_groupTypeIdKey);
+        capturedParameters.CampusId.Should().Be(_campusIdKey);
+        capturedParameters.ParentGroupId.Should().Be(_parentGroupIdKey);
+        capturedParameters.IncludeInactive.Should().BeTrue();
+        capturedParameters.IncludeArchived.Should().BeTrue();
+        capturedParameters.Page.Should().Be(2);
+        capturedParameters.PageSize.Should().Be(50);
+    }
+
+    [Fact]
+    public async Task Search_WithInvalidGroupTypeId_ReturnsBadRequest()
+    {
+        // Act
+        var result = await _controller.Search(
+            query: null,
+            groupTypeId: "invalid-idkey",
+            campusId: null,
+            parentGroupId: null);
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task Search_WithInvalidCampusId_ReturnsBadRequest()
+    {
+        // Act
+        var result = await _controller.Search(
+            query: null,
+            groupTypeId: null,
+            campusId: "invalid-idkey",
+            parentGroupId: null);
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task Search_WithInvalidParentGroupId_ReturnsBadRequest()
+    {
+        // Act
+        var result = await _controller.Search(
+            query: null,
+            groupTypeId: null,
+            campusId: null,
+            parentGroupId: "invalid-idkey");
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    #endregion
+
+    #region GetByIdKey Tests
+
+    [Fact]
+    public async Task GetByIdKey_WithExistingGroup_ReturnsOkWithGroup()
+    {
+        // Arrange
+        var expectedGroup = new GroupDto
+        {
+            IdKey = _groupIdKey,
+            Guid = Guid.NewGuid(),
+            Name = "Youth Group",
+            Description = "Middle school youth",
+            IsActive = true,
+            IsArchived = false,
+            IsSecurityRole = false,
+            IsPublic = true,
+            AllowGuests = true,
+            GroupCapacity = 20,
+            Order = 0,
+            GroupType = new GroupTypeDto
+            {
+                IdKey = _groupTypeIdKey,
+                Guid = Guid.NewGuid(),
+                Name = "Serving Team",
+                Description = null,
+                IsFamilyGroupType = false,
+                AllowMultipleLocations = false,
+                Roles = new List<GroupTypeRoleDto>()
+            },
+            Campus = null,
+            ParentGroup = null,
+            Members = new List<GroupMemberDto>(),
+            ChildGroups = new List<GroupSummaryDto>(),
+            CreatedDateTime = DateTime.UtcNow,
+            ModifiedDateTime = null,
+            ArchivedDateTime = null
+        };
+
+        _groupServiceMock
+            .Setup(s => s.GetByIdKeyAsync(_groupIdKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedGroup);
+
+        // Act
+        var result = await _controller.GetByIdKey(_groupIdKey);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var group = okResult.Value.Should().BeOfType<GroupDto>().Subject;
+        group.IdKey.Should().Be(_groupIdKey);
+        group.Name.Should().Be("Youth Group");
+    }
+
+    [Fact]
+    public async Task GetByIdKey_WithNonExistentGroup_ReturnsNotFound()
+    {
+        // Arrange
+        var nonExistentIdKey = IdKeyHelper.Encode(99999);
+        _groupServiceMock
+            .Setup(s => s.GetByIdKeyAsync(nonExistentIdKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GroupDto?)null);
+
+        // Act
+        var result = await _controller.GetByIdKey(nonExistentIdKey);
+
+        // Assert
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        var problemDetails = notFoundResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status404NotFound);
+        problemDetails.Detail.Should().Contain(nonExistentIdKey);
+    }
+
+    [Fact]
+    public async Task GetByIdKey_WithInvalidIdKey_ReturnsBadRequest()
+    {
+        // Act
+        var result = await _controller.GetByIdKey("invalid-idkey");
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    #endregion
+
+    #region Create Tests
+
+    [Fact]
+    public async Task Create_WithValidRequest_ReturnsCreatedWithGroup()
+    {
+        // Arrange
+        var request = new CreateGroupRequest
+        {
+            Name = "New Youth Group",
+            Description = "High school youth",
+            GroupTypeId = _groupTypeIdKey,
+            IsActive = true,
+            IsPublic = true,
+            AllowGuests = false,
+            Order = 0
+        };
+
+        var createdGroup = new GroupDto
+        {
+            IdKey = _newGroupIdKey,
+            Guid = Guid.NewGuid(),
+            Name = "New Youth Group",
+            Description = "High school youth",
+            IsActive = true,
+            IsArchived = false,
+            IsSecurityRole = false,
+            IsPublic = true,
+            AllowGuests = false,
+            GroupCapacity = null,
+            Order = 0,
+            GroupType = new GroupTypeDto
+            {
+                IdKey = _groupTypeIdKey,
+                Guid = Guid.NewGuid(),
+                Name = "Serving Team",
+                Description = null,
+                IsFamilyGroupType = false,
+                AllowMultipleLocations = false,
+                Roles = new List<GroupTypeRoleDto>()
+            },
+            Campus = null,
+            ParentGroup = null,
+            Members = new List<GroupMemberDto>(),
+            ChildGroups = new List<GroupSummaryDto>(),
+            CreatedDateTime = DateTime.UtcNow,
+            ModifiedDateTime = null,
+            ArchivedDateTime = null
+        };
+
+        _groupServiceMock
+            .Setup(s => s.CreateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<GroupDto>.Success(createdGroup));
+
+        // Act
+        var result = await _controller.Create(request);
+
+        // Assert
+        var createdResult = result.Should().BeOfType<CreatedAtActionResult>().Subject;
+        createdResult.ActionName.Should().Be(nameof(GroupsController.GetByIdKey));
+        createdResult.RouteValues.Should().ContainKey("idKey");
+        createdResult.RouteValues!["idKey"].Should().Be(_newGroupIdKey);
+
+        var group = createdResult.Value.Should().BeOfType<GroupDto>().Subject;
+        group.IdKey.Should().Be(_newGroupIdKey);
+        group.Name.Should().Be("New Youth Group");
+    }
+
+    [Fact]
+    public async Task Create_WithValidationError_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new CreateGroupRequest
+        {
+            Name = "",
+            GroupTypeId = _groupTypeIdKey
+        };
+
+        var error = new Error(
+            "VALIDATION_ERROR",
+            "One or more validation errors occurred",
+            new Dictionary<string, string[]>
+            {
+                { "Name", new[] { "Group name is required" } }
+            }
+        );
+
+        _groupServiceMock
+            .Setup(s => s.CreateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<GroupDto>.Failure(error));
+
+        // Act
+        var result = await _controller.Create(request);
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+        problemDetails.Extensions.Should().ContainKey("errors");
+    }
+
+    [Fact]
+    public async Task Create_WithBusinessRuleViolation_ReturnsUnprocessableEntity()
+    {
+        // Arrange
+        var request = new CreateGroupRequest
+        {
+            Name = "Test Group",
+            GroupTypeId = _groupTypeIdKey
+        };
+
+        var error = Error.UnprocessableEntity("Cannot create family groups via GroupService");
+
+        _groupServiceMock
+            .Setup(s => s.CreateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<GroupDto>.Failure(error));
+
+        // Act
+        var result = await _controller.Create(request);
+
+        // Assert
+        var unprocessableResult = result.Should().BeOfType<UnprocessableEntityObjectResult>().Subject;
+        var problemDetails = unprocessableResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    #endregion
+
+    #region Update Tests
+
+    [Fact]
+    public async Task Update_WithValidRequest_ReturnsOkWithUpdatedGroup()
+    {
+        // Arrange
+        var request = new UpdateGroupRequest
+        {
+            Name = "Youth Group Updated",
+            Description = "Updated description"
+        };
+
+        var updatedGroup = new GroupDto
+        {
+            IdKey = _groupIdKey,
+            Guid = Guid.NewGuid(),
+            Name = "Youth Group Updated",
+            Description = "Updated description",
+            IsActive = true,
+            IsArchived = false,
+            IsSecurityRole = false,
+            IsPublic = true,
+            AllowGuests = true,
+            GroupCapacity = 20,
+            Order = 0,
+            GroupType = new GroupTypeDto
+            {
+                IdKey = _groupTypeIdKey,
+                Guid = Guid.NewGuid(),
+                Name = "Serving Team",
+                Description = null,
+                IsFamilyGroupType = false,
+                AllowMultipleLocations = false,
+                Roles = new List<GroupTypeRoleDto>()
+            },
+            Campus = null,
+            ParentGroup = null,
+            Members = new List<GroupMemberDto>(),
+            ChildGroups = new List<GroupSummaryDto>(),
+            CreatedDateTime = DateTime.UtcNow.AddDays(-1),
+            ModifiedDateTime = DateTime.UtcNow,
+            ArchivedDateTime = null
+        };
+
+        _groupServiceMock
+            .Setup(s => s.UpdateAsync(_groupIdKey, request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<GroupDto>.Success(updatedGroup));
+
+        // Act
+        var result = await _controller.Update(_groupIdKey, request);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var group = okResult.Value.Should().BeOfType<GroupDto>().Subject;
+        group.IdKey.Should().Be(_groupIdKey);
+        group.Name.Should().Be("Youth Group Updated");
+        group.ModifiedDateTime.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task Update_WithNonExistentGroup_ReturnsNotFound()
+    {
+        // Arrange
+        var nonExistentIdKey = IdKeyHelper.Encode(99999);
+        var request = new UpdateGroupRequest
+        {
+            Name = "Test Group"
+        };
+
+        var error = Error.NotFound("Group", nonExistentIdKey);
+
+        _groupServiceMock
+            .Setup(s => s.UpdateAsync(nonExistentIdKey, request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<GroupDto>.Failure(error));
+
+        // Act
+        var result = await _controller.Update(nonExistentIdKey, request);
+
+        // Assert
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        var problemDetails = notFoundResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task Update_WithInvalidIdKey_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new UpdateGroupRequest
+        {
+            Name = "Test"
+        };
+
+        // Act
+        var result = await _controller.Update("invalid-idkey", request);
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    #endregion
+
+    #region Delete Tests
+
+    [Fact]
+    public async Task Delete_WithExistingGroup_ReturnsNoContent()
+    {
+        // Arrange
+        _groupServiceMock
+            .Setup(s => s.DeleteAsync(_groupIdKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        var result = await _controller.Delete(_groupIdKey);
+
+        // Assert
+        result.Should().BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task Delete_WithNonExistentGroup_ReturnsNotFound()
+    {
+        // Arrange
+        var nonExistentIdKey = IdKeyHelper.Encode(99999);
+        var error = Error.NotFound("Group", nonExistentIdKey);
+
+        _groupServiceMock
+            .Setup(s => s.DeleteAsync(nonExistentIdKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(error));
+
+        // Act
+        var result = await _controller.Delete(nonExistentIdKey);
+
+        // Assert
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        var problemDetails = notFoundResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task Delete_WithBusinessRuleViolation_ReturnsUnprocessableEntity()
+    {
+        // Arrange
+        var error = Error.UnprocessableEntity("Cannot delete system-protected groups");
+
+        _groupServiceMock
+            .Setup(s => s.DeleteAsync(_groupIdKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(error));
+
+        // Act
+        var result = await _controller.Delete(_groupIdKey);
+
+        // Assert
+        var unprocessableResult = result.Should().BeOfType<UnprocessableEntityObjectResult>().Subject;
+        var problemDetails = unprocessableResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status422UnprocessableEntity);
+    }
+
+    [Fact]
+    public async Task Delete_WithInvalidIdKey_ReturnsBadRequest()
+    {
+        // Act
+        var result = await _controller.Delete("invalid-idkey");
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    #endregion
+
+    #region GetMembers Tests
+
+    [Fact]
+    public async Task GetMembers_WithExistingGroup_ReturnsOkWithMembers()
+    {
+        // Arrange
+        var expectedMembers = new List<GroupMemberDto>
+        {
+            new()
+            {
+                IdKey = IdKeyHelper.Encode(1),
+                Person = new PersonSummaryDto
+                {
+                    IdKey = _personIdKey,
+                    FirstName = "John",
+                    LastName = "Doe",
+                    FullName = "John Doe",
+                    Gender = "Male"
+                },
+                Role = new GroupTypeRoleDto
+                {
+                    IdKey = _roleIdKey,
+                    Name = "Leader",
+                    IsLeader = true
+                },
+                Status = "Active",
+                DateTimeAdded = DateTime.UtcNow.AddDays(-30),
+                InactiveDateTime = null,
+                Note = null
+            }
+        };
+
+        _groupServiceMock
+            .Setup(s => s.GetMembersAsync(_groupIdKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedMembers);
+
+        // Act
+        var result = await _controller.GetMembers(_groupIdKey);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var members = okResult.Value.Should().BeAssignableTo<IReadOnlyList<GroupMemberDto>>().Subject;
+        members.Should().HaveCount(1);
+        members[0].Person.IdKey.Should().Be(_personIdKey);
+    }
+
+    [Fact]
+    public async Task GetMembers_WithNoMembers_ReturnsEmptyList()
+    {
+        // Arrange
+        _groupServiceMock
+            .Setup(s => s.GetMembersAsync(_groupIdKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GroupMemberDto>());
+
+        // Act
+        var result = await _controller.GetMembers(_groupIdKey);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var members = okResult.Value.Should().BeAssignableTo<IReadOnlyList<GroupMemberDto>>().Subject;
+        members.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetMembers_WithInvalidIdKey_ReturnsBadRequest()
+    {
+        // Act
+        var result = await _controller.GetMembers("invalid-idkey");
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    #endregion
+
+    #region AddMember Tests
+
+    [Fact]
+    public async Task AddMember_WithValidRequest_ReturnsCreatedWithMember()
+    {
+        // Arrange
+        var request = new AddGroupMemberRequest
+        {
+            PersonId = _personIdKey,
+            RoleId = _roleIdKey,
+            Note = "New member"
+        };
+
+        var createdMember = new GroupMemberDto
+        {
+            IdKey = IdKeyHelper.Encode(1),
+            Person = new PersonSummaryDto
+            {
+                IdKey = _personIdKey,
+                FirstName = "John",
+                LastName = "Doe",
+                FullName = "John Doe",
+                Gender = "Male"
+            },
+            Role = new GroupTypeRoleDto
+            {
+                IdKey = _roleIdKey,
+                Name = "Member",
+                IsLeader = false
+            },
+            Status = "Active",
+            DateTimeAdded = DateTime.UtcNow,
+            InactiveDateTime = null,
+            Note = "New member"
+        };
+
+        _groupServiceMock
+            .Setup(s => s.AddMemberAsync(_groupIdKey, request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<GroupMemberDto>.Success(createdMember));
+
+        // Act
+        var result = await _controller.AddMember(_groupIdKey, request);
+
+        // Assert
+        var createdResult = result.Should().BeOfType<CreatedAtActionResult>().Subject;
+        createdResult.ActionName.Should().Be(nameof(GroupsController.GetMembers));
+        createdResult.RouteValues.Should().ContainKey("idKey");
+        createdResult.RouteValues!["idKey"].Should().Be(_groupIdKey);
+
+        var member = createdResult.Value.Should().BeOfType<GroupMemberDto>().Subject;
+        member.Person.IdKey.Should().Be(_personIdKey);
+    }
+
+    [Fact]
+    public async Task AddMember_WithNonExistentGroup_ReturnsNotFound()
+    {
+        // Arrange
+        var request = new AddGroupMemberRequest
+        {
+            PersonId = _personIdKey,
+            RoleId = _roleIdKey
+        };
+
+        var error = Error.NotFound("Group", _groupIdKey);
+
+        _groupServiceMock
+            .Setup(s => s.AddMemberAsync(_groupIdKey, request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<GroupMemberDto>.Failure(error));
+
+        // Act
+        var result = await _controller.AddMember(_groupIdKey, request);
+
+        // Assert
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        var problemDetails = notFoundResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task AddMember_WithInvalidIdKey_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new AddGroupMemberRequest
+        {
+            PersonId = _personIdKey,
+            RoleId = _roleIdKey
+        };
+
+        // Act
+        var result = await _controller.AddMember("invalid-idkey", request);
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    #endregion
+
+    #region RemoveMember Tests
+
+    [Fact]
+    public async Task RemoveMember_WithExistingMember_ReturnsNoContent()
+    {
+        // Arrange
+        _groupServiceMock
+            .Setup(s => s.RemoveMemberAsync(_groupIdKey, _personIdKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+
+        // Act
+        var result = await _controller.RemoveMember(_groupIdKey, _personIdKey);
+
+        // Assert
+        result.Should().BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task RemoveMember_WithNonExistentMember_ReturnsNotFound()
+    {
+        // Arrange
+        var error = Error.NotFound("GroupMember", $"Person {_personIdKey} in Group {_groupIdKey}");
+
+        _groupServiceMock
+            .Setup(s => s.RemoveMemberAsync(_groupIdKey, _personIdKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(error));
+
+        // Act
+        var result = await _controller.RemoveMember(_groupIdKey, _personIdKey);
+
+        // Assert
+        var notFoundResult = result.Should().BeOfType<NotFoundObjectResult>().Subject;
+        var problemDetails = notFoundResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status404NotFound);
+    }
+
+    [Fact]
+    public async Task RemoveMember_WithInvalidGroupIdKey_ReturnsBadRequest()
+    {
+        // Act
+        var result = await _controller.RemoveMember("invalid-idkey", _personIdKey);
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    [Fact]
+    public async Task RemoveMember_WithInvalidPersonIdKey_ReturnsBadRequest()
+    {
+        // Act
+        var result = await _controller.RemoveMember(_groupIdKey, "invalid-idkey");
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    #endregion
+
+    #region GetChildren Tests
+
+    [Fact]
+    public async Task GetChildren_WithExistingChildGroups_ReturnsOkWithChildren()
+    {
+        // Arrange
+        var expectedChildren = new List<GroupSummaryDto>
+        {
+            new()
+            {
+                IdKey = _group2IdKey,
+                Name = "Sub Group 1",
+                Description = "First child group",
+                IsActive = true,
+                MemberCount = 5,
+                GroupTypeName = "Small Group"
+            }
+        };
+
+        _groupServiceMock
+            .Setup(s => s.GetChildGroupsAsync(_groupIdKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedChildren);
+
+        // Act
+        var result = await _controller.GetChildren(_groupIdKey);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var children = okResult.Value.Should().BeAssignableTo<IReadOnlyList<GroupSummaryDto>>().Subject;
+        children.Should().HaveCount(1);
+        children[0].Name.Should().Be("Sub Group 1");
+    }
+
+    [Fact]
+    public async Task GetChildren_WithNoChildren_ReturnsEmptyList()
+    {
+        // Arrange
+        _groupServiceMock
+            .Setup(s => s.GetChildGroupsAsync(_groupIdKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GroupSummaryDto>());
+
+        // Act
+        var result = await _controller.GetChildren(_groupIdKey);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var children = okResult.Value.Should().BeAssignableTo<IReadOnlyList<GroupSummaryDto>>().Subject;
+        children.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetChildren_WithInvalidIdKey_ReturnsBadRequest()
+    {
+        // Act
+        var result = await _controller.GetChildren("invalid-idkey");
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
## Summary
- Create GroupsController with full CRUD operations for group management
- Member management endpoints (add/remove/list)
- Hierarchy traversal endpoint (child groups)
- 31 comprehensive controller tests

## API Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/api/v1/groups` | Search groups with filters |
| GET | `/api/v1/groups/{idKey}` | Get group details |
| POST | `/api/v1/groups` | Create new group |
| PUT | `/api/v1/groups/{idKey}` | Update group |
| DELETE | `/api/v1/groups/{idKey}` | Archive group |
| GET | `/api/v1/groups/{idKey}/members` | List group members |
| POST | `/api/v1/groups/{idKey}/members` | Add member to group |
| DELETE | `/api/v1/groups/{idKey}/members/{personIdKey}` | Remove member |
| GET | `/api/v1/groups/{idKey}/children` | List child groups |

## Acceptance Criteria
- [x] GroupsController with all endpoints
- [x] GroupService integration (service already existed)
- [x] DTOs (already existed)
- [x] Validation with IdKey checks
- [x] Tests with edge case coverage

## Test Plan
- [x] All 31 controller tests pass
- [ ] Manual API testing with Swagger
- [ ] Verify group CRUD operations

## Tech Debt
Created #76 for IdKey validation refactoring and logging review.

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)