### PR TITLE
feat: Add attendance analytics dashboard with trends and charts (#94)

### DIFF
--- a/src/Koinon.Api/Controllers/AnalyticsController.cs
+++ b/src/Koinon.Api/Controllers/AnalyticsController.cs
@@ -1,0 +1,140 @@
+using Koinon.Api.Filters;
+using Koinon.Application.DTOs;
+using Koinon.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Koinon.Api.Controllers;
+
+/// <summary>
+/// Controller for attendance analytics and reporting.
+/// Provides endpoints for summary statistics, trends, and group-based breakdowns.
+/// </summary>
+[ApiController]
+[Route("api/v1/analytics")]
+[Authorize]
+[ValidateIdKey]
+public class AnalyticsController(
+    IAttendanceAnalyticsService analyticsService,
+    ILogger<AnalyticsController> logger) : ControllerBase
+{
+    /// <summary>
+    /// Gets summary analytics for attendance over a date range.
+    /// </summary>
+    /// <param name="startDate">Start date for the analysis period (ISO 8601 format)</param>
+    /// <param name="endDate">End date for the analysis period (ISO 8601 format)</param>
+    /// <param name="campusIdKey">Optional campus IdKey to filter results</param>
+    /// <param name="groupTypeIdKey">Optional group type IdKey to filter results</param>
+    /// <param name="groupIdKey">Optional group IdKey to filter results</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Summary analytics including total attendance, unique attendees, and averages</returns>
+    /// <response code="200">Returns attendance summary statistics</response>
+    /// <response code="400">Invalid IdKey format</response>
+    [HttpGet("attendance")]
+    [ProducesResponseType(typeof(AttendanceAnalyticsDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetAttendanceSummary(
+        [FromQuery] DateOnly? startDate,
+        [FromQuery] DateOnly? endDate,
+        [FromQuery] string? campusIdKey,
+        [FromQuery] string? groupTypeIdKey,
+        [FromQuery] string? groupIdKey,
+        CancellationToken ct = default)
+    {
+        var options = new AttendanceQueryOptions(
+            StartDate: startDate,
+            EndDate: endDate,
+            CampusIdKey: campusIdKey,
+            GroupTypeIdKey: groupTypeIdKey,
+            GroupIdKey: groupIdKey
+        );
+
+        var analytics = await analyticsService.GetSummaryAsync(options, ct);
+
+        logger.LogInformation(
+            "Attendance summary retrieved: StartDate={StartDate}, EndDate={EndDate}, TotalAttendance={TotalAttendance}, UniqueAttendees={UniqueAttendees}",
+            analytics.StartDate, analytics.EndDate, analytics.TotalAttendance, analytics.UniqueAttendees);
+
+        return Ok(analytics);
+    }
+
+    /// <summary>
+    /// Gets attendance trends over time with flexible grouping.
+    /// </summary>
+    /// <param name="startDate">Start date for the analysis period (ISO 8601 format)</param>
+    /// <param name="endDate">End date for the analysis period (ISO 8601 format)</param>
+    /// <param name="campusIdKey">Optional campus IdKey to filter results</param>
+    /// <param name="groupTypeIdKey">Optional group type IdKey to filter results</param>
+    /// <param name="groupIdKey">Optional group IdKey to filter results</param>
+    /// <param name="groupBy">Time grouping: Day, Week, Month, or Year (default: Day)</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of time-series data points with attendance counts</returns>
+    /// <response code="200">Returns attendance trend data</response>
+    /// <response code="400">Invalid IdKey format or groupBy value</response>
+    [HttpGet("attendance/trends")]
+    [ProducesResponseType(typeof(IReadOnlyList<AttendanceTrendDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetAttendanceTrends(
+        [FromQuery] DateOnly? startDate,
+        [FromQuery] DateOnly? endDate,
+        [FromQuery] string? campusIdKey,
+        [FromQuery] string? groupTypeIdKey,
+        [FromQuery] string? groupIdKey,
+        [FromQuery] GroupBy groupBy = GroupBy.Day,
+        CancellationToken ct = default)
+    {
+        var options = new AttendanceQueryOptions(
+            StartDate: startDate,
+            EndDate: endDate,
+            CampusIdKey: campusIdKey,
+            GroupTypeIdKey: groupTypeIdKey,
+            GroupIdKey: groupIdKey,
+            GroupBy: groupBy
+        );
+
+        var trends = await analyticsService.GetTrendsAsync(options, ct);
+
+        logger.LogInformation(
+            "Attendance trends retrieved: StartDate={StartDate}, EndDate={EndDate}, GroupBy={GroupBy}, DataPoints={DataPoints}",
+            startDate, endDate, groupBy, trends.Count);
+
+        return Ok(trends);
+    }
+
+    /// <summary>
+    /// Gets attendance statistics broken down by group.
+    /// </summary>
+    /// <param name="startDate">Start date for the analysis period (ISO 8601 format)</param>
+    /// <param name="endDate">End date for the analysis period (ISO 8601 format)</param>
+    /// <param name="campusIdKey">Optional campus IdKey to filter results</param>
+    /// <param name="groupTypeIdKey">Optional group type IdKey to filter results</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of attendance metrics per group</returns>
+    /// <response code="200">Returns attendance data by group</response>
+    /// <response code="400">Invalid IdKey format</response>
+    [HttpGet("attendance/by-group")]
+    [ProducesResponseType(typeof(IReadOnlyList<AttendanceByGroupDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    public async Task<IActionResult> GetAttendanceByGroup(
+        [FromQuery] DateOnly? startDate,
+        [FromQuery] DateOnly? endDate,
+        [FromQuery] string? campusIdKey,
+        [FromQuery] string? groupTypeIdKey,
+        CancellationToken ct = default)
+    {
+        var options = new AttendanceQueryOptions(
+            StartDate: startDate,
+            EndDate: endDate,
+            CampusIdKey: campusIdKey,
+            GroupTypeIdKey: groupTypeIdKey
+        );
+
+        var byGroup = await analyticsService.GetByGroupAsync(options, ct);
+
+        logger.LogInformation(
+            "Attendance by group retrieved: StartDate={StartDate}, EndDate={EndDate}, GroupCount={GroupCount}",
+            startDate, endDate, byGroup.Count);
+
+        return Ok(byGroup);
+    }
+}

--- a/src/Koinon.Application/DTOs/AttendanceAnalyticsDto.cs
+++ b/src/Koinon.Application/DTOs/AttendanceAnalyticsDto.cs
@@ -1,0 +1,15 @@
+namespace Koinon.Application.DTOs;
+
+/// <summary>
+/// Summary analytics for attendance over a date range.
+/// Provides key metrics for attendance reporting and dashboard displays.
+/// </summary>
+public record AttendanceAnalyticsDto(
+    int TotalAttendance,
+    int UniqueAttendees,
+    int FirstTimeVisitors,
+    int ReturningVisitors,
+    decimal AverageAttendance,
+    DateOnly StartDate,
+    DateOnly EndDate
+);

--- a/src/Koinon.Application/DTOs/AttendanceByGroupDto.cs
+++ b/src/Koinon.Application/DTOs/AttendanceByGroupDto.cs
@@ -1,0 +1,13 @@
+namespace Koinon.Application.DTOs;
+
+/// <summary>
+/// Attendance metrics grouped by a specific group.
+/// Provides breakdown of attendance counts by group for reporting.
+/// </summary>
+public record AttendanceByGroupDto(
+    string GroupIdKey,
+    string GroupName,
+    string GroupTypeName,
+    int TotalAttendance,
+    int UniqueAttendees
+);

--- a/src/Koinon.Application/DTOs/AttendanceQueryOptions.cs
+++ b/src/Koinon.Application/DTOs/AttendanceQueryOptions.cs
@@ -1,0 +1,24 @@
+namespace Koinon.Application.DTOs;
+
+/// <summary>
+/// Query parameters for filtering and grouping attendance data.
+/// </summary>
+public record AttendanceQueryOptions(
+    DateOnly? StartDate = null,
+    DateOnly? EndDate = null,
+    string? CampusIdKey = null,
+    string? GroupTypeIdKey = null,
+    string? GroupIdKey = null,
+    GroupBy GroupBy = GroupBy.Day
+);
+
+/// <summary>
+/// Enumeration for time-based grouping of attendance data.
+/// </summary>
+public enum GroupBy
+{
+    Day,
+    Week,
+    Month,
+    Year
+}

--- a/src/Koinon.Application/DTOs/AttendanceTrendDto.cs
+++ b/src/Koinon.Application/DTOs/AttendanceTrendDto.cs
@@ -1,0 +1,12 @@
+namespace Koinon.Application.DTOs;
+
+/// <summary>
+/// Time-series data point for attendance trends.
+/// Represents attendance counts for a specific date or time period.
+/// </summary>
+public record AttendanceTrendDto(
+    DateOnly Date,
+    int Count,
+    int FirstTime,
+    int Returning
+);

--- a/src/Koinon.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Koinon.Application/Extensions/ServiceCollectionExtensions.cs
@@ -57,6 +57,9 @@ public static class ServiceCollectionExtensions
         // Supervisor mode service
         services.AddScoped<ISupervisorModeService, SupervisorModeService>();
 
+        // Analytics services
+        services.AddScoped<IAttendanceAnalyticsService, AttendanceAnalyticsService>();
+
         // AutoMapper - register all mapping profiles
         services.AddAutoMapper(typeof(ServiceCollectionExtensions).Assembly);
 

--- a/src/Koinon.Application/Interfaces/IAttendanceAnalyticsService.cs
+++ b/src/Koinon.Application/Interfaces/IAttendanceAnalyticsService.cs
@@ -1,0 +1,40 @@
+using Koinon.Application.DTOs;
+
+namespace Koinon.Application.Interfaces;
+
+/// <summary>
+/// Service for generating attendance analytics and reports.
+/// Provides summary statistics, trends, and group-based breakdowns.
+/// </summary>
+public interface IAttendanceAnalyticsService
+{
+    /// <summary>
+    /// Gets summary analytics for attendance over a date range.
+    /// </summary>
+    /// <param name="options">Query parameters for filtering attendance data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Summary analytics including total attendance, unique attendees, and averages.</returns>
+    Task<AttendanceAnalyticsDto> GetSummaryAsync(
+        AttendanceQueryOptions options,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets attendance trends over time (grouped by day, week, month, or year).
+    /// </summary>
+    /// <param name="options">Query parameters for filtering and grouping attendance data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of time-series data points with attendance counts.</returns>
+    Task<IReadOnlyList<AttendanceTrendDto>> GetTrendsAsync(
+        AttendanceQueryOptions options,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets attendance statistics broken down by group.
+    /// </summary>
+    /// <param name="options">Query parameters for filtering attendance data.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>List of attendance metrics per group.</returns>
+    Task<IReadOnlyList<AttendanceByGroupDto>> GetByGroupAsync(
+        AttendanceQueryOptions options,
+        CancellationToken cancellationToken = default);
+}

--- a/src/Koinon.Application/Services/AttendanceAnalyticsService.cs
+++ b/src/Koinon.Application/Services/AttendanceAnalyticsService.cs
@@ -1,0 +1,257 @@
+using Koinon.Application.DTOs;
+using Koinon.Application.Interfaces;
+using Koinon.Domain.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Koinon.Application.Services;
+
+/// <summary>
+/// Service for generating attendance analytics and reports.
+/// Provides summary statistics, trends, and group-based breakdowns with efficient database queries.
+/// </summary>
+public class AttendanceAnalyticsService(
+    IApplicationDbContext context,
+    ILogger<AttendanceAnalyticsService> logger) : IAttendanceAnalyticsService
+{
+    public async Task<AttendanceAnalyticsDto> GetSummaryAsync(
+        AttendanceQueryOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Retrieving attendance summary analytics");
+
+        var (startDate, endDate) = GetDateRange(options);
+        var query = BuildBaseQuery(options, startDate, endDate);
+
+        // Execute single aggregated query to avoid N+1 pattern
+        var stats = await query
+            .GroupBy(a => 1)
+            .Select(g => new
+            {
+                TotalAttendance = g.Count(),
+                UniqueAttendees = g.Where(a => a.PersonAliasId.HasValue)
+                    .Select(a => a.PersonAliasId)
+                    .Distinct()
+                    .Count(),
+                FirstTimeVisitors = g.Count(a => a.IsFirstTime),
+                TotalOccurrences = g.Select(a => a.OccurrenceId).Distinct().Count()
+            })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        // Handle case where no data exists
+        if (stats == null)
+        {
+            return new AttendanceAnalyticsDto(0, 0, 0, 0, 0m, startDate, endDate);
+        }
+
+        var totalAttendance = stats.TotalAttendance;
+        var uniqueAttendees = stats.UniqueAttendees;
+        var firstTimeVisitors = stats.FirstTimeVisitors;
+        var returningVisitors = totalAttendance - firstTimeVisitors;
+        var totalOccurrences = stats.TotalOccurrences;
+
+        var averageAttendance = totalOccurrences > 0
+            ? (decimal)totalAttendance / totalOccurrences
+            : 0m;
+
+        logger.LogInformation(
+            "Attendance summary: Total={TotalAttendance}, Unique={UniqueAttendees}, " +
+            "FirstTime={FirstTimeVisitors}, Returning={ReturningVisitors}, Average={AverageAttendance:F2}",
+            totalAttendance, uniqueAttendees, firstTimeVisitors, returningVisitors, averageAttendance);
+
+        return new AttendanceAnalyticsDto(
+            totalAttendance,
+            uniqueAttendees,
+            firstTimeVisitors,
+            returningVisitors,
+            averageAttendance,
+            startDate,
+            endDate);
+    }
+
+    public async Task<IReadOnlyList<AttendanceTrendDto>> GetTrendsAsync(
+        AttendanceQueryOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Retrieving attendance trends with GroupBy={GroupBy}", options.GroupBy);
+
+        var (startDate, endDate) = GetDateRange(options);
+        var query = BuildBaseQuery(options, startDate, endDate);
+
+        // Group by the specified time period in the database
+        // Use anonymous type for EF Core translation, then convert to DTO
+        var groupedData = options.GroupBy switch
+        {
+            GroupBy.Day => await query
+                .GroupBy(a => a.Occurrence!.OccurrenceDate)
+                .Select(g => new
+                {
+                    Date = g.Key,
+                    TotalAttendance = g.Count(),
+                    FirstTimeCount = g.Count(a => a.IsFirstTime),
+                    ReturningCount = g.Count(a => !a.IsFirstTime)
+                })
+                .OrderBy(x => x.Date)
+                .ToListAsync(cancellationToken),
+
+            GroupBy.Week => await query
+                .GroupBy(a => a.Occurrence!.OccurrenceDate.AddDays(-(int)a.Occurrence.OccurrenceDate.DayOfWeek))
+                .Select(g => new
+                {
+                    Date = g.Key,
+                    TotalAttendance = g.Count(),
+                    FirstTimeCount = g.Count(a => a.IsFirstTime),
+                    ReturningCount = g.Count(a => !a.IsFirstTime)
+                })
+                .OrderBy(x => x.Date)
+                .ToListAsync(cancellationToken),
+
+            GroupBy.Month => await query
+                .GroupBy(a => new DateOnly(a.Occurrence!.OccurrenceDate.Year, a.Occurrence.OccurrenceDate.Month, 1))
+                .Select(g => new
+                {
+                    Date = g.Key,
+                    TotalAttendance = g.Count(),
+                    FirstTimeCount = g.Count(a => a.IsFirstTime),
+                    ReturningCount = g.Count(a => !a.IsFirstTime)
+                })
+                .OrderBy(x => x.Date)
+                .ToListAsync(cancellationToken),
+
+            GroupBy.Year => await query
+                .GroupBy(a => new DateOnly(a.Occurrence!.OccurrenceDate.Year, 1, 1))
+                .Select(g => new
+                {
+                    Date = g.Key,
+                    TotalAttendance = g.Count(),
+                    FirstTimeCount = g.Count(a => a.IsFirstTime),
+                    ReturningCount = g.Count(a => !a.IsFirstTime)
+                })
+                .OrderBy(x => x.Date)
+                .ToListAsync(cancellationToken),
+
+            _ => await query
+                .GroupBy(a => a.Occurrence!.OccurrenceDate)
+                .Select(g => new
+                {
+                    Date = g.Key,
+                    TotalAttendance = g.Count(),
+                    FirstTimeCount = g.Count(a => a.IsFirstTime),
+                    ReturningCount = g.Count(a => !a.IsFirstTime)
+                })
+                .OrderBy(x => x.Date)
+                .ToListAsync(cancellationToken)
+        };
+
+        // Convert to DTOs in memory
+        var trends = groupedData
+            .Select(g => new AttendanceTrendDto(
+                g.Date,
+                g.TotalAttendance,
+                g.FirstTimeCount,
+                g.ReturningCount))
+            .ToList();
+
+        logger.LogInformation("Retrieved {TrendCount} trend data points", trends.Count);
+
+        return trends;
+    }
+
+    public async Task<IReadOnlyList<AttendanceByGroupDto>> GetByGroupAsync(
+        AttendanceQueryOptions options,
+        CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Retrieving attendance by group");
+
+        var (startDate, endDate) = GetDateRange(options);
+        var query = BuildBaseQuery(options, startDate, endDate);
+
+        // Group by occurrence group and calculate statistics
+        var groupedData = await query
+            .Where(a => a.Occurrence!.GroupId.HasValue)
+            .GroupBy(a => new
+            {
+                GroupId = a.Occurrence!.GroupId!.Value,
+                GroupName = a.Occurrence!.Group!.Name,
+                GroupTypeName = a.Occurrence!.Group!.GroupType!.Name
+            })
+            .Select(g => new
+            {
+                g.Key.GroupId,
+                g.Key.GroupName,
+                g.Key.GroupTypeName,
+                TotalAttendance = g.Count(),
+                // Count distinct PersonAliasId values efficiently
+                UniqueAttendees = g.Select(a => a.PersonAliasId).Where(id => id != null).Distinct().Count()
+            })
+            .OrderByDescending(g => g.TotalAttendance)
+            .ToListAsync(cancellationToken);
+
+        // Convert to DTOs with IdKey encoding
+        var results = groupedData
+            .Select(g => new AttendanceByGroupDto(
+                IdKeyHelper.Encode(g.GroupId),
+                g.GroupName,
+                g.GroupTypeName,
+                g.TotalAttendance,
+                g.UniqueAttendees))
+            .ToList();
+
+        logger.LogInformation("Retrieved attendance for {GroupCount} groups", results.Count);
+
+        return results;
+    }
+
+    /// <summary>
+    /// Builds the base query with common filters applied.
+    /// </summary>
+    private IQueryable<Domain.Entities.Attendance> BuildBaseQuery(
+        AttendanceQueryOptions options,
+        DateOnly startDate,
+        DateOnly endDate)
+    {
+        var query = context.Attendances.AsNoTracking();
+
+        // Filter by date range using Occurrence.OccurrenceDate
+        query = query
+            .Include(a => a.Occurrence)
+                .ThenInclude(o => o!.Group)
+                    .ThenInclude(g => g!.GroupType)
+            .Where(a => a.Occurrence!.OccurrenceDate >= startDate && a.Occurrence.OccurrenceDate <= endDate);
+
+        // Filter by campus if specified
+        if (!string.IsNullOrWhiteSpace(options.CampusIdKey))
+        {
+            var campusId = IdKeyHelper.Decode(options.CampusIdKey);
+            query = query.Where(a => a.CampusId == campusId);
+        }
+
+        // Filter by group type if specified
+        if (!string.IsNullOrWhiteSpace(options.GroupTypeIdKey))
+        {
+            var groupTypeId = IdKeyHelper.Decode(options.GroupTypeIdKey);
+            query = query.Where(a => a.Occurrence!.Group!.GroupTypeId == groupTypeId);
+        }
+
+        // Filter by specific group if specified
+        if (!string.IsNullOrWhiteSpace(options.GroupIdKey))
+        {
+            var groupId = IdKeyHelper.Decode(options.GroupIdKey);
+            query = query.Where(a => a.Occurrence!.GroupId == groupId);
+        }
+
+        return query;
+    }
+
+    /// <summary>
+    /// Gets the date range for the query, using defaults if not specified.
+    /// </summary>
+    private static (DateOnly StartDate, DateOnly EndDate) GetDateRange(AttendanceQueryOptions options)
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var startDate = options.StartDate ?? today.AddDays(-30);
+        var endDate = options.EndDate ?? today;
+
+        return (startDate, endDate);
+    }
+}

--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.20.0",
+        "recharts": "^2.10.0",
         "tailwind-merge": "^2.1.0",
         "zod": "^4.1.13"
       },
@@ -1619,7 +1620,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3603,6 +3603,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -4752,8 +4815,128 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4826,6 +5009,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -4947,6 +5136,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5413,6 +5612,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "license": "MIT"
+    },
     "node_modules/expect-type": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.2.2.tgz",
@@ -5439,6 +5644,15 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-equals": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-5.3.3.tgz",
+      "integrity": "sha512-/boTcHZeIAQ2r/tL11voclBHDeP9WPxLt+tyAbVSyyXuUFyh0Tne7gJZTqGbxnvj79TjLdCXLOY7UIPhyG5MTw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -6163,6 +6377,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -6912,7 +7135,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -7163,7 +7385,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7679,6 +7900,23 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -7804,6 +8042,37 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/react-smooth": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
+      "integrity": "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-equals": "^5.0.1",
+        "prop-types": "^15.8.1",
+        "react-transition-group": "^4.4.5"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -7826,6 +8095,44 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-2.15.4.tgz",
+      "integrity": "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.0.0",
+        "eventemitter3": "^4.0.1",
+        "lodash": "^4.17.21",
+        "react-is": "^18.3.1",
+        "react-smooth": "^4.0.4",
+        "recharts-scale": "^0.4.4",
+        "tiny-invariant": "^1.3.1",
+        "victory-vendor": "^36.6.8"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/recharts-scale": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/recharts-scale/-/recharts-scale-0.4.5.tgz",
+      "integrity": "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==",
+      "license": "MIT",
+      "dependencies": {
+        "decimal.js-light": "^2.4.1"
+      }
+    },
+    "node_modules/recharts/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "license": "MIT"
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -8942,6 +9249,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -9347,6 +9660,28 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/victory-vendor": {
+      "version": "36.9.2",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-36.9.2.tgz",
+      "integrity": "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -25,6 +25,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.20.0",
+    "recharts": "^2.10.0",
     "tailwind-merge": "^2.1.0",
     "zod": "^4.1.13"
   },

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -10,6 +10,7 @@ import {
   DashboardPage,
   GroupsPage,
   SettingsPage,
+  AnalyticsPage,
 } from './pages/admin';
 import {
   GroupsTreePage,
@@ -195,6 +196,7 @@ function App() {
           <Route path="schedules/new" element={<ScheduleFormPage />} />
           <Route path="schedules/:idKey" element={<ScheduleDetailPage />} />
           <Route path="schedules/:idKey/edit" element={<ScheduleFormPage />} />
+          <Route path="analytics" element={<AnalyticsPage />} />
           <Route path="settings" element={<SettingsPage />} />
         </Route>
 

--- a/src/web/src/components/admin/Sidebar.tsx
+++ b/src/web/src/components/admin/Sidebar.tsx
@@ -24,6 +24,15 @@ const navSections = [
           </svg>
         ),
       },
+      {
+        path: '/admin/analytics',
+        label: 'Analytics',
+        icon: (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+          </svg>
+        ),
+      },
     ],
   },
   {

--- a/src/web/src/components/admin/analytics/AnalyticsSummaryCards.tsx
+++ b/src/web/src/components/admin/analytics/AnalyticsSummaryCards.tsx
@@ -1,0 +1,167 @@
+/**
+ * Analytics Summary Cards Component
+ * Displays key attendance metrics in card format
+ */
+
+import type { AttendanceAnalytics } from '@/services/api/analytics';
+
+export interface AnalyticsSummaryCardsProps {
+  analytics: AttendanceAnalytics | undefined;
+  isLoading: boolean;
+}
+
+export function AnalyticsSummaryCards({ analytics, isLoading }: AnalyticsSummaryCardsProps) {
+  const formatNumber = (value: number | undefined): string => {
+    if (isLoading || value === undefined) return '--';
+    return value.toLocaleString();
+  };
+
+  const formatDecimal = (value: number | undefined): string => {
+    if (isLoading || value === undefined) return '--';
+    return value.toFixed(1);
+  };
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-5 gap-4">
+      {/* Total Attendance */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <div className="flex items-center justify-between">
+          <div className="flex-1">
+            <p className="text-sm font-medium text-gray-600">Total Attendance</p>
+            <p className="mt-2 text-3xl font-bold text-gray-900">
+              {formatNumber(analytics?.totalAttendance)}
+            </p>
+          </div>
+          <div className="p-3 rounded-lg bg-blue-50 text-blue-600">
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+
+      {/* Unique Attendees */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <div className="flex items-center justify-between">
+          <div className="flex-1">
+            <p className="text-sm font-medium text-gray-600">Unique Attendees</p>
+            <p className="mt-2 text-3xl font-bold text-gray-900">
+              {formatNumber(analytics?.uniqueAttendees)}
+            </p>
+          </div>
+          <div className="p-3 rounded-lg bg-green-50 text-green-600">
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+
+      {/* First-Time Visitors */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <div className="flex items-center justify-between">
+          <div className="flex-1">
+            <p className="text-sm font-medium text-gray-600">First-Time Visitors</p>
+            <p className="mt-2 text-3xl font-bold text-gray-900">
+              {formatNumber(analytics?.firstTimeVisitors)}
+            </p>
+          </div>
+          <div className="p-3 rounded-lg bg-purple-50 text-purple-600">
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+
+      {/* Returning Visitors */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <div className="flex items-center justify-between">
+          <div className="flex-1">
+            <p className="text-sm font-medium text-gray-600">Returning Visitors</p>
+            <p className="mt-2 text-3xl font-bold text-gray-900">
+              {formatNumber(analytics?.returningVisitors)}
+            </p>
+          </div>
+          <div className="p-3 rounded-lg bg-indigo-50 text-indigo-600">
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+
+      {/* Average Attendance */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <div className="flex items-center justify-between">
+          <div className="flex-1">
+            <p className="text-sm font-medium text-gray-600">Average Attendance</p>
+            <p className="mt-2 text-3xl font-bold text-gray-900">
+              {formatDecimal(analytics?.averageAttendance)}
+            </p>
+          </div>
+          <div className="p-3 rounded-lg bg-amber-50 text-amber-600">
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/admin/analytics/AttendanceByGroupTable.tsx
+++ b/src/web/src/components/admin/analytics/AttendanceByGroupTable.tsx
@@ -1,0 +1,240 @@
+/**
+ * Attendance By Group Table Component
+ * Displays attendance breakdown by group with sortable columns
+ */
+
+import { useState } from 'react';
+import type { AttendanceByGroup } from '@/services/api/analytics';
+
+export interface AttendanceByGroupTableProps {
+  groups: AttendanceByGroup[] | undefined;
+  isLoading: boolean;
+}
+
+type SortField = 'groupName' | 'groupTypeName' | 'totalAttendance' | 'uniqueAttendees';
+type SortDirection = 'asc' | 'desc';
+
+export function AttendanceByGroupTable({ groups, isLoading }: AttendanceByGroupTableProps) {
+  const [sortField, setSortField] = useState<SortField>('totalAttendance');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortDirection('desc');
+    }
+  };
+
+  const sortedGroups = groups
+    ? [...groups].sort((a, b) => {
+        let aValue: string | number;
+        let bValue: string | number;
+
+        switch (sortField) {
+          case 'groupName':
+            aValue = a.groupName;
+            bValue = b.groupName;
+            break;
+          case 'groupTypeName':
+            aValue = a.groupTypeName;
+            bValue = b.groupTypeName;
+            break;
+          case 'totalAttendance':
+            aValue = a.totalAttendance;
+            bValue = b.totalAttendance;
+            break;
+          case 'uniqueAttendees':
+            aValue = a.uniqueAttendees;
+            bValue = b.uniqueAttendees;
+            break;
+          default:
+            return 0;
+        }
+
+        if (typeof aValue === 'string' && typeof bValue === 'string') {
+          const comparison = aValue.localeCompare(bValue);
+          return sortDirection === 'asc' ? comparison : -comparison;
+        }
+
+        if (typeof aValue === 'number' && typeof bValue === 'number') {
+          return sortDirection === 'asc' ? aValue - bValue : bValue - aValue;
+        }
+
+        return 0;
+      })
+    : [];
+
+  const SortIcon = ({ field }: { field: SortField }) => {
+    if (sortField !== field) {
+      return (
+        <svg
+          className="w-4 h-4 text-gray-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"
+          />
+        </svg>
+      );
+    }
+
+    return sortDirection === 'asc' ? (
+      <svg
+        className="w-4 h-4 text-blue-600"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M5 15l7-7 7 7"
+        />
+      </svg>
+    ) : (
+      <svg
+        className="w-4 h-4 text-blue-600"
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M19 9l-7 7-7-7"
+        />
+      </svg>
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          Attendance by Group
+        </h3>
+        <div className="flex items-center justify-center py-12">
+          <div className="text-center">
+            <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            <p className="mt-2 text-sm text-gray-500">Loading group data...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!groups || groups.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">
+          Attendance by Group
+        </h3>
+        <div className="flex items-center justify-center py-12">
+          <div className="text-center text-gray-500">
+            <svg
+              className="w-16 h-16 mx-auto mb-4 text-gray-300"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+              />
+            </svg>
+            <p>No group attendance data for selected date range</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h3 className="text-lg font-semibold text-gray-900 mb-4">
+        Attendance by Group
+      </h3>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th
+                scope="col"
+                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 transition-colors"
+                onClick={() => handleSort('groupName')}
+              >
+                <div className="flex items-center gap-2">
+                  <span>Group Name</span>
+                  <SortIcon field="groupName" />
+                </div>
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 transition-colors"
+                onClick={() => handleSort('groupTypeName')}
+              >
+                <div className="flex items-center gap-2">
+                  <span>Type</span>
+                  <SortIcon field="groupTypeName" />
+                </div>
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 transition-colors"
+                onClick={() => handleSort('totalAttendance')}
+              >
+                <div className="flex items-center justify-end gap-2">
+                  <span>Total Attendance</span>
+                  <SortIcon field="totalAttendance" />
+                </div>
+              </th>
+              <th
+                scope="col"
+                className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100 transition-colors"
+                onClick={() => handleSort('uniqueAttendees')}
+              >
+                <div className="flex items-center justify-end gap-2">
+                  <span>Unique Attendees</span>
+                  <SortIcon field="uniqueAttendees" />
+                </div>
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {sortedGroups.map((group) => (
+              <tr key={group.groupIdKey} className="hover:bg-gray-50 transition-colors">
+                <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                  {group.groupName}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {group.groupTypeName}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right font-medium">
+                  {group.totalAttendance.toLocaleString()}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 text-right">
+                  {group.uniqueAttendees.toLocaleString()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/admin/analytics/AttendanceTrendChart.tsx
+++ b/src/web/src/components/admin/analytics/AttendanceTrendChart.tsx
@@ -1,0 +1,137 @@
+/**
+ * Attendance Trend Chart Component
+ * Displays attendance trends over time using Recharts
+ */
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from 'recharts';
+import type { AttendanceTrend } from '@/services/api/analytics';
+
+export interface AttendanceTrendChartProps {
+  trends: AttendanceTrend[] | undefined;
+  isLoading: boolean;
+}
+
+export function AttendanceTrendChart({ trends, isLoading }: AttendanceTrendChartProps) {
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Attendance Trends</h3>
+        <div className="flex items-center justify-center h-80">
+          <div className="text-center">
+            <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div>
+            <p className="mt-2 text-sm text-gray-500">Loading chart data...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!trends || trends.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Attendance Trends</h3>
+        <div className="flex items-center justify-center h-80">
+          <div className="text-center text-gray-500">
+            <svg
+              className="w-16 h-16 mx-auto mb-4 text-gray-300"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+              />
+            </svg>
+            <p>No attendance data for selected date range</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Format date for display (e.g., "2024-01-15" -> "Jan 15")
+  const formatDate = (dateString: string): string => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  };
+
+  // Transform data for chart
+  const chartData = trends.map((trend) => ({
+    date: formatDate(trend.date),
+    Total: trend.count,
+    'First-Time': trend.firstTime,
+    Returning: trend.returning,
+  }));
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h3 className="text-lg font-semibold text-gray-900 mb-4">Attendance Trends</h3>
+      <ResponsiveContainer width="100%" height={400}>
+        <LineChart
+          data={chartData}
+          margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
+          <XAxis
+            dataKey="date"
+            stroke="#6b7280"
+            style={{ fontSize: '0.875rem' }}
+          />
+          <YAxis
+            stroke="#6b7280"
+            style={{ fontSize: '0.875rem' }}
+          />
+          <Tooltip
+            contentStyle={{
+              backgroundColor: '#fff',
+              border: '1px solid #e5e7eb',
+              borderRadius: '0.5rem',
+              boxShadow: '0 1px 3px 0 rgb(0 0 0 / 0.1)',
+            }}
+          />
+          <Legend
+            wrapperStyle={{ paddingTop: '1rem' }}
+            iconType="line"
+          />
+          <Line
+            type="monotone"
+            dataKey="Total"
+            stroke="#2563eb"
+            strokeWidth={2}
+            dot={{ fill: '#2563eb', r: 4 }}
+            activeDot={{ r: 6 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="First-Time"
+            stroke="#7c3aed"
+            strokeWidth={2}
+            dot={{ fill: '#7c3aed', r: 4 }}
+            activeDot={{ r: 6 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="Returning"
+            stroke="#059669"
+            strokeWidth={2}
+            dot={{ fill: '#059669', r: 4 }}
+            activeDot={{ r: 6 }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/web/src/components/admin/analytics/DateRangePicker.tsx
+++ b/src/web/src/components/admin/analytics/DateRangePicker.tsx
@@ -1,0 +1,172 @@
+/**
+ * Date Range Picker Component
+ * Allows selection of predefined or custom date ranges
+ */
+
+import { useState } from 'react';
+
+export interface DateRange {
+  startDate: string;
+  endDate: string;
+}
+
+export interface DateRangePickerProps {
+  value: DateRange;
+  onChange: (range: DateRange) => void;
+}
+
+type PresetOption = 'last7' | 'last30' | 'last90' | 'thisYear' | 'custom';
+
+export function DateRangePicker({ value, onChange }: DateRangePickerProps) {
+  const [selectedPreset, setSelectedPreset] = useState<PresetOption>('last30');
+  const [isCustom, setIsCustom] = useState(false);
+
+  const handlePresetChange = (preset: PresetOption) => {
+    setSelectedPreset(preset);
+
+    if (preset === 'custom') {
+      setIsCustom(true);
+      return;
+    }
+
+    setIsCustom(false);
+
+    const today = new Date();
+    const endDate = today.toISOString().split('T')[0];
+    let startDate: string;
+
+    switch (preset) {
+      case 'last7':
+        startDate = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000)
+          .toISOString()
+          .split('T')[0];
+        break;
+      case 'last30':
+        startDate = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000)
+          .toISOString()
+          .split('T')[0];
+        break;
+      case 'last90':
+        startDate = new Date(today.getTime() - 90 * 24 * 60 * 60 * 1000)
+          .toISOString()
+          .split('T')[0];
+        break;
+      case 'thisYear':
+        startDate = `${today.getFullYear()}-01-01`;
+        break;
+      default:
+        return;
+    }
+
+    onChange({ startDate, endDate });
+  };
+
+  const handleCustomDateChange = (field: 'startDate' | 'endDate', dateValue: string) => {
+    onChange({
+      ...value,
+      [field]: dateValue,
+    });
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4 space-y-4">
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-2">
+          Date Range
+        </label>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={() => handlePresetChange('last7')}
+            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              selectedPreset === 'last7' && !isCustom
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            Last 7 Days
+          </button>
+          <button
+            type="button"
+            onClick={() => handlePresetChange('last30')}
+            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              selectedPreset === 'last30' && !isCustom
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            Last 30 Days
+          </button>
+          <button
+            type="button"
+            onClick={() => handlePresetChange('last90')}
+            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              selectedPreset === 'last90' && !isCustom
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            Last 90 Days
+          </button>
+          <button
+            type="button"
+            onClick={() => handlePresetChange('thisYear')}
+            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              selectedPreset === 'thisYear' && !isCustom
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            This Year
+          </button>
+          <button
+            type="button"
+            onClick={() => handlePresetChange('custom')}
+            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              isCustom
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+            }`}
+          >
+            Custom
+          </button>
+        </div>
+      </div>
+
+      {isCustom && (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label
+              htmlFor="startDate"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Start Date
+            </label>
+            <input
+              type="date"
+              id="startDate"
+              value={value.startDate}
+              onChange={(e) => handleCustomDateChange('startDate', e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div>
+            <label
+              htmlFor="endDate"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              End Date
+            </label>
+            <input
+              type="date"
+              id="endDate"
+              value={value.endDate}
+              onChange={(e) => handleCustomDateChange('endDate', e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/web/src/components/admin/analytics/index.ts
+++ b/src/web/src/components/admin/analytics/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Analytics components barrel export
+ */
+
+export { DateRangePicker } from './DateRangePicker';
+export { AnalyticsSummaryCards } from './AnalyticsSummaryCards';
+export { AttendanceTrendChart } from './AttendanceTrendChart';
+export { AttendanceByGroupTable } from './AttendanceByGroupTable';
+
+export type { DateRange, DateRangePickerProps } from './DateRangePicker';
+export type { AnalyticsSummaryCardsProps } from './AnalyticsSummaryCards';
+export type { AttendanceTrendChartProps } from './AttendanceTrendChart';
+export type { AttendanceByGroupTableProps } from './AttendanceByGroupTable';

--- a/src/web/src/hooks/useAnalytics.ts
+++ b/src/web/src/hooks/useAnalytics.ts
@@ -1,0 +1,31 @@
+/**
+ * Analytics hooks using TanStack Query
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import * as analyticsApi from '@/services/api/analytics';
+import type { AttendanceAnalyticsParams } from '@/services/api/analytics';
+
+export function useAttendanceAnalytics(params: AttendanceAnalyticsParams) {
+  return useQuery({
+    queryKey: ['analytics', 'attendance', params],
+    queryFn: () => analyticsApi.getAttendanceAnalytics(params),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}
+
+export function useAttendanceTrends(params: AttendanceAnalyticsParams) {
+  return useQuery({
+    queryKey: ['analytics', 'attendance', 'trends', params],
+    queryFn: () => analyticsApi.getAttendanceTrends(params),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}
+
+export function useAttendanceByGroup(params: AttendanceAnalyticsParams) {
+  return useQuery({
+    queryKey: ['analytics', 'attendance', 'by-group', params],
+    queryFn: () => analyticsApi.getAttendanceByGroup(params),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}

--- a/src/web/src/pages/admin/AnalyticsPage.tsx
+++ b/src/web/src/pages/admin/AnalyticsPage.tsx
@@ -1,0 +1,157 @@
+/**
+ * Attendance Analytics Page
+ * Dashboard for viewing attendance metrics, trends, and group breakdowns
+ */
+
+import { useState } from 'react';
+import {
+  DateRangePicker,
+  AnalyticsSummaryCards,
+  AttendanceTrendChart,
+  AttendanceByGroupTable,
+} from '@/components/admin/analytics';
+import type { DateRange } from '@/components/admin/analytics';
+import {
+  useAttendanceAnalytics,
+  useAttendanceTrends,
+  useAttendanceByGroup,
+} from '@/hooks/useAnalytics';
+
+export function AnalyticsPage() {
+  // Calculate default date range (last 30 days)
+  const getDefaultDateRange = (): DateRange => {
+    const today = new Date();
+    const endDate = today.toISOString().split('T')[0];
+    const startDate = new Date(today.getTime() - 30 * 24 * 60 * 60 * 1000)
+      .toISOString()
+      .split('T')[0];
+    return { startDate, endDate };
+  };
+
+  const [dateRange, setDateRange] = useState<DateRange>(getDefaultDateRange());
+  const [campusFilter, setCampusFilter] = useState<string>('');
+  const [groupTypeFilter, setGroupTypeFilter] = useState<string>('');
+
+  // Build params for API queries
+  const queryParams = {
+    startDate: dateRange.startDate,
+    endDate: dateRange.endDate,
+    ...(campusFilter && { campusIdKey: campusFilter }),
+    ...(groupTypeFilter && { groupTypeIdKey: groupTypeFilter }),
+  };
+
+  // Fetch analytics data
+  const {
+    data: analytics,
+    isLoading: isLoadingAnalytics,
+    error: analyticsError,
+  } = useAttendanceAnalytics(queryParams);
+
+  const {
+    data: trends,
+    isLoading: isLoadingTrends,
+    error: trendsError,
+  } = useAttendanceTrends(queryParams);
+
+  const {
+    data: groupData,
+    isLoading: isLoadingGroups,
+    error: groupsError,
+  } = useAttendanceByGroup(queryParams);
+
+  // Combined error state
+  const error = analyticsError || trendsError || groupsError;
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div>
+        <h1 className="text-3xl font-bold text-gray-900">Attendance Analytics</h1>
+        <p className="mt-2 text-gray-600">
+          View attendance metrics, trends, and group breakdowns
+        </p>
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-6">
+          <div className="flex items-start gap-3">
+            <svg
+              className="w-6 h-6 text-red-400 flex-shrink-0 mt-0.5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <div>
+              <p className="text-red-700 font-medium">Failed to load analytics data</p>
+              <p className="text-red-600 text-sm mt-1">
+                {error instanceof Error ? error.message : 'An unknown error occurred'}
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Date Range Picker */}
+      <DateRangePicker value={dateRange} onChange={setDateRange} />
+
+      {/* Filters */}
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <h3 className="text-sm font-medium text-gray-700 mb-3">Filters</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div>
+            <label
+              htmlFor="campus-filter"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Campus (Optional)
+            </label>
+            <select
+              id="campus-filter"
+              value={campusFilter}
+              onChange={(e) => setCampusFilter(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">All Campuses</option>
+              {/* Add campus options here - could be fetched from API */}
+            </select>
+          </div>
+          <div>
+            <label
+              htmlFor="group-type-filter"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Group Type (Optional)
+            </label>
+            <select
+              id="group-type-filter"
+              value={groupTypeFilter}
+              onChange={(e) => setGroupTypeFilter(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">All Group Types</option>
+              {/* Add group type options here - could be fetched from API */}
+            </select>
+          </div>
+        </div>
+      </div>
+
+      {/* Summary Cards */}
+      <AnalyticsSummaryCards analytics={analytics} isLoading={isLoadingAnalytics} />
+
+      {/* Trend Chart */}
+      <AttendanceTrendChart trends={trends} isLoading={isLoadingTrends} />
+
+      {/* Group Table */}
+      <AttendanceByGroupTable groups={groupData} isLoading={isLoadingGroups} />
+    </div>
+  );
+}

--- a/src/web/src/pages/admin/index.ts
+++ b/src/web/src/pages/admin/index.ts
@@ -9,3 +9,4 @@ export { FamiliesPage } from './FamiliesPage';
 export { GroupsPage } from './GroupsPage';
 export { SchedulesPage } from './SchedulesPage';
 export { SettingsPage } from './SettingsPage';
+export { AnalyticsPage } from './AnalyticsPage';

--- a/src/web/src/services/api/analytics.ts
+++ b/src/web/src/services/api/analytics.ts
@@ -1,0 +1,103 @@
+/**
+ * Analytics API service
+ */
+
+import { get } from './client';
+
+export interface AttendanceAnalytics {
+  totalAttendance: number;
+  uniqueAttendees: number;
+  firstTimeVisitors: number;
+  returningVisitors: number;
+  averageAttendance: number;
+  startDate: string;
+  endDate: string;
+}
+
+export interface AttendanceTrend {
+  date: string;
+  count: number;
+  firstTime: number;
+  returning: number;
+}
+
+export interface AttendanceByGroup {
+  groupIdKey: string;
+  groupName: string;
+  groupTypeName: string;
+  totalAttendance: number;
+  uniqueAttendees: number;
+}
+
+export interface AttendanceAnalyticsParams {
+  startDate: string;
+  endDate: string;
+  campusIdKey?: string;
+  groupTypeIdKey?: string;
+}
+
+export async function getAttendanceAnalytics(
+  params: AttendanceAnalyticsParams
+): Promise<AttendanceAnalytics> {
+  const queryParams = new URLSearchParams({
+    startDate: params.startDate,
+    endDate: params.endDate,
+  });
+
+  if (params.campusIdKey) {
+    queryParams.append('campusIdKey', params.campusIdKey);
+  }
+
+  if (params.groupTypeIdKey) {
+    queryParams.append('groupTypeIdKey', params.groupTypeIdKey);
+  }
+
+  const response = await get<{ data: AttendanceAnalytics }>(
+    `/analytics/attendance?${queryParams.toString()}`
+  );
+  return response.data;
+}
+
+export async function getAttendanceTrends(
+  params: AttendanceAnalyticsParams
+): Promise<AttendanceTrend[]> {
+  const queryParams = new URLSearchParams({
+    startDate: params.startDate,
+    endDate: params.endDate,
+  });
+
+  if (params.campusIdKey) {
+    queryParams.append('campusIdKey', params.campusIdKey);
+  }
+
+  if (params.groupTypeIdKey) {
+    queryParams.append('groupTypeIdKey', params.groupTypeIdKey);
+  }
+
+  const response = await get<{ data: AttendanceTrend[] }>(
+    `/analytics/attendance/trends?${queryParams.toString()}`
+  );
+  return response.data;
+}
+
+export async function getAttendanceByGroup(
+  params: AttendanceAnalyticsParams
+): Promise<AttendanceByGroup[]> {
+  const queryParams = new URLSearchParams({
+    startDate: params.startDate,
+    endDate: params.endDate,
+  });
+
+  if (params.campusIdKey) {
+    queryParams.append('campusIdKey', params.campusIdKey);
+  }
+
+  if (params.groupTypeIdKey) {
+    queryParams.append('groupTypeIdKey', params.groupTypeIdKey);
+  }
+
+  const response = await get<{ data: AttendanceByGroup[] }>(
+    `/analytics/attendance/by-group?${queryParams.toString()}`
+  );
+  return response.data;
+}

--- a/tests/Koinon.Api.Tests/Controllers/AnalyticsControllerTests.cs
+++ b/tests/Koinon.Api.Tests/Controllers/AnalyticsControllerTests.cs
@@ -1,0 +1,279 @@
+using FluentAssertions;
+using Koinon.Api.Controllers;
+using Koinon.Application.DTOs;
+using Koinon.Application.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Api.Tests.Controllers;
+
+public class AnalyticsControllerTests
+{
+    private readonly Mock<IAttendanceAnalyticsService> _analyticsServiceMock;
+    private readonly Mock<ILogger<AnalyticsController>> _loggerMock;
+    private readonly AnalyticsController _controller;
+
+    public AnalyticsControllerTests()
+    {
+        _analyticsServiceMock = new Mock<IAttendanceAnalyticsService>();
+        _loggerMock = new Mock<ILogger<AnalyticsController>>();
+        _controller = new AnalyticsController(_analyticsServiceMock.Object, _loggerMock.Object);
+
+        // Setup HttpContext for controller
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+    }
+
+    [Fact]
+    public async Task GetAttendanceSummary_ReturnsOk_WithAnalyticsData()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 1, 1);
+        var endDate = new DateOnly(2024, 1, 31);
+        var expectedAnalytics = new AttendanceAnalyticsDto(
+            TotalAttendance: 450,
+            UniqueAttendees: 125,
+            FirstTimeVisitors: 15,
+            ReturningVisitors: 110,
+            AverageAttendance: 50.5m,
+            StartDate: startDate,
+            EndDate: endDate
+        );
+
+        _analyticsServiceMock
+            .Setup(s => s.GetSummaryAsync(It.IsAny<AttendanceQueryOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedAnalytics);
+
+        // Act
+        var result = await _controller.GetAttendanceSummary(
+            startDate, endDate, null, null, null, CancellationToken.None);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var analytics = okResult.Value.Should().BeOfType<AttendanceAnalyticsDto>().Subject;
+
+        analytics.TotalAttendance.Should().Be(450);
+        analytics.UniqueAttendees.Should().Be(125);
+        analytics.FirstTimeVisitors.Should().Be(15);
+        analytics.ReturningVisitors.Should().Be(110);
+        analytics.AverageAttendance.Should().Be(50.5m);
+        analytics.StartDate.Should().Be(startDate);
+        analytics.EndDate.Should().Be(endDate);
+
+        _analyticsServiceMock.Verify(
+            s => s.GetSummaryAsync(It.IsAny<AttendanceQueryOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAttendanceSummary_WithFilters_PassesCorrectOptions()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 1, 1);
+        var endDate = new DateOnly(2024, 1, 31);
+        var campusIdKey = "campus123";
+        var groupTypeIdKey = "grouptype456";
+        var groupIdKey = "group789";
+
+        var expectedAnalytics = new AttendanceAnalyticsDto(
+            TotalAttendance: 100,
+            UniqueAttendees: 50,
+            FirstTimeVisitors: 5,
+            ReturningVisitors: 45,
+            AverageAttendance: 25m,
+            StartDate: startDate,
+            EndDate: endDate
+        );
+
+        AttendanceQueryOptions? capturedOptions = null;
+        _analyticsServiceMock
+            .Setup(s => s.GetSummaryAsync(It.IsAny<AttendanceQueryOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<AttendanceQueryOptions, CancellationToken>((opts, _) => capturedOptions = opts)
+            .ReturnsAsync(expectedAnalytics);
+
+        // Act
+        await _controller.GetAttendanceSummary(
+            startDate, endDate, campusIdKey, groupTypeIdKey, groupIdKey, CancellationToken.None);
+
+        // Assert
+        capturedOptions.Should().NotBeNull();
+        capturedOptions!.StartDate.Should().Be(startDate);
+        capturedOptions.EndDate.Should().Be(endDate);
+        capturedOptions.CampusIdKey.Should().Be(campusIdKey);
+        capturedOptions.GroupTypeIdKey.Should().Be(groupTypeIdKey);
+        capturedOptions.GroupIdKey.Should().Be(groupIdKey);
+    }
+
+    [Fact]
+    public async Task GetAttendanceTrends_ReturnsOk_WithTrendData()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 1, 1);
+        var endDate = new DateOnly(2024, 1, 7);
+        var expectedTrends = new List<AttendanceTrendDto>
+        {
+            new(new DateOnly(2024, 1, 1), 50, 5, 45),
+            new(new DateOnly(2024, 1, 2), 55, 3, 52),
+            new(new DateOnly(2024, 1, 3), 48, 2, 46)
+        };
+
+        _analyticsServiceMock
+            .Setup(s => s.GetTrendsAsync(It.IsAny<AttendanceQueryOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedTrends);
+
+        // Act
+        var result = await _controller.GetAttendanceTrends(
+            startDate, endDate, null, null, null, GroupBy.Day, CancellationToken.None);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var trends = okResult.Value.Should().BeAssignableTo<IReadOnlyList<AttendanceTrendDto>>().Subject;
+
+        trends.Should().HaveCount(3);
+        trends[0].Date.Should().Be(new DateOnly(2024, 1, 1));
+        trends[0].Count.Should().Be(50);
+        trends[0].FirstTime.Should().Be(5);
+        trends[0].Returning.Should().Be(45);
+
+        _analyticsServiceMock.Verify(
+            s => s.GetTrendsAsync(It.IsAny<AttendanceQueryOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAttendanceTrends_WithGroupByWeek_PassesCorrectOptions()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 1, 1);
+        var endDate = new DateOnly(2024, 1, 31);
+
+        AttendanceQueryOptions? capturedOptions = null;
+        _analyticsServiceMock
+            .Setup(s => s.GetTrendsAsync(It.IsAny<AttendanceQueryOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<AttendanceQueryOptions, CancellationToken>((opts, _) => capturedOptions = opts)
+            .ReturnsAsync(new List<AttendanceTrendDto>());
+
+        // Act
+        await _controller.GetAttendanceTrends(
+            startDate, endDate, null, null, null, GroupBy.Week, CancellationToken.None);
+
+        // Assert
+        capturedOptions.Should().NotBeNull();
+        capturedOptions!.GroupBy.Should().Be(GroupBy.Week);
+    }
+
+    [Fact]
+    public async Task GetAttendanceByGroup_ReturnsOk_WithGroupData()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 1, 1);
+        var endDate = new DateOnly(2024, 1, 31);
+        var expectedByGroup = new List<AttendanceByGroupDto>
+        {
+            new("group1", "Youth Group", "Small Group", 150, 35),
+            new("group2", "Children's Ministry", "Check-in Area", 200, 45),
+            new("group3", "Adult Bible Study", "Small Group", 100, 25)
+        };
+
+        _analyticsServiceMock
+            .Setup(s => s.GetByGroupAsync(It.IsAny<AttendanceQueryOptions>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedByGroup);
+
+        // Act
+        var result = await _controller.GetAttendanceByGroup(
+            startDate, endDate, null, null, CancellationToken.None);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var byGroup = okResult.Value.Should().BeAssignableTo<IReadOnlyList<AttendanceByGroupDto>>().Subject;
+
+        byGroup.Should().HaveCount(3);
+        byGroup[0].GroupName.Should().Be("Youth Group");
+        byGroup[0].TotalAttendance.Should().Be(150);
+        byGroup[0].UniqueAttendees.Should().Be(35);
+
+        _analyticsServiceMock.Verify(
+            s => s.GetByGroupAsync(It.IsAny<AttendanceQueryOptions>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task GetAttendanceByGroup_WithFilters_PassesCorrectOptions()
+    {
+        // Arrange
+        var startDate = new DateOnly(2024, 1, 1);
+        var endDate = new DateOnly(2024, 1, 31);
+        var campusIdKey = "campus123";
+        var groupTypeIdKey = "grouptype456";
+
+        AttendanceQueryOptions? capturedOptions = null;
+        _analyticsServiceMock
+            .Setup(s => s.GetByGroupAsync(It.IsAny<AttendanceQueryOptions>(), It.IsAny<CancellationToken>()))
+            .Callback<AttendanceQueryOptions, CancellationToken>((opts, _) => capturedOptions = opts)
+            .ReturnsAsync(new List<AttendanceByGroupDto>());
+
+        // Act
+        await _controller.GetAttendanceByGroup(
+            startDate, endDate, campusIdKey, groupTypeIdKey, CancellationToken.None);
+
+        // Assert
+        capturedOptions.Should().NotBeNull();
+        capturedOptions!.StartDate.Should().Be(startDate);
+        capturedOptions.EndDate.Should().Be(endDate);
+        capturedOptions.CampusIdKey.Should().Be(campusIdKey);
+        capturedOptions.GroupTypeIdKey.Should().Be(groupTypeIdKey);
+    }
+
+    [Fact]
+    public async Task GetAttendanceSummary_WhenServiceThrows_PropagatesException()
+    {
+        // Arrange
+        _analyticsServiceMock
+            .Setup(s => s.GetSummaryAsync(It.IsAny<AttendanceQueryOptions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Database connection failed"));
+
+        // Act & Assert
+        var act = async () => await _controller.GetAttendanceSummary(
+            null, null, null, null, null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Database connection failed");
+    }
+
+    [Fact]
+    public async Task GetAttendanceTrends_WhenServiceThrows_PropagatesException()
+    {
+        // Arrange
+        _analyticsServiceMock
+            .Setup(s => s.GetTrendsAsync(It.IsAny<AttendanceQueryOptions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Database connection failed"));
+
+        // Act & Assert
+        var act = async () => await _controller.GetAttendanceTrends(
+            null, null, null, null, null, GroupBy.Day, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Database connection failed");
+    }
+
+    [Fact]
+    public async Task GetAttendanceByGroup_WhenServiceThrows_PropagatesException()
+    {
+        // Arrange
+        _analyticsServiceMock
+            .Setup(s => s.GetByGroupAsync(It.IsAny<AttendanceQueryOptions>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Database connection failed"));
+
+        // Act & Assert
+        var act = async () => await _controller.GetAttendanceByGroup(
+            null, null, null, null, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Database connection failed");
+    }
+}

--- a/tests/Koinon.Application.Tests/Services/AttendanceAnalyticsServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/AttendanceAnalyticsServiceTests.cs
@@ -1,0 +1,435 @@
+using FluentAssertions;
+using Koinon.Application.DTOs;
+using Koinon.Application.Services;
+using Koinon.Domain.Data;
+using Koinon.Domain.Entities;
+using Koinon.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Application.Tests.Services;
+
+/// <summary>
+/// Tests for AttendanceAnalyticsService.
+/// </summary>
+public class AttendanceAnalyticsServiceTests : IDisposable
+{
+    private readonly KoinonDbContext _context;
+    private readonly Mock<ILogger<AttendanceAnalyticsService>> _mockLogger;
+    private readonly AttendanceAnalyticsService _service;
+
+    public AttendanceAnalyticsServiceTests()
+    {
+        // Setup in-memory database
+        var options = new DbContextOptionsBuilder<KoinonDbContext>()
+            .UseInMemoryDatabase(databaseName: $"KoinonTestDb_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _context = new KoinonDbContext(options);
+
+        // Manually initialize the context
+        _context.Database.EnsureCreated();
+
+        // Setup logger mock
+        _mockLogger = new Mock<ILogger<AttendanceAnalyticsService>>();
+
+        // Create service
+        _service = new AttendanceAnalyticsService(_context, _mockLogger.Object);
+
+        // Seed test data
+        SeedTestData();
+    }
+
+    private void SeedTestData()
+    {
+        var now = DateTime.UtcNow;
+        var today = DateOnly.FromDateTime(now);
+
+        // Add group types
+        var worshipGroupType = new GroupType
+        {
+            Id = 1,
+            Name = "Worship Service",
+            IsFamilyGroupType = false,
+            AllowMultipleLocations = false,
+            IsSystem = false,
+            CreatedDateTime = now
+        };
+
+        var smallGroupType = new GroupType
+        {
+            Id = 2,
+            Name = "Small Group",
+            IsFamilyGroupType = false,
+            AllowMultipleLocations = false,
+            IsSystem = false,
+            CreatedDateTime = now
+        };
+
+        _context.GroupTypes.AddRange(worshipGroupType, smallGroupType);
+
+        // Add groups
+        var sundayService = new Group
+        {
+            Id = 1,
+            GroupTypeId = 1,
+            Name = "Sunday Service",
+            IsActive = true,
+            IsArchived = false,
+            CreatedDateTime = now
+        };
+
+        var eveningService = new Group
+        {
+            Id = 2,
+            GroupTypeId = 1,
+            Name = "Evening Service",
+            IsActive = true,
+            IsArchived = false,
+            CreatedDateTime = now
+        };
+
+        var smallGroup1 = new Group
+        {
+            Id = 3,
+            GroupTypeId = 2,
+            Name = "Small Group 1",
+            IsActive = true,
+            IsArchived = false,
+            CreatedDateTime = now
+        };
+
+        _context.Groups.AddRange(sundayService, eveningService, smallGroup1);
+
+        // Add attendance occurrences
+        var occurrence1 = new AttendanceOccurrence
+        {
+            Id = 1,
+            GroupId = 1,
+            OccurrenceDate = today.AddDays(-14),
+            SundayDate = today.AddDays(-14),
+            CreatedDateTime = now
+        };
+
+        var occurrence2 = new AttendanceOccurrence
+        {
+            Id = 2,
+            GroupId = 1,
+            OccurrenceDate = today.AddDays(-7),
+            SundayDate = today.AddDays(-7),
+            CreatedDateTime = now
+        };
+
+        var occurrence3 = new AttendanceOccurrence
+        {
+            Id = 3,
+            GroupId = 1,
+            OccurrenceDate = today,
+            SundayDate = today,
+            CreatedDateTime = now
+        };
+
+        var occurrence4 = new AttendanceOccurrence
+        {
+            Id = 4,
+            GroupId = 2,
+            OccurrenceDate = today.AddDays(-7),
+            SundayDate = today.AddDays(-7),
+            CreatedDateTime = now
+        };
+
+        var occurrence5 = new AttendanceOccurrence
+        {
+            Id = 5,
+            GroupId = 3,
+            OccurrenceDate = today.AddDays(-3),
+            SundayDate = today.AddDays(-7),
+            CreatedDateTime = now
+        };
+
+        _context.AttendanceOccurrences.AddRange(occurrence1, occurrence2, occurrence3, occurrence4, occurrence5);
+
+        // Add person aliases
+        var personAlias1 = new PersonAlias
+        {
+            Id = 1,
+            PersonId = 1,
+            AliasPersonId = 1,
+            CreatedDateTime = now
+        };
+
+        var personAlias2 = new PersonAlias
+        {
+            Id = 2,
+            PersonId = 2,
+            AliasPersonId = 2,
+            CreatedDateTime = now
+        };
+
+        var personAlias3 = new PersonAlias
+        {
+            Id = 3,
+            PersonId = 3,
+            AliasPersonId = 3,
+            CreatedDateTime = now
+        };
+
+        _context.PersonAliases.AddRange(personAlias1, personAlias2, personAlias3);
+
+        // Add attendances
+        var attendances = new List<Attendance>
+        {
+            // Occurrence 1 (14 days ago) - Sunday Service
+            new() { Id = 1, PersonAliasId = 1, OccurrenceId = 1, StartDateTime = now.AddDays(-14), IsFirstTime = true, CreatedDateTime = now },
+            new() { Id = 2, PersonAliasId = 2, OccurrenceId = 1, StartDateTime = now.AddDays(-14), IsFirstTime = false, CreatedDateTime = now },
+            new() { Id = 3, PersonAliasId = 3, OccurrenceId = 1, StartDateTime = now.AddDays(-14), IsFirstTime = false, CreatedDateTime = now },
+
+            // Occurrence 2 (7 days ago) - Sunday Service
+            new() { Id = 4, PersonAliasId = 1, OccurrenceId = 2, StartDateTime = now.AddDays(-7), IsFirstTime = false, CreatedDateTime = now },
+            new() { Id = 5, PersonAliasId = 2, OccurrenceId = 2, StartDateTime = now.AddDays(-7), IsFirstTime = false, CreatedDateTime = now },
+
+            // Occurrence 3 (today) - Sunday Service
+            new() { Id = 6, PersonAliasId = 1, OccurrenceId = 3, StartDateTime = now, IsFirstTime = false, CreatedDateTime = now },
+            new() { Id = 7, PersonAliasId = 2, OccurrenceId = 3, StartDateTime = now, IsFirstTime = false, CreatedDateTime = now },
+            new() { Id = 8, PersonAliasId = 3, OccurrenceId = 3, StartDateTime = now, IsFirstTime = false, CreatedDateTime = now },
+
+            // Occurrence 4 (7 days ago) - Evening Service
+            new() { Id = 9, PersonAliasId = 1, OccurrenceId = 4, StartDateTime = now.AddDays(-7), IsFirstTime = false, CreatedDateTime = now },
+            new() { Id = 10, PersonAliasId = 3, OccurrenceId = 4, StartDateTime = now.AddDays(-7), IsFirstTime = true, CreatedDateTime = now },
+
+            // Occurrence 5 (3 days ago) - Small Group 1
+            new() { Id = 11, PersonAliasId = 2, OccurrenceId = 5, StartDateTime = now.AddDays(-3), IsFirstTime = false, CreatedDateTime = now },
+            new() { Id = 12, PersonAliasId = 3, OccurrenceId = 5, StartDateTime = now.AddDays(-3), IsFirstTime = false, CreatedDateTime = now },
+        };
+
+        _context.Attendances.AddRange(attendances);
+
+        _context.SaveChanges();
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ReturnsCorrectTotalAttendance()
+    {
+        // Arrange
+        var options = new AttendanceQueryOptions(
+            StartDate: DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30),
+            EndDate: DateOnly.FromDateTime(DateTime.UtcNow));
+
+        // Act
+        var summary = await _service.GetSummaryAsync(options);
+
+        // Assert
+        summary.TotalAttendance.Should().Be(12); // All attendance records within range
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ReturnsCorrectUniqueAttendees()
+    {
+        // Arrange
+        var options = new AttendanceQueryOptions(
+            StartDate: DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30),
+            EndDate: DateOnly.FromDateTime(DateTime.UtcNow));
+
+        // Act
+        var summary = await _service.GetSummaryAsync(options);
+
+        // Assert
+        summary.UniqueAttendees.Should().Be(3); // 3 unique PersonAliasIds
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ReturnsCorrectFirstTimeVisitors()
+    {
+        // Arrange
+        var options = new AttendanceQueryOptions(
+            StartDate: DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30),
+            EndDate: DateOnly.FromDateTime(DateTime.UtcNow));
+
+        // Act
+        var summary = await _service.GetSummaryAsync(options);
+
+        // Assert
+        summary.FirstTimeVisitors.Should().Be(2); // 2 records with IsFirstTime = true
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_ReturnsCorrectReturningVisitors()
+    {
+        // Arrange
+        var options = new AttendanceQueryOptions(
+            StartDate: DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30),
+            EndDate: DateOnly.FromDateTime(DateTime.UtcNow));
+
+        // Act
+        var summary = await _service.GetSummaryAsync(options);
+
+        // Assert
+        summary.ReturningVisitors.Should().Be(10); // Total - FirstTime = 12 - 2 = 10
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_CalculatesAverageAttendancePerOccurrence()
+    {
+        // Arrange
+        var options = new AttendanceQueryOptions(
+            StartDate: DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30),
+            EndDate: DateOnly.FromDateTime(DateTime.UtcNow));
+
+        // Act
+        var summary = await _service.GetSummaryAsync(options);
+
+        // Assert
+        // 12 total attendance / 5 occurrences = 2.4
+        summary.AverageAttendance.Should().Be(2.4m);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WithGroupFilter_FiltersCorrectly()
+    {
+        // Arrange
+        var groupIdKey = IdKeyHelper.Encode(1); // Sunday Service
+        var options = new AttendanceQueryOptions(
+            StartDate: DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30),
+            EndDate: DateOnly.FromDateTime(DateTime.UtcNow),
+            GroupIdKey: groupIdKey);
+
+        // Act
+        var summary = await _service.GetSummaryAsync(options);
+
+        // Assert
+        summary.TotalAttendance.Should().Be(8); // Only attendance for Sunday Service (occurrences 1, 2, 3)
+    }
+
+    [Fact]
+    public async Task GetTrendsAsync_GroupsByDay_ReturnsCorrectData()
+    {
+        // Arrange
+        var options = new AttendanceQueryOptions(
+            StartDate: DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30),
+            EndDate: DateOnly.FromDateTime(DateTime.UtcNow),
+            GroupBy: GroupBy.Day);
+
+        // Act
+        var trends = await _service.GetTrendsAsync(options);
+
+        // Assert
+        trends.Should().NotBeEmpty();
+        trends.Should().HaveCount(4); // 4 distinct dates (14 days ago, 7 days ago, 3 days ago, today)
+
+        // Verify trends are sorted by date
+        trends.Should().BeInAscendingOrder(t => t.Date);
+    }
+
+    [Fact]
+    public async Task GetTrendsAsync_GroupsByWeek_ReturnsCorrectData()
+    {
+        // Arrange
+        var options = new AttendanceQueryOptions(
+            StartDate: DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30),
+            EndDate: DateOnly.FromDateTime(DateTime.UtcNow),
+            GroupBy: GroupBy.Week);
+
+        // Act
+        var trends = await _service.GetTrendsAsync(options);
+
+        // Assert
+        trends.Should().NotBeEmpty();
+        // All occurrences should be grouped into weeks
+        foreach (var trend in trends)
+        {
+            trend.Count.Should().BeGreaterThan(0);
+            trend.Date.DayOfWeek.Should().Be(DayOfWeek.Sunday); // Week should start on Sunday
+        }
+    }
+
+    [Fact]
+    public async Task GetByGroupAsync_ReturnsCorrectGroupBreakdown()
+    {
+        // Arrange
+        var options = new AttendanceQueryOptions(
+            StartDate: DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30),
+            EndDate: DateOnly.FromDateTime(DateTime.UtcNow));
+
+        // Act
+        var groupData = await _service.GetByGroupAsync(options);
+
+        // Assert
+        groupData.Should().NotBeEmpty();
+        groupData.Should().HaveCount(3); // 3 groups with attendance
+
+        // Verify sorted by total attendance (descending)
+        groupData.Should().BeInDescendingOrder(g => g.TotalAttendance);
+
+        // Check the highest attendance group (Sunday Service)
+        var sundayService = groupData.First();
+        sundayService.GroupName.Should().Be("Sunday Service");
+        sundayService.TotalAttendance.Should().Be(8);
+        sundayService.UniqueAttendees.Should().Be(3);
+        sundayService.GroupIdKey.Should().NotBeNullOrEmpty();
+    }
+
+    [Fact]
+    public async Task GetByGroupAsync_WithGroupTypeFilter_FiltersCorrectly()
+    {
+        // Arrange
+        var groupTypeIdKey = IdKeyHelper.Encode(2); // Small Group
+        var options = new AttendanceQueryOptions(
+            StartDate: DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30),
+            EndDate: DateOnly.FromDateTime(DateTime.UtcNow),
+            GroupTypeIdKey: groupTypeIdKey);
+
+        // Act
+        var groupData = await _service.GetByGroupAsync(options);
+
+        // Assert
+        groupData.Should().HaveCount(1); // Only Small Group 1
+        groupData.First().GroupName.Should().Be("Small Group 1");
+        groupData.First().GroupTypeName.Should().Be("Small Group");
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WithNoData_ReturnsZeroCounts()
+    {
+        // Arrange - Clear all data
+        _context.Attendances.RemoveRange(_context.Attendances);
+        await _context.SaveChangesAsync();
+
+        var options = new AttendanceQueryOptions(
+            StartDate: DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30),
+            EndDate: DateOnly.FromDateTime(DateTime.UtcNow));
+
+        // Act
+        var summary = await _service.GetSummaryAsync(options);
+
+        // Assert
+        summary.TotalAttendance.Should().Be(0);
+        summary.UniqueAttendees.Should().Be(0);
+        summary.FirstTimeVisitors.Should().Be(0);
+        summary.ReturningVisitors.Should().Be(0);
+        summary.AverageAttendance.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_UsesDefaultDateRange_WhenNotProvided()
+    {
+        // Arrange
+        var options = new AttendanceQueryOptions(); // No dates specified
+
+        // Act
+        var summary = await _service.GetSummaryAsync(options);
+
+        // Assert
+        // Should default to last 30 days
+        summary.StartDate.Should().Be(DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-30));
+        summary.EndDate.Should().Be(DateOnly.FromDateTime(DateTime.UtcNow));
+    }
+
+    public void Dispose()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary
Full-stack attendance analytics feature with dashboard, charts, and filtering.

## Backend
- `AttendanceAnalyticsService` with optimized database queries
- DTOs: AttendanceAnalyticsDto, AttendanceTrendDto, AttendanceByGroupDto
- `AnalyticsController` with 3 endpoints
- 21 unit tests

## Frontend
- Analytics page at `/admin/analytics`
- Date range picker with presets
- Summary cards with key metrics
- Line chart for trends (Recharts)
- Sortable group breakdown table
- TanStack Query hooks

## API Endpoints
- `GET /api/v1/analytics/attendance` - Summary stats
- `GET /api/v1/analytics/attendance/trends` - Time-series data
- `GET /api/v1/analytics/attendance/by-group` - Group breakdown

## Test plan
- [x] All 565 tests pass
- [x] Build succeeds
- [x] Code-critic approved
- [x] Database queries optimized (no N+1)

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)