### PR TITLE
feat: Add Admin Dashboard Overview Page (#72)

### DIFF
--- a/src/Koinon.Api/Controllers/DashboardController.cs
+++ b/src/Koinon.Api/Controllers/DashboardController.cs
@@ -1,0 +1,37 @@
+using Koinon.Application.DTOs;
+using Koinon.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Koinon.Api.Controllers;
+
+/// <summary>
+/// Controller for dashboard statistics and metrics.
+/// Provides aggregated data for admin dashboard displays.
+/// </summary>
+[ApiController]
+[Route("api/v1/dashboard")]
+[Authorize]
+public class DashboardController(
+    IDashboardService dashboardService,
+    ILogger<DashboardController> logger) : ControllerBase
+{
+    /// <summary>
+    /// Gets dashboard statistics including people, families, groups, and check-in metrics.
+    /// </summary>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Dashboard statistics summary</returns>
+    /// <response code="200">Returns dashboard statistics</response>
+    [HttpGet("stats")]
+    [ProducesResponseType(typeof(DashboardStatsDto), StatusCodes.Status200OK)]
+    public async Task<IActionResult> GetStats(CancellationToken ct = default)
+    {
+        var stats = await dashboardService.GetStatsAsync(ct);
+
+        logger.LogInformation(
+            "Dashboard stats retrieved: People={TotalPeople}, Families={TotalFamilies}, Groups={ActiveGroups}",
+            stats.TotalPeople, stats.TotalFamilies, stats.ActiveGroups);
+
+        return Ok(stats);
+    }
+}

--- a/src/Koinon.Application/DTOs/DashboardStatsDto.cs
+++ b/src/Koinon.Application/DTOs/DashboardStatsDto.cs
@@ -1,0 +1,70 @@
+namespace Koinon.Application.DTOs;
+
+/// <summary>
+/// Dashboard statistics summary data transfer object.
+/// Provides key metrics for the admin dashboard overview.
+/// </summary>
+public record DashboardStatsDto
+{
+    /// <summary>
+    /// Total count of active people in the system.
+    /// </summary>
+    public required int TotalPeople { get; init; }
+
+    /// <summary>
+    /// Total count of family groups.
+    /// </summary>
+    public required int TotalFamilies { get; init; }
+
+    /// <summary>
+    /// Count of active non-family groups.
+    /// </summary>
+    public required int ActiveGroups { get; init; }
+
+    /// <summary>
+    /// Count of check-ins for today.
+    /// </summary>
+    public required int TodayCheckIns { get; init; }
+
+    /// <summary>
+    /// Count of check-ins for the same day last week (for comparison).
+    /// </summary>
+    public required int LastWeekCheckIns { get; init; }
+
+    /// <summary>
+    /// Count of active schedules.
+    /// </summary>
+    public required int ActiveSchedules { get; init; }
+
+    /// <summary>
+    /// List of upcoming schedules with their next occurrence times.
+    /// </summary>
+    public required List<UpcomingScheduleDto> UpcomingSchedules { get; init; }
+}
+
+/// <summary>
+/// Data transfer object for upcoming schedule information.
+/// </summary>
+public record UpcomingScheduleDto
+{
+    /// <summary>
+    /// URL-safe identifier for the schedule.
+    /// </summary>
+    public required string IdKey { get; init; }
+
+    /// <summary>
+    /// Name of the schedule.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// The date and time of the next occurrence.
+    /// </summary>
+    public required DateTime NextOccurrence { get; init; }
+
+    /// <summary>
+    /// Minutes until check-in opens for this schedule.
+    /// Negative values indicate check-in is already open.
+    /// </summary>
+    public required int MinutesUntilCheckIn { get; init; }
+}

--- a/src/Koinon.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Koinon.Application/Extensions/ServiceCollectionExtensions.cs
@@ -36,6 +36,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IGroupService, GroupService>();
         services.AddScoped<IFamilyService, FamilyService>();
         services.AddScoped<IScheduleService, ScheduleService>();
+        services.AddScoped<IDashboardService, DashboardService>();
 
         // Check-in common services (foundation classes for consistent patterns)
         services.AddScoped<CheckinDataLoader>();

--- a/src/Koinon.Application/Interfaces/IDashboardService.cs
+++ b/src/Koinon.Application/Interfaces/IDashboardService.cs
@@ -1,0 +1,17 @@
+using Koinon.Application.DTOs;
+
+namespace Koinon.Application.Interfaces;
+
+/// <summary>
+/// Service interface for dashboard statistics and metrics.
+/// Provides aggregated data for admin dashboard displays.
+/// </summary>
+public interface IDashboardService
+{
+    /// <summary>
+    /// Retrieves dashboard statistics including people, families, groups, check-ins, and upcoming schedules.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token for async operation.</param>
+    /// <returns>Dashboard statistics DTO with all aggregated metrics.</returns>
+    Task<DashboardStatsDto> GetStatsAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Koinon.Application/Services/DashboardService.cs
+++ b/src/Koinon.Application/Services/DashboardService.cs
@@ -1,0 +1,169 @@
+using Koinon.Application.DTOs;
+using Koinon.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Koinon.Application.Services;
+
+/// <summary>
+/// Service for retrieving dashboard statistics and metrics.
+/// Aggregates data from multiple entities for admin dashboard displays.
+/// </summary>
+public class DashboardService(
+    IApplicationDbContext context,
+    ILogger<DashboardService> logger) : IDashboardService
+{
+    public async Task<DashboardStatsDto> GetStatsAsync(CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Retrieving dashboard statistics");
+
+        var now = DateTime.UtcNow;
+        var today = DateOnly.FromDateTime(now);
+        var lastWeek = today.AddDays(-7);
+
+        // Execute all count queries in parallel for better performance
+        var totalPeopleTask = context.People
+            .CountAsync(p => !p.IsDeceased, cancellationToken);
+
+        var totalFamiliesTask = context.Groups
+            .CountAsync(g => g.GroupType != null && g.GroupType.IsFamilyGroupType && !g.IsArchived, cancellationToken);
+
+        var activeGroupsTask = context.Groups
+            .CountAsync(g => g.GroupType != null && !g.GroupType.IsFamilyGroupType && g.IsActive && !g.IsArchived, cancellationToken);
+
+        var activeSchedulesTask = context.Schedules
+            .CountAsync(s => s.IsActive, cancellationToken);
+
+        // Check-ins for today (attendance records where StartDateTime is today in UTC)
+        var todayStart = today.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        var todayEnd = today.AddDays(1).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+        var todayCheckInsTask = context.Attendances
+            .CountAsync(a => a.StartDateTime >= todayStart && a.StartDateTime < todayEnd, cancellationToken);
+
+        // Check-ins for same day last week
+        var lastWeekStart = lastWeek.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        var lastWeekEnd = lastWeek.AddDays(1).ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+        var lastWeekCheckInsTask = context.Attendances
+            .CountAsync(a => a.StartDateTime >= lastWeekStart && a.StartDateTime < lastWeekEnd, cancellationToken);
+
+        // Get upcoming schedules (next 5 active weekly schedules)
+        var upcomingSchedulesTask = GetUpcomingSchedulesAsync(now, cancellationToken);
+
+        // Await all tasks
+        await Task.WhenAll(
+            totalPeopleTask,
+            totalFamiliesTask,
+            activeGroupsTask,
+            activeSchedulesTask,
+            todayCheckInsTask,
+            lastWeekCheckInsTask,
+            upcomingSchedulesTask);
+
+        var stats = new DashboardStatsDto
+        {
+            TotalPeople = await totalPeopleTask,
+            TotalFamilies = await totalFamiliesTask,
+            ActiveGroups = await activeGroupsTask,
+            ActiveSchedules = await activeSchedulesTask,
+            TodayCheckIns = await todayCheckInsTask,
+            LastWeekCheckIns = await lastWeekCheckInsTask,
+            UpcomingSchedules = await upcomingSchedulesTask
+        };
+
+        logger.LogInformation(
+            "Dashboard statistics retrieved: People={TotalPeople}, Families={TotalFamilies}, Groups={ActiveGroups}, " +
+            "TodayCheckIns={TodayCheckIns}, LastWeekCheckIns={LastWeekCheckIns}, ActiveSchedules={ActiveSchedules}",
+            stats.TotalPeople, stats.TotalFamilies, stats.ActiveGroups,
+            stats.TodayCheckIns, stats.LastWeekCheckIns, stats.ActiveSchedules);
+
+        return stats;
+    }
+
+    private async Task<List<UpcomingScheduleDto>> GetUpcomingSchedulesAsync(
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        // Get active weekly schedules with check-in times configured
+        var activeSchedules = await context.Schedules
+            .AsNoTracking()
+            .Where(s => s.IsActive && s.WeeklyDayOfWeek.HasValue && s.WeeklyTimeOfDay.HasValue)
+            .OrderBy(s => s.Order)
+            .ThenBy(s => s.Name)
+            .Take(10) // Get top 10 to filter down to next 5 occurrences
+            .Select(s => new
+            {
+                s.IdKey,
+                s.Name,
+                s.WeeklyDayOfWeek,
+                s.WeeklyTimeOfDay,
+                s.CheckInStartOffsetMinutes
+            })
+            .ToListAsync(cancellationToken);
+
+        var upcomingSchedules = new List<UpcomingScheduleDto>();
+
+        foreach (var schedule in activeSchedules)
+        {
+            if (!schedule.WeeklyDayOfWeek.HasValue || !schedule.WeeklyTimeOfDay.HasValue)
+            {
+                continue;
+            }
+
+            // Calculate next occurrence for this weekly schedule
+            var nextOccurrence = CalculateNextOccurrence(
+                now,
+                schedule.WeeklyDayOfWeek.Value,
+                schedule.WeeklyTimeOfDay.Value);
+
+            // Calculate when check-in opens
+            var checkInStartOffset = schedule.CheckInStartOffsetMinutes ?? 60; // Default to 60 minutes before
+            var checkInOpenTime = nextOccurrence.AddMinutes(-checkInStartOffset);
+
+            // Calculate minutes until check-in
+            var minutesUntilCheckIn = (int)(checkInOpenTime - now).TotalMinutes;
+
+            upcomingSchedules.Add(new UpcomingScheduleDto
+            {
+                IdKey = schedule.IdKey,
+                Name = schedule.Name,
+                NextOccurrence = nextOccurrence,
+                MinutesUntilCheckIn = minutesUntilCheckIn
+            });
+        }
+
+        // Return next 5 occurrences sorted by next occurrence time
+        return upcomingSchedules
+            .OrderBy(s => s.NextOccurrence)
+            .Take(5)
+            .ToList();
+    }
+
+    private static DateTime CalculateNextOccurrence(DateTime fromDateTime, DayOfWeek targetDayOfWeek, TimeSpan targetTime)
+    {
+        var currentDate = DateOnly.FromDateTime(fromDateTime);
+        var currentTime = TimeOnly.FromDateTime(fromDateTime);
+        var targetTimeOnly = TimeOnly.FromTimeSpan(targetTime);
+
+        // Start with today
+        var candidateDate = currentDate;
+        var currentDayOfWeek = fromDateTime.DayOfWeek;
+
+        // If today is the target day and the time hasn't passed yet, use today
+        if (currentDayOfWeek == targetDayOfWeek && currentTime < targetTimeOnly)
+        {
+            return candidateDate.ToDateTime(targetTimeOnly, DateTimeKind.Utc);
+        }
+
+        // Otherwise, find the next occurrence of the target day
+        var daysUntilTarget = ((int)targetDayOfWeek - (int)currentDayOfWeek + 7) % 7;
+        if (daysUntilTarget == 0)
+        {
+            daysUntilTarget = 7; // Move to next week if same day but time has passed
+        }
+
+        candidateDate = candidateDate.AddDays(daysUntilTarget);
+        return candidateDate.ToDateTime(targetTimeOnly, DateTimeKind.Utc);
+    }
+}

--- a/src/web/src/components/admin/dashboard/QuickActions.tsx
+++ b/src/web/src/components/admin/dashboard/QuickActions.tsx
@@ -1,0 +1,89 @@
+/**
+ * Quick Actions Component
+ * Dashboard widget with quick navigation actions
+ */
+
+import { Link } from 'react-router-dom';
+
+export function QuickActions() {
+  const actions = [
+    {
+      to: '/admin/people/new',
+      label: 'Add Person',
+      description: 'Create a new person record',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"
+          />
+        </svg>
+      ),
+    },
+    {
+      to: '/admin/families/new',
+      label: 'Create Family',
+      description: 'Add a new family household',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
+        </svg>
+      ),
+    },
+    {
+      to: '/admin/groups',
+      label: 'Manage Groups',
+      description: 'View and edit check-in groups',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+          />
+        </svg>
+      ),
+    },
+    {
+      to: '/admin/schedules',
+      label: 'View Schedules',
+      description: 'Manage check-in schedules',
+      icon: (
+        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+          />
+        </svg>
+      ),
+    },
+  ];
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">Quick Actions</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        {actions.map((action) => (
+          <Link
+            key={action.to}
+            to={action.to}
+            className="flex items-start gap-4 p-4 rounded-lg border border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-all group"
+          >
+            <div className="p-2 rounded-lg bg-gray-100 text-gray-600 group-hover:bg-primary-100 group-hover:text-primary-600 transition-colors">
+              {action.icon}
+            </div>
+            <div className="flex-1 min-w-0">
+              <h3 className="text-sm font-semibold text-gray-900">{action.label}</h3>
+              <p className="mt-1 text-sm text-gray-500">{action.description}</p>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/admin/dashboard/StatCard.tsx
+++ b/src/web/src/components/admin/dashboard/StatCard.tsx
@@ -1,0 +1,77 @@
+/**
+ * Stat Card Component
+ * Reusable card for displaying dashboard statistics
+ */
+
+export interface StatCardProps {
+  title: string;
+  value: string | number;
+  subtitle?: string;
+  icon: React.ReactNode;
+  color: 'blue' | 'green' | 'purple' | 'indigo' | 'amber';
+  trend?: 'up' | 'down' | 'neutral';
+  trendValue?: string;
+}
+
+export function StatCard({
+  title,
+  value,
+  subtitle,
+  icon,
+  color,
+  trend,
+  trendValue,
+}: StatCardProps) {
+  const colorClasses = {
+    blue: 'bg-blue-50 text-blue-600',
+    green: 'bg-green-50 text-green-600',
+    purple: 'bg-purple-50 text-purple-600',
+    indigo: 'bg-indigo-50 text-indigo-600',
+    amber: 'bg-amber-50 text-amber-600',
+  };
+
+  const trendClasses = {
+    up: 'text-green-600',
+    down: 'text-red-600',
+    neutral: 'text-gray-500',
+  };
+
+  const trendIcons = {
+    up: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 10l7-7m0 0l7 7m-7-7v18" />
+      </svg>
+    ),
+    down: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+      </svg>
+    ),
+    neutral: (
+      <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 12h14" />
+      </svg>
+    ),
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <div className="flex items-center justify-between">
+        <div className="flex-1">
+          <p className="text-sm font-medium text-gray-600">{title}</p>
+          <p className="mt-2 text-3xl font-bold text-gray-900">{value}</p>
+          {subtitle && <p className="mt-1 text-sm text-gray-500">{subtitle}</p>}
+          {trend && trendValue && (
+            <div className={`mt-2 flex items-center gap-1 text-sm ${trendClasses[trend]}`}>
+              {trendIcons[trend]}
+              <span>{trendValue}</span>
+            </div>
+          )}
+        </div>
+        <div className={`p-3 rounded-lg ${colorClasses[color]}`}>
+          {icon}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/admin/dashboard/UpcomingSchedules.tsx
+++ b/src/web/src/components/admin/dashboard/UpcomingSchedules.tsx
@@ -1,0 +1,132 @@
+/**
+ * Upcoming Schedules Component
+ * Displays upcoming check-in schedules with status indicators
+ */
+
+import { Link } from 'react-router-dom';
+import type { UpcomingSchedule } from '@/services/api/dashboard';
+
+export interface UpcomingSchedulesProps {
+  schedules: UpcomingSchedule[];
+  isLoading: boolean;
+}
+
+export function UpcomingSchedules({ schedules, isLoading }: UpcomingSchedulesProps) {
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Upcoming Schedules</h2>
+        <div className="flex items-center justify-center py-12">
+          <div className="flex items-center gap-3 text-gray-500">
+            <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              />
+            </svg>
+            <span>Loading schedules...</span>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (schedules.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Upcoming Schedules</h2>
+        <div className="text-center py-12">
+          <svg
+            className="w-12 h-12 text-gray-400 mx-auto mb-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+          <p className="text-gray-500">No upcoming schedules</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">Upcoming Schedules</h2>
+      <div className="space-y-3">
+        {schedules.map((schedule) => (
+          <ScheduleItem key={schedule.idKey} schedule={schedule} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface ScheduleItemProps {
+  schedule: UpcomingSchedule;
+}
+
+function ScheduleItem({ schedule }: ScheduleItemProps) {
+  const isOpen = schedule.minutesUntilCheckIn <= 0;
+  const formattedTime = new Date(schedule.nextOccurrence).toLocaleString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+
+  // Calculate status text and color
+  let statusText: string;
+  let statusColor: string;
+
+  if (isOpen) {
+    statusText = 'Open';
+    statusColor = 'text-green-700 bg-green-50 border-green-200';
+  } else {
+    const minutes = schedule.minutesUntilCheckIn;
+    if (minutes < 60) {
+      statusText = `Opens in ${minutes} min`;
+      statusColor = 'text-yellow-700 bg-yellow-50 border-yellow-200';
+    } else {
+      const hours = Math.floor(minutes / 60);
+      statusText = `Opens in ${hours} hr${hours > 1 ? 's' : ''}`;
+      statusColor = 'text-gray-700 bg-gray-50 border-gray-200';
+    }
+  }
+
+  return (
+    <Link
+      to={`/admin/schedules/${schedule.idKey}`}
+      className="flex items-center justify-between p-4 rounded-lg border border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-all group"
+    >
+      <div className="flex-1 min-w-0">
+        <h3 className="text-sm font-semibold text-gray-900 group-hover:text-primary-700">
+          {schedule.name}
+        </h3>
+        <p className="mt-1 text-sm text-gray-500">
+          <svg className="w-4 h-4 inline-block mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          {formattedTime}
+        </p>
+      </div>
+      <div className={`px-3 py-1 text-xs font-medium rounded-full border ${statusColor}`}>
+        {statusText}
+      </div>
+    </Link>
+  );
+}

--- a/src/web/src/components/admin/dashboard/index.ts
+++ b/src/web/src/components/admin/dashboard/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Dashboard components barrel export
+ */
+
+export { StatCard } from './StatCard';
+export { QuickActions } from './QuickActions';
+export { UpcomingSchedules } from './UpcomingSchedules';
+
+export type { StatCardProps } from './StatCard';
+export type { UpcomingSchedulesProps } from './UpcomingSchedules';

--- a/src/web/src/hooks/useDashboard.ts
+++ b/src/web/src/hooks/useDashboard.ts
@@ -1,0 +1,15 @@
+/**
+ * Dashboard hooks using TanStack Query
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import * as dashboardApi from '@/services/api/dashboard';
+
+export function useDashboardStats() {
+  return useQuery({
+    queryKey: ['dashboard', 'stats'],
+    queryFn: () => dashboardApi.getDashboardStats(),
+    staleTime: 60 * 1000, // 1 minute
+    refetchInterval: 60 * 1000, // Auto refresh every minute
+  });
+}

--- a/src/web/src/pages/admin/DashboardPage.tsx
+++ b/src/web/src/pages/admin/DashboardPage.tsx
@@ -3,25 +3,90 @@
  * Overview page with key metrics and quick actions
  */
 
+import { useDashboardStats } from '@/hooks/useDashboard';
+import { StatCard, QuickActions, UpcomingSchedules } from '@/components/admin/dashboard';
+
 export function DashboardPage() {
+  const { data: stats, isLoading, error } = useDashboardStats();
+
+  // Calculate trend for check-ins
+  const calculateTrend = () => {
+    if (!stats) return undefined;
+
+    const today = stats.todayCheckIns;
+    const lastWeek = stats.lastWeekCheckIns;
+
+    if (lastWeek === 0) {
+      return today > 0 ? { trend: 'up' as const, value: 'New activity' } : undefined;
+    }
+
+    const percentChange = ((today - lastWeek) / lastWeek) * 100;
+    const formattedPercent = Math.abs(percentChange).toFixed(0);
+
+    if (percentChange > 5) {
+      return { trend: 'up' as const, value: `+${formattedPercent}% vs last week` };
+    } else if (percentChange < -5) {
+      return { trend: 'down' as const, value: `-${formattedPercent}% vs last week` };
+    } else {
+      return { trend: 'neutral' as const, value: 'Similar to last week' };
+    }
+  };
+
+  const checkInTrend = calculateTrend();
+
+  // Show error state
+  if (error) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Dashboard</h1>
+          <p className="mt-2 text-gray-600">Welcome to Koinon RMS admin dashboard</p>
+        </div>
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6 text-center">
+          <svg
+            className="w-12 h-12 text-red-400 mx-auto mb-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+          <p className="text-red-700 font-medium">Failed to load dashboard data</p>
+          <p className="text-red-600 text-sm mt-1">
+            {error instanceof Error ? error.message : 'An unknown error occurred'}
+          </p>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
       {/* Page header */}
       <div>
         <h1 className="text-3xl font-bold text-gray-900">Dashboard</h1>
-        <p className="mt-2 text-gray-600">
-          Welcome to Koinon RMS admin dashboard
-        </p>
+        <p className="mt-2 text-gray-600">Welcome to Koinon RMS admin dashboard</p>
       </div>
 
       {/* Stats grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
         <StatCard
           title="Total People"
-          value="--"
+          value={isLoading ? '--' : stats?.totalPeople.toLocaleString() ?? '--'}
           icon={
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+              />
             </svg>
           }
           color="blue"
@@ -29,10 +94,15 @@ export function DashboardPage() {
 
         <StatCard
           title="Families"
-          value="--"
+          value={isLoading ? '--' : stats?.totalFamilies.toLocaleString() ?? '--'}
           icon={
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+              />
             </svg>
           }
           color="green"
@@ -40,131 +110,48 @@ export function DashboardPage() {
 
         <StatCard
           title="Active Groups"
-          value="--"
+          value={isLoading ? '--' : stats?.activeGroups.toLocaleString() ?? '--'}
           icon={
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z" />
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
+              />
             </svg>
           }
           color="purple"
         />
 
         <StatCard
-          title="This Week"
-          value="--"
+          title="Today"
+          value={isLoading ? '--' : stats?.todayCheckIns.toLocaleString() ?? '--'}
           subtitle="Check-ins"
           icon={
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
             </svg>
           }
           color="indigo"
+          trend={checkInTrend?.trend}
+          trendValue={checkInTrend?.value}
         />
       </div>
 
       {/* Quick actions */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Quick Actions</h2>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          <ActionButton
-            label="Add Person"
-            description="Create a new person record"
-            icon={
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z" />
-              </svg>
-            }
-          />
+      <QuickActions />
 
-          <ActionButton
-            label="Create Family"
-            description="Add a new family household"
-            icon={
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 4v16m8-8H4" />
-              </svg>
-            }
-          />
-
-          <ActionButton
-            label="Manage Groups"
-            description="View and edit check-in groups"
-            icon={
-              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z" />
-              </svg>
-            }
-          />
-        </div>
-      </div>
-
-      {/* Recent activity placeholder */}
-      <div className="bg-white rounded-lg border border-gray-200 p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Recent Activity</h2>
-        <div className="text-center py-12">
-          <svg className="w-12 h-12 text-gray-400 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-          <p className="text-gray-500">Activity tracking coming soon...</p>
-        </div>
-      </div>
+      {/* Upcoming schedules */}
+      <UpcomingSchedules
+        schedules={stats?.upcomingSchedules ?? []}
+        isLoading={isLoading}
+      />
     </div>
-  );
-}
-
-// Helper components
-interface StatCardProps {
-  title: string;
-  value: string;
-  subtitle?: string;
-  icon: React.ReactNode;
-  color: 'blue' | 'green' | 'purple' | 'indigo';
-}
-
-function StatCard({ title, value, subtitle, icon, color }: StatCardProps) {
-  const colorClasses = {
-    blue: 'bg-blue-50 text-blue-600',
-    green: 'bg-green-50 text-green-600',
-    purple: 'bg-purple-50 text-purple-600',
-    indigo: 'bg-indigo-50 text-indigo-600',
-  };
-
-  return (
-    <div className="bg-white rounded-lg border border-gray-200 p-6">
-      <div className="flex items-center justify-between">
-        <div className="flex-1">
-          <p className="text-sm font-medium text-gray-600">{title}</p>
-          <p className="mt-2 text-3xl font-bold text-gray-900">{value}</p>
-          {subtitle && <p className="mt-1 text-sm text-gray-500">{subtitle}</p>}
-        </div>
-        <div className={`p-3 rounded-lg ${colorClasses[color]}`}>
-          {icon}
-        </div>
-      </div>
-    </div>
-  );
-}
-
-interface ActionButtonProps {
-  label: string;
-  description: string;
-  icon: React.ReactNode;
-  onClick?: () => void;
-}
-
-function ActionButton({ label, description, icon, onClick }: ActionButtonProps) {
-  return (
-    <button
-      onClick={onClick}
-      className="flex items-start gap-4 p-4 text-left rounded-lg border border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-all group"
-    >
-      <div className="p-2 rounded-lg bg-gray-100 text-gray-600 group-hover:bg-primary-100 group-hover:text-primary-600 transition-colors">
-        {icon}
-      </div>
-      <div className="flex-1 min-w-0">
-        <h3 className="text-sm font-semibold text-gray-900">{label}</h3>
-        <p className="mt-1 text-sm text-gray-500">{description}</p>
-      </div>
-    </button>
   );
 }

--- a/src/web/src/services/api/dashboard.ts
+++ b/src/web/src/services/api/dashboard.ts
@@ -1,0 +1,27 @@
+/**
+ * Dashboard API service
+ */
+
+import { get } from './client';
+
+export interface DashboardStats {
+  totalPeople: number;
+  totalFamilies: number;
+  activeGroups: number;
+  todayCheckIns: number;
+  lastWeekCheckIns: number;
+  activeSchedules: number;
+  upcomingSchedules: UpcomingSchedule[];
+}
+
+export interface UpcomingSchedule {
+  idKey: string;
+  name: string;
+  nextOccurrence: string;
+  minutesUntilCheckIn: number;
+}
+
+export async function getDashboardStats(): Promise<DashboardStats> {
+  const response = await get<{ data: DashboardStats }>('/dashboard/stats');
+  return response.data;
+}

--- a/tests/Koinon.Api.Tests/Controllers/DashboardControllerTests.cs
+++ b/tests/Koinon.Api.Tests/Controllers/DashboardControllerTests.cs
@@ -1,0 +1,121 @@
+using FluentAssertions;
+using Koinon.Api.Controllers;
+using Koinon.Application.DTOs;
+using Koinon.Application.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Api.Tests.Controllers;
+
+public class DashboardControllerTests
+{
+    private readonly Mock<IDashboardService> _dashboardServiceMock;
+    private readonly Mock<ILogger<DashboardController>> _loggerMock;
+    private readonly DashboardController _controller;
+
+    public DashboardControllerTests()
+    {
+        _dashboardServiceMock = new Mock<IDashboardService>();
+        _loggerMock = new Mock<ILogger<DashboardController>>();
+        _controller = new DashboardController(_dashboardServiceMock.Object, _loggerMock.Object);
+
+        // Setup HttpContext for controller
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+    }
+
+    [Fact]
+    public async Task GetStats_ReturnsOk_WithDashboardStats()
+    {
+        // Arrange
+        var expectedStats = new DashboardStatsDto
+        {
+            TotalPeople = 150,
+            TotalFamilies = 45,
+            ActiveGroups = 12,
+            TodayCheckIns = 23,
+            LastWeekCheckIns = 18,
+            ActiveSchedules = 5,
+            UpcomingSchedules = new List<UpcomingScheduleDto>
+            {
+                new()
+                {
+                    IdKey = "abc123",
+                    Name = "Sunday Morning Service",
+                    NextOccurrence = DateTime.UtcNow.AddDays(1),
+                    MinutesUntilCheckIn = 60
+                }
+            }
+        };
+
+        _dashboardServiceMock
+            .Setup(s => s.GetStatsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedStats);
+
+        // Act
+        var result = await _controller.GetStats(CancellationToken.None);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var stats = okResult.Value.Should().BeOfType<DashboardStatsDto>().Subject;
+
+        stats.TotalPeople.Should().Be(150);
+        stats.TotalFamilies.Should().Be(45);
+        stats.ActiveGroups.Should().Be(12);
+        stats.TodayCheckIns.Should().Be(23);
+        stats.LastWeekCheckIns.Should().Be(18);
+        stats.ActiveSchedules.Should().Be(5);
+        stats.UpcomingSchedules.Should().HaveCount(1);
+        stats.UpcomingSchedules[0].Name.Should().Be("Sunday Morning Service");
+
+        _dashboardServiceMock.Verify(s => s.GetStatsAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task GetStats_WhenServiceThrows_PropagatesException()
+    {
+        // Arrange
+        _dashboardServiceMock
+            .Setup(s => s.GetStatsAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Database connection failed"));
+
+        // Act & Assert
+        var act = async () => await _controller.GetStats(CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Database connection failed");
+    }
+
+    [Fact]
+    public async Task GetStats_WithCancellationToken_PassesToService()
+    {
+        // Arrange
+        var cts = new CancellationTokenSource();
+        var expectedStats = new DashboardStatsDto
+        {
+            TotalPeople = 0,
+            TotalFamilies = 0,
+            ActiveGroups = 0,
+            TodayCheckIns = 0,
+            LastWeekCheckIns = 0,
+            ActiveSchedules = 0,
+            UpcomingSchedules = new List<UpcomingScheduleDto>()
+        };
+
+        _dashboardServiceMock
+            .Setup(s => s.GetStatsAsync(cts.Token))
+            .ReturnsAsync(expectedStats);
+
+        // Act
+        var result = await _controller.GetStats(cts.Token);
+
+        // Assert
+        result.Should().BeOfType<OkObjectResult>();
+        _dashboardServiceMock.Verify(s => s.GetStatsAsync(cts.Token), Times.Once);
+    }
+}

--- a/tests/Koinon.Application.Tests/Services/DashboardServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/DashboardServiceTests.cs
@@ -1,0 +1,284 @@
+using FluentAssertions;
+using Koinon.Application.Services;
+using Koinon.Domain.Entities;
+using Koinon.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Application.Tests.Services;
+
+/// <summary>
+/// Tests for DashboardService.
+/// </summary>
+public class DashboardServiceTests : IDisposable
+{
+    private readonly KoinonDbContext _context;
+    private readonly Mock<ILogger<DashboardService>> _mockLogger;
+    private readonly DashboardService _service;
+
+    public DashboardServiceTests()
+    {
+        // Setup in-memory database
+        var options = new DbContextOptionsBuilder<KoinonDbContext>()
+            .UseInMemoryDatabase(databaseName: $"KoinonTestDb_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _context = new KoinonDbContext(options);
+
+        // Manually initialize the context
+        _context.Database.EnsureCreated();
+
+        // Setup logger mock
+        _mockLogger = new Mock<ILogger<DashboardService>>();
+
+        // Create service
+        _service = new DashboardService(_context, _mockLogger.Object);
+
+        // Seed test data
+        SeedTestData();
+    }
+
+    private void SeedTestData()
+    {
+        var now = DateTime.UtcNow;
+        var today = DateOnly.FromDateTime(now);
+
+        // Add group types (family and non-family)
+        var familyGroupType = new GroupType
+        {
+            Id = 1,
+            Name = "Family",
+            IsFamilyGroupType = true,
+            AllowMultipleLocations = false,
+            IsSystem = true,
+            CreatedDateTime = now
+        };
+
+        var servingGroupType = new GroupType
+        {
+            Id = 2,
+            Name = "Serving Team",
+            IsFamilyGroupType = false,
+            AllowMultipleLocations = false,
+            IsSystem = false,
+            CreatedDateTime = now
+        };
+
+        _context.GroupTypes.AddRange(familyGroupType, servingGroupType);
+
+        // Add people (some deceased)
+        var people = new List<Person>
+        {
+            new() { Id = 1, FirstName = "John", LastName = "Doe", IsDeceased = false, CreatedDateTime = now },
+            new() { Id = 2, FirstName = "Jane", LastName = "Smith", IsDeceased = false, CreatedDateTime = now },
+            new() { Id = 3, FirstName = "Bob", LastName = "Johnson", IsDeceased = false, CreatedDateTime = now },
+            new() { Id = 4, FirstName = "Deceased", LastName = "Person", IsDeceased = true, CreatedDateTime = now }
+        };
+        _context.People.AddRange(people);
+
+        // Add family groups (should be counted in TotalFamilies)
+        var families = new List<Group>
+        {
+            new() { Id = 1, GroupTypeId = 1, Name = "Doe Family", IsActive = true, IsArchived = false, CreatedDateTime = now },
+            new() { Id = 2, GroupTypeId = 1, Name = "Smith Family", IsActive = true, IsArchived = false, CreatedDateTime = now },
+            new() { Id = 3, GroupTypeId = 1, Name = "Archived Family", IsActive = true, IsArchived = true, ArchivedDateTime = now, CreatedDateTime = now }
+        };
+        _context.Groups.AddRange(families);
+
+        // Add non-family groups (should be counted in ActiveGroups)
+        var groups = new List<Group>
+        {
+            new() { Id = 4, GroupTypeId = 2, Name = "Worship Team", IsActive = true, IsArchived = false, CreatedDateTime = now },
+            new() { Id = 5, GroupTypeId = 2, Name = "Audio Team", IsActive = true, IsArchived = false, CreatedDateTime = now },
+            new() { Id = 6, GroupTypeId = 2, Name = "Inactive Team", IsActive = false, IsArchived = false, CreatedDateTime = now },
+            new() { Id = 7, GroupTypeId = 2, Name = "Archived Team", IsActive = true, IsArchived = true, ArchivedDateTime = now, CreatedDateTime = now }
+        };
+        _context.Groups.AddRange(groups);
+
+        // Add schedules (active and inactive)
+        var schedules = new List<Schedule>
+        {
+            new()
+            {
+                Id = 1,
+                Name = "Sunday Morning",
+                IsActive = true,
+                WeeklyDayOfWeek = DayOfWeek.Sunday,
+                WeeklyTimeOfDay = TimeSpan.FromHours(10),
+                CheckInStartOffsetMinutes = 60,
+                Order = 0,
+                CreatedDateTime = now
+            },
+            new()
+            {
+                Id = 2,
+                Name = "Wednesday Evening",
+                IsActive = true,
+                WeeklyDayOfWeek = DayOfWeek.Wednesday,
+                WeeklyTimeOfDay = TimeSpan.FromHours(19),
+                CheckInStartOffsetMinutes = 30,
+                Order = 1,
+                CreatedDateTime = now
+            },
+            new()
+            {
+                Id = 3,
+                Name = "Inactive Schedule",
+                IsActive = false,
+                WeeklyDayOfWeek = DayOfWeek.Saturday,
+                WeeklyTimeOfDay = TimeSpan.FromHours(18),
+                Order = 2,
+                CreatedDateTime = now
+            }
+        };
+        _context.Schedules.AddRange(schedules);
+
+        // Add attendances (check-ins for today and last week)
+        var todayStart = today.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+        var lastWeek = today.AddDays(-7);
+        var lastWeekStart = lastWeek.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);
+
+        var attendances = new List<Attendance>
+        {
+            // Today's check-ins
+            new() { Id = 1, PersonAliasId = 1, OccurrenceId = 1, StartDateTime = todayStart.AddHours(9), CreatedDateTime = now },
+            new() { Id = 2, PersonAliasId = 2, OccurrenceId = 1, StartDateTime = todayStart.AddHours(10), CreatedDateTime = now },
+            new() { Id = 3, PersonAliasId = 3, OccurrenceId = 1, StartDateTime = todayStart.AddHours(11), CreatedDateTime = now },
+
+            // Last week's check-ins (same day)
+            new() { Id = 4, PersonAliasId = 1, OccurrenceId = 2, StartDateTime = lastWeekStart.AddHours(9), CreatedDateTime = now.AddDays(-7) },
+            new() { Id = 5, PersonAliasId = 2, OccurrenceId = 2, StartDateTime = lastWeekStart.AddHours(10), CreatedDateTime = now.AddDays(-7) },
+
+            // Other days (should not be counted)
+            new() { Id = 6, PersonAliasId = 1, OccurrenceId = 3, StartDateTime = todayStart.AddDays(-2).AddHours(9), CreatedDateTime = now.AddDays(-2) }
+        };
+        _context.Attendances.AddRange(attendances);
+
+        _context.SaveChanges();
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_ReturnsCorrectPeopleCounts()
+    {
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.TotalPeople.Should().Be(3); // Excludes deceased person
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_ReturnsCorrectFamilyCounts()
+    {
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.TotalFamilies.Should().Be(2); // Excludes archived family
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_ReturnsCorrectGroupCounts()
+    {
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.ActiveGroups.Should().Be(2); // Only active, non-archived, non-family groups
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_ReturnsCorrectScheduleCounts()
+    {
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.ActiveSchedules.Should().Be(2); // Only active schedules
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_ReturnsCorrectCheckInCounts()
+    {
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.TodayCheckIns.Should().Be(3); // Check-ins for today
+        stats.LastWeekCheckIns.Should().Be(2); // Check-ins for same day last week
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_ReturnsUpcomingSchedules_SortedByNextOccurrence()
+    {
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.UpcomingSchedules.Should().NotBeNull();
+        stats.UpcomingSchedules.Should().HaveCountLessOrEqualTo(5); // Maximum 5 schedules
+        stats.UpcomingSchedules.Should().HaveCount(2); // We have 2 active schedules with weekly times
+
+        // Verify schedules are sorted by next occurrence
+        for (int i = 0; i < stats.UpcomingSchedules.Count - 1; i++)
+        {
+            stats.UpcomingSchedules[i].NextOccurrence.Should().BeOnOrBefore(stats.UpcomingSchedules[i + 1].NextOccurrence);
+        }
+
+        // Verify all schedules have valid data
+        foreach (var schedule in stats.UpcomingSchedules)
+        {
+            schedule.IdKey.Should().NotBeNullOrEmpty();
+            schedule.Name.Should().NotBeNullOrEmpty();
+            schedule.NextOccurrence.Should().BeAfter(DateTime.UtcNow.AddMinutes(-1)); // Should be in the future or very close to now
+        }
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_WithNoData_ReturnsZeroCounts()
+    {
+        // Arrange - Clear all data
+        _context.People.RemoveRange(_context.People);
+        _context.Groups.RemoveRange(_context.Groups);
+        _context.Schedules.RemoveRange(_context.Schedules);
+        _context.Attendances.RemoveRange(_context.Attendances);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.TotalPeople.Should().Be(0);
+        stats.TotalFamilies.Should().Be(0);
+        stats.ActiveGroups.Should().Be(0);
+        stats.ActiveSchedules.Should().Be(0);
+        stats.TodayCheckIns.Should().Be(0);
+        stats.LastWeekCheckIns.Should().Be(0);
+        stats.UpcomingSchedules.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_UpcomingSchedules_CalculatesMinutesUntilCheckIn()
+    {
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.UpcomingSchedules.Should().NotBeEmpty();
+
+        foreach (var schedule in stats.UpcomingSchedules)
+        {
+            // MinutesUntilCheckIn should be calculated based on NextOccurrence minus CheckInStartOffsetMinutes
+            schedule.MinutesUntilCheckIn.Should().NotBe(0); // Should have a calculated value
+        }
+    }
+
+    public void Dispose()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
- Implements the admin dashboard overview page with real-time statistics and quick actions
- Adds Dashboard API endpoint for aggregated stats with parallel query execution
- Creates reusable dashboard UI components with TanStack Query hooks

## Changes
### Backend
- `GET /api/v1/dashboard/stats` - Dashboard statistics endpoint
- `DashboardService` - Service layer with parallel DB queries
- `DashboardStatsDto` - Response DTO with metrics

### Frontend
- `StatCard` - Reusable stat card with trend indicators
- `QuickActions` - Navigation shortcuts to common tasks
- `UpcomingSchedules` - Widget showing next 5 scheduled events
- `useDashboardStats` - TanStack Query hook with 60s auto-refresh

## Test plan
- [x] DashboardControllerTests (3 tests - success, error handling, cancellation)
- [x] DashboardServiceTests (8 tests - counts, date ranges, edge cases)
- [x] Backend build passes
- [x] Frontend build passes
- [x] All 546 tests pass

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)