### PR TITLE
feat: Add group leader dashboard with member management (#112)

### DIFF
--- a/src/Koinon.Api/Controllers/MyGroupsController.cs
+++ b/src/Koinon.Api/Controllers/MyGroupsController.cs
@@ -1,0 +1,145 @@
+using Koinon.Application.DTOs.Requests;
+using Koinon.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Koinon.Api.Controllers;
+
+/// <summary>
+/// API controller for managing groups where the current user is a leader.
+/// </summary>
+[Authorize]
+[ApiController]
+[Route("api/v1/my-groups")]
+public class MyGroupsController(IMyGroupsService myGroupsService) : ControllerBase
+{
+    /// <summary>
+    /// Gets all groups where the current user is a leader.
+    /// </summary>
+    [HttpGet]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetMyGroups(CancellationToken ct)
+    {
+        var groups = await myGroupsService.GetMyGroupsAsync(ct);
+        return Ok(groups);
+    }
+
+    /// <summary>
+    /// Gets detailed member information including contact details for a group.
+    /// Only accessible to group leaders and staff.
+    /// </summary>
+    [HttpGet("{groupIdKey}/members")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetGroupMembersWithContactInfo(string groupIdKey, CancellationToken ct)
+    {
+        var result = await myGroupsService.GetGroupMembersWithContactInfoAsync(groupIdKey, ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.Error!.Code switch
+            {
+                "NOT_FOUND" => NotFound(result.Error),
+                "FORBIDDEN" => StatusCode(StatusCodes.Status403Forbidden, result.Error),
+                _ => BadRequest(result.Error)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Updates a group member's role or status.
+    /// Only accessible to group leaders and staff.
+    /// </summary>
+    [HttpPut("{groupIdKey}/members/{memberIdKey}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateGroupMember(
+        string groupIdKey,
+        string memberIdKey,
+        [FromBody] UpdateGroupMemberRequest request,
+        CancellationToken ct)
+    {
+        var result = await myGroupsService.UpdateGroupMemberAsync(groupIdKey, memberIdKey, request, ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.Error!.Code switch
+            {
+                "NOT_FOUND" => NotFound(result.Error),
+                "FORBIDDEN" => StatusCode(StatusCodes.Status403Forbidden, result.Error),
+                "VALIDATION_ERROR" => BadRequest(result.Error),
+                _ => BadRequest(result.Error)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Removes a member from a group.
+    /// Only accessible to group leaders and staff.
+    /// </summary>
+    [HttpDelete("{groupIdKey}/members/{memberIdKey}")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> RemoveGroupMember(
+        string groupIdKey,
+        string memberIdKey,
+        CancellationToken ct)
+    {
+        var result = await myGroupsService.RemoveGroupMemberAsync(groupIdKey, memberIdKey, ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.Error!.Code switch
+            {
+                "NOT_FOUND" => NotFound(result.Error),
+                "FORBIDDEN" => StatusCode(StatusCodes.Status403Forbidden, result.Error),
+                _ => BadRequest(result.Error)
+            };
+        }
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Records attendance for a group meeting.
+    /// Only accessible to group leaders and staff.
+    /// </summary>
+    [HttpPost("{groupIdKey}/attendance")]
+    [ProducesResponseType(StatusCodes.Status201Created)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> RecordAttendance(
+        string groupIdKey,
+        [FromBody] RecordAttendanceRequest request,
+        CancellationToken ct)
+    {
+        var result = await myGroupsService.RecordAttendanceAsync(groupIdKey, request, ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.Error!.Code switch
+            {
+                "NOT_FOUND" => NotFound(result.Error),
+                "FORBIDDEN" => StatusCode(StatusCodes.Status403Forbidden, result.Error),
+                "VALIDATION_ERROR" => BadRequest(result.Error),
+                _ => BadRequest(result.Error)
+            };
+        }
+
+        return StatusCode(StatusCodes.Status201Created);
+    }
+}

--- a/src/Koinon.Application/DTOs/GroupMemberDetailDto.cs
+++ b/src/Koinon.Application/DTOs/GroupMemberDetailDto.cs
@@ -1,0 +1,24 @@
+namespace Koinon.Application.DTOs;
+
+/// <summary>
+/// Enhanced group member DTO with contact information.
+/// Contact details (Email, Phone) are only populated for group leaders.
+/// </summary>
+public record GroupMemberDetailDto
+{
+    public required string IdKey { get; init; }
+    public required string PersonIdKey { get; init; }
+    public required string FirstName { get; init; }
+    public required string LastName { get; init; }
+    public required string FullName { get; init; }
+    public string? Email { get; init; }
+    public string? Phone { get; init; }
+    public string? PhotoUrl { get; init; }
+    public int? Age { get; init; }
+    public required string Gender { get; init; }
+    public required GroupTypeRoleDto Role { get; init; }
+    public required string Status { get; init; }
+    public DateTime? DateTimeAdded { get; init; }
+    public DateTime? InactiveDateTime { get; init; }
+    public string? Note { get; init; }
+}

--- a/src/Koinon.Application/DTOs/MyGroupDto.cs
+++ b/src/Koinon.Application/DTOs/MyGroupDto.cs
@@ -1,0 +1,21 @@
+namespace Koinon.Application.DTOs;
+
+/// <summary>
+/// DTO for groups where the current user is a leader.
+/// Includes summary information and leadership-specific metrics.
+/// </summary>
+public record MyGroupDto
+{
+    public required string IdKey { get; init; }
+    public required Guid Guid { get; init; }
+    public required string Name { get; init; }
+    public string? Description { get; init; }
+    public required string GroupTypeName { get; init; }
+    public required bool IsActive { get; init; }
+    public required int MemberCount { get; init; }
+    public int? GroupCapacity { get; init; }
+    public DateTime? LastMeetingDate { get; init; }
+    public CampusSummaryDto? Campus { get; init; }
+    public required DateTime CreatedDateTime { get; init; }
+    public DateTime? ModifiedDateTime { get; init; }
+}

--- a/src/Koinon.Application/DTOs/Requests/RecordAttendanceRequest.cs
+++ b/src/Koinon.Application/DTOs/Requests/RecordAttendanceRequest.cs
@@ -1,0 +1,22 @@
+namespace Koinon.Application.DTOs.Requests;
+
+/// <summary>
+/// Request to record attendance for a group meeting.
+/// </summary>
+public record RecordAttendanceRequest
+{
+    /// <summary>
+    /// Date of the meeting occurrence.
+    /// </summary>
+    public required DateOnly OccurrenceDate { get; init; }
+
+    /// <summary>
+    /// List of person IdKeys who attended.
+    /// </summary>
+    public required IReadOnlyList<string> AttendedPersonIds { get; init; }
+
+    /// <summary>
+    /// Optional notes about the meeting.
+    /// </summary>
+    public string? Notes { get; init; }
+}

--- a/src/Koinon.Application/DTOs/Requests/UpdateGroupMemberRequest.cs
+++ b/src/Koinon.Application/DTOs/Requests/UpdateGroupMemberRequest.cs
@@ -1,0 +1,22 @@
+namespace Koinon.Application.DTOs.Requests;
+
+/// <summary>
+/// Request to update a group member's role or status.
+/// </summary>
+public record UpdateGroupMemberRequest
+{
+    /// <summary>
+    /// Optional new role IdKey for the member.
+    /// </summary>
+    public string? RoleId { get; init; }
+
+    /// <summary>
+    /// Optional new status (Active, Inactive, Pending).
+    /// </summary>
+    public string? Status { get; init; }
+
+    /// <summary>
+    /// Optional note about the member.
+    /// </summary>
+    public string? Note { get; init; }
+}

--- a/src/Koinon.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Koinon.Application/Extensions/ServiceCollectionExtensions.cs
@@ -34,6 +34,7 @@ public static class ServiceCollectionExtensions
         // Core entity services
         services.AddScoped<IPersonService, PersonService>();
         services.AddScoped<IGroupService, GroupService>();
+        services.AddScoped<IMyGroupsService, MyGroupsService>();
         services.AddScoped<IFamilyService, FamilyService>();
         services.AddScoped<IScheduleService, ScheduleService>();
         services.AddScoped<IDashboardService, DashboardService>();

--- a/src/Koinon.Application/Interfaces/IMyGroupsService.cs
+++ b/src/Koinon.Application/Interfaces/IMyGroupsService.cs
@@ -1,0 +1,49 @@
+using Koinon.Application.Common;
+using Koinon.Application.DTOs;
+using Koinon.Application.DTOs.Requests;
+
+namespace Koinon.Application.Interfaces;
+
+/// <summary>
+/// Service interface for managing groups where the current user is a leader.
+/// </summary>
+public interface IMyGroupsService
+{
+    /// <summary>
+    /// Gets all groups where the current user is a leader.
+    /// </summary>
+    Task<IReadOnlyList<MyGroupDto>> GetMyGroupsAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets detailed member information for a group (only if current user is a leader).
+    /// Includes contact information that is not available in public views.
+    /// </summary>
+    Task<Result<IReadOnlyList<GroupMemberDetailDto>>> GetGroupMembersWithContactInfoAsync(
+        string groupIdKey,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates a group member's role or status (only if current user is a leader).
+    /// </summary>
+    Task<Result<GroupMemberDetailDto>> UpdateGroupMemberAsync(
+        string groupIdKey,
+        string memberIdKey,
+        UpdateGroupMemberRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Removes a member from the group (only if current user is a leader).
+    /// </summary>
+    Task<Result> RemoveGroupMemberAsync(
+        string groupIdKey,
+        string memberIdKey,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Records attendance for a group meeting (only if current user is a leader).
+    /// </summary>
+    Task<Result> RecordAttendanceAsync(
+        string groupIdKey,
+        RecordAttendanceRequest request,
+        CancellationToken ct = default);
+}

--- a/src/Koinon.Application/Services/MyGroupsService.cs
+++ b/src/Koinon.Application/Services/MyGroupsService.cs
@@ -1,0 +1,487 @@
+using FluentValidation;
+using Koinon.Application.Common;
+using Koinon.Application.DTOs;
+using Koinon.Application.DTOs.Requests;
+using Koinon.Application.Interfaces;
+using Koinon.Domain.Data;
+using Koinon.Domain.Entities;
+using Koinon.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Koinon.Application.Services;
+
+/// <summary>
+/// Service for managing groups where the current user is a leader.
+/// Provides leader-specific functionality including member management and attendance tracking.
+/// </summary>
+public class MyGroupsService(
+    IApplicationDbContext context,
+    IUserContext userContext,
+    IValidator<UpdateGroupMemberRequest> updateMemberValidator,
+    IValidator<RecordAttendanceRequest> recordAttendanceValidator,
+    ILogger<MyGroupsService> logger) : IMyGroupsService
+{
+    public async Task<IReadOnlyList<MyGroupDto>> GetMyGroupsAsync(CancellationToken ct = default)
+    {
+        var currentPersonId = userContext.CurrentPersonId;
+        if (!currentPersonId.HasValue)
+        {
+            return Array.Empty<MyGroupDto>();
+        }
+
+        // Get groups where current user is a leader
+        var leaderGroups = await context.GroupMembers
+            .AsNoTracking()
+            .Include(gm => gm.Group)
+                .ThenInclude(g => g!.GroupType)
+            .Include(gm => gm.Group)
+                .ThenInclude(g => g!.Campus)
+            .Include(gm => gm.GroupRole)
+            .Where(gm => gm.PersonId == currentPersonId.Value
+                && gm.GroupMemberStatus == GroupMemberStatus.Active
+                && gm.GroupRole!.IsLeader
+                && !gm.Group!.IsArchived
+                && !gm.Group.GroupType!.IsFamilyGroupType)
+            .Select(gm => gm.Group!)
+            .Distinct()
+            .ToListAsync(ct);
+
+        var groupIds = leaderGroups.Select(g => g.Id).ToList();
+
+        // Get member counts
+        var memberCounts = await context.GroupMembers
+            .Where(gm => groupIds.Contains(gm.GroupId) && gm.GroupMemberStatus == GroupMemberStatus.Active)
+            .GroupBy(gm => gm.GroupId)
+            .Select(g => new { GroupId = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.GroupId, x => x.Count, ct);
+
+        // Get last meeting dates from attendance occurrences
+        var lastMeetingDates = await context.AttendanceOccurrences
+            .Where(ao => groupIds.Contains(ao.GroupId!.Value) && ao.DidNotOccur != true)
+            .GroupBy(ao => ao.GroupId)
+            .Select(g => new
+            {
+                GroupId = g.Key!.Value,
+                LastMeetingDate = g.Max(ao => ao.OccurrenceDate)
+            })
+            .ToDictionaryAsync(x => x.GroupId, x => (DateTime?)x.LastMeetingDate.ToDateTime(TimeOnly.MinValue), ct);
+
+        // Map to DTOs
+        var result = leaderGroups.Select(g => new MyGroupDto
+        {
+            IdKey = g.IdKey,
+            Guid = g.Guid,
+            Name = g.Name,
+            Description = g.Description,
+            GroupTypeName = g.GroupType?.Name ?? "Unknown",
+            IsActive = g.IsActive,
+            MemberCount = memberCounts.ContainsKey(g.Id) ? memberCounts[g.Id] : 0,
+            GroupCapacity = g.GroupCapacity,
+            LastMeetingDate = lastMeetingDates.ContainsKey(g.Id) ? lastMeetingDates[g.Id] : null,
+            Campus = g.Campus != null ? new CampusSummaryDto
+            {
+                IdKey = g.Campus.IdKey,
+                Name = g.Campus.Name,
+                ShortCode = g.Campus.ShortCode
+            } : null,
+            CreatedDateTime = g.CreatedDateTime,
+            ModifiedDateTime = g.ModifiedDateTime
+        }).OrderBy(g => g.Name).ToList();
+
+        logger.LogInformation(
+            "Retrieved {Count} groups for leader PersonIdKey={PersonIdKey}",
+            result.Count, IdKeyHelper.Encode(currentPersonId.Value));
+
+        return result;
+    }
+
+    public async Task<Result<IReadOnlyList<GroupMemberDetailDto>>> GetGroupMembersWithContactInfoAsync(
+        string groupIdKey,
+        CancellationToken ct = default)
+    {
+        if (!IdKeyHelper.TryDecode(groupIdKey, out int groupId))
+        {
+            return Result<IReadOnlyList<GroupMemberDetailDto>>.Failure(Error.NotFound("Group", groupIdKey));
+        }
+
+        // Verify user is a leader of this group
+        if (!await IsGroupLeaderAsync(groupId, ct))
+        {
+            return Result<IReadOnlyList<GroupMemberDetailDto>>.Failure(
+                Error.Forbidden("You must be a leader of this group to view member contact information"));
+        }
+
+        // Get members with contact info
+        var members = await context.GroupMembers
+            .AsNoTracking()
+            .Include(gm => gm.Person)
+                .ThenInclude(p => p!.PhoneNumbers)
+            .Include(gm => gm.GroupRole)
+            .Where(gm => gm.GroupId == groupId && gm.GroupMemberStatus == GroupMemberStatus.Active)
+            .OrderBy(gm => gm.GroupRole!.Order)
+            .ThenBy(gm => gm.Person!.LastName)
+            .ThenBy(gm => gm.Person!.FirstName)
+            .ToListAsync(ct);
+
+        var memberDtos = members.Select(m => new GroupMemberDetailDto
+        {
+            IdKey = m.IdKey,
+            PersonIdKey = m.Person!.IdKey,
+            FirstName = m.Person.FirstName,
+            LastName = m.Person.LastName,
+            FullName = m.Person.FullName,
+            Email = m.Person.Email,
+            Phone = m.Person.PhoneNumbers
+                .Where(pn => pn.NumberTypeValue != null)
+                .OrderBy(pn => pn.NumberTypeValue!.Order)
+                .FirstOrDefault()?.Number,
+            PhotoUrl = null, // Photo URLs will be implemented in future work unit
+            Age = m.Person.BirthDate.HasValue
+                ? DateTime.UtcNow.Year - m.Person.BirthDate.Value.Year
+                : null,
+            Gender = m.Person.Gender.ToString(),
+            Role = new GroupTypeRoleDto
+            {
+                IdKey = m.GroupRole!.IdKey,
+                Name = m.GroupRole.Name,
+                IsLeader = m.GroupRole.IsLeader
+            },
+            Status = m.GroupMemberStatus.ToString(),
+            DateTimeAdded = m.DateTimeAdded,
+            InactiveDateTime = m.InactiveDateTime,
+            Note = m.Note
+        }).ToList();
+
+        logger.LogInformation(
+            "Retrieved {Count} members with contact info for group {GroupIdKey}",
+            memberDtos.Count, groupIdKey);
+
+        return Result<IReadOnlyList<GroupMemberDetailDto>>.Success(memberDtos);
+    }
+
+    public async Task<Result<GroupMemberDetailDto>> UpdateGroupMemberAsync(
+        string groupIdKey,
+        string memberIdKey,
+        UpdateGroupMemberRequest request,
+        CancellationToken ct = default)
+    {
+        // Validate
+        var validation = await updateMemberValidator.ValidateAsync(request, ct);
+        if (!validation.IsValid)
+        {
+            return Result<GroupMemberDetailDto>.Failure(Error.FromFluentValidation(validation));
+        }
+
+        if (!IdKeyHelper.TryDecode(groupIdKey, out int groupId))
+        {
+            return Result<GroupMemberDetailDto>.Failure(Error.NotFound("Group", groupIdKey));
+        }
+
+        if (!IdKeyHelper.TryDecode(memberIdKey, out int memberId))
+        {
+            return Result<GroupMemberDetailDto>.Failure(Error.NotFound("GroupMember", memberIdKey));
+        }
+
+        // Verify user is a leader of this group
+        if (!await IsGroupLeaderAsync(groupId, ct))
+        {
+            return Result<GroupMemberDetailDto>.Failure(
+                Error.Forbidden("You must be a leader of this group to update members"));
+        }
+
+        // Get the group member
+        var groupMember = await context.GroupMembers
+            .Include(gm => gm.Group)
+                .ThenInclude(g => g!.GroupType)
+            .Include(gm => gm.Person)
+                .ThenInclude(p => p!.PhoneNumbers)
+            .Include(gm => gm.GroupRole)
+            .FirstOrDefaultAsync(gm => gm.Id == memberId && gm.GroupId == groupId, ct);
+
+        if (groupMember is null)
+        {
+            return Result<GroupMemberDetailDto>.Failure(Error.NotFound("GroupMember", memberIdKey));
+        }
+
+        // Update role if provided
+        if (!string.IsNullOrWhiteSpace(request.RoleId))
+        {
+            if (!IdKeyHelper.TryDecode(request.RoleId, out int roleId))
+            {
+                return Result<GroupMemberDetailDto>.Failure(Error.NotFound("Role", request.RoleId));
+            }
+
+            var role = await context.GroupTypeRoles
+                .FirstOrDefaultAsync(r => r.Id == roleId && r.GroupTypeId == groupMember.Group!.GroupTypeId, ct);
+
+            if (role is null)
+            {
+                return Result<GroupMemberDetailDto>.Failure(
+                    Error.UnprocessableEntity("Role is not valid for this group type"));
+            }
+
+            groupMember.GroupRoleId = roleId;
+        }
+
+        // Update status if provided
+        if (!string.IsNullOrWhiteSpace(request.Status))
+        {
+            if (!Enum.TryParse<GroupMemberStatus>(request.Status, out var status))
+            {
+                return Result<GroupMemberDetailDto>.Failure(
+                    Error.UnprocessableEntity("Invalid status value"));
+            }
+
+            groupMember.GroupMemberStatus = status;
+
+            if (status == GroupMemberStatus.Inactive && groupMember.InactiveDateTime is null)
+            {
+                groupMember.InactiveDateTime = DateTime.UtcNow;
+            }
+            else if (status == GroupMemberStatus.Active)
+            {
+                groupMember.InactiveDateTime = null;
+            }
+        }
+
+        // Update note if provided
+        if (request.Note != null)
+        {
+            groupMember.Note = request.Note;
+        }
+
+        groupMember.ModifiedDateTime = DateTime.UtcNow;
+
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation(
+            "Updated group member {MemberIdKey} in group {GroupIdKey}",
+            memberIdKey, groupIdKey);
+
+        // Map from the already-tracked entity instead of re-querying
+        var memberDto = new GroupMemberDetailDto
+        {
+            IdKey = groupMember.IdKey,
+            PersonIdKey = groupMember.Person!.IdKey,
+            FirstName = groupMember.Person.FirstName,
+            LastName = groupMember.Person.LastName,
+            FullName = groupMember.Person.FullName,
+            Email = groupMember.Person.Email,
+            Phone = groupMember.Person.PhoneNumbers
+                .Where(pn => pn.NumberTypeValue != null)
+                .OrderBy(pn => pn.NumberTypeValue!.Order)
+                .FirstOrDefault()?.Number,
+            PhotoUrl = null,
+            Age = groupMember.Person.BirthDate.HasValue
+                ? DateTime.UtcNow.Year - groupMember.Person.BirthDate.Value.Year
+                : null,
+            Gender = groupMember.Person.Gender.ToString(),
+            Role = new GroupTypeRoleDto
+            {
+                IdKey = groupMember.GroupRole!.IdKey,
+                Name = groupMember.GroupRole.Name,
+                IsLeader = groupMember.GroupRole.IsLeader
+            },
+            Status = groupMember.GroupMemberStatus.ToString(),
+            DateTimeAdded = groupMember.DateTimeAdded,
+            InactiveDateTime = groupMember.InactiveDateTime,
+            Note = groupMember.Note
+        };
+
+        return Result<GroupMemberDetailDto>.Success(memberDto);
+    }
+
+    public async Task<Result> RemoveGroupMemberAsync(
+        string groupIdKey,
+        string memberIdKey,
+        CancellationToken ct = default)
+    {
+        if (!IdKeyHelper.TryDecode(groupIdKey, out int groupId))
+        {
+            return Result.Failure(Error.NotFound("Group", groupIdKey));
+        }
+
+        if (!IdKeyHelper.TryDecode(memberIdKey, out int memberId))
+        {
+            return Result.Failure(Error.NotFound("GroupMember", memberIdKey));
+        }
+
+        // Verify user is a leader of this group
+        if (!await IsGroupLeaderAsync(groupId, ct))
+        {
+            return Result.Failure(
+                Error.Forbidden("You must be a leader of this group to remove members"));
+        }
+
+        // Get the group member
+        var groupMember = await context.GroupMembers
+            .FirstOrDefaultAsync(gm => gm.Id == memberId && gm.GroupId == groupId, ct);
+
+        if (groupMember is null)
+        {
+            return Result.Failure(Error.NotFound("GroupMember", memberIdKey));
+        }
+
+        // Soft delete by marking as inactive
+        groupMember.GroupMemberStatus = GroupMemberStatus.Inactive;
+        groupMember.InactiveDateTime = DateTime.UtcNow;
+        groupMember.ModifiedDateTime = DateTime.UtcNow;
+
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation(
+            "Removed group member {MemberIdKey} from group {GroupIdKey}",
+            memberIdKey, groupIdKey);
+
+        return Result.Success();
+    }
+
+    public async Task<Result> RecordAttendanceAsync(
+        string groupIdKey,
+        RecordAttendanceRequest request,
+        CancellationToken ct = default)
+    {
+        // Validate
+        var validation = await recordAttendanceValidator.ValidateAsync(request, ct);
+        if (!validation.IsValid)
+        {
+            return Result.Failure(Error.FromFluentValidation(validation));
+        }
+
+        if (!IdKeyHelper.TryDecode(groupIdKey, out int groupId))
+        {
+            return Result.Failure(Error.NotFound("Group", groupIdKey));
+        }
+
+        // Verify user is a leader of this group
+        if (!await IsGroupLeaderAsync(groupId, ct))
+        {
+            return Result.Failure(
+                Error.Forbidden("You must be a leader of this group to record attendance"));
+        }
+
+        // Calculate Sunday date for the occurrence
+        var occurrenceDateTime = request.OccurrenceDate.ToDateTime(TimeOnly.MinValue);
+        var daysSinceSunday = ((int)occurrenceDateTime.DayOfWeek + 7) % 7;
+        var sundayDate = DateOnly.FromDateTime(occurrenceDateTime.AddDays(-daysSinceSunday));
+
+        // Check if occurrence already exists
+        var occurrence = await context.AttendanceOccurrences
+            .FirstOrDefaultAsync(ao => ao.GroupId == groupId && ao.OccurrenceDate == request.OccurrenceDate, ct);
+
+        if (occurrence is null)
+        {
+            // Create new occurrence
+            occurrence = new AttendanceOccurrence
+            {
+                GroupId = groupId,
+                OccurrenceDate = request.OccurrenceDate,
+                SundayDate = sundayDate,
+                Notes = request.Notes,
+                CreatedDateTime = DateTime.UtcNow
+            };
+
+            await context.AttendanceOccurrences.AddAsync(occurrence, ct);
+            await context.SaveChangesAsync(ct);
+        }
+        else
+        {
+            // Update notes if provided
+            if (request.Notes != null)
+            {
+                occurrence.Notes = request.Notes;
+                occurrence.ModifiedDateTime = DateTime.UtcNow;
+            }
+        }
+
+        // Get PersonAlias IDs for attendees
+        var attendedPersonIds = new List<int>();
+        foreach (var personIdKey in request.AttendedPersonIds)
+        {
+            if (IdKeyHelper.TryDecode(personIdKey, out int personId))
+            {
+                attendedPersonIds.Add(personId);
+            }
+        }
+
+        // Get primary PersonAlias for each person
+        var personAliasMap = await context.PersonAliases
+            .Where(pa => attendedPersonIds.Contains(pa.PersonId!.Value) && pa.AliasPersonId == pa.PersonId)
+            .ToDictionaryAsync(pa => pa.PersonId!.Value, pa => pa.Id, ct);
+
+        // Get existing attendance records for this occurrence
+        var existingAttendance = await context.Attendances
+            .Where(a => a.OccurrenceId == occurrence.Id)
+            .ToListAsync(ct);
+
+        // Mark all existing as not attended
+        foreach (var existing in existingAttendance)
+        {
+            existing.DidAttend = false;
+            existing.ModifiedDateTime = DateTime.UtcNow;
+        }
+
+        // Create or update attendance records for attendees
+        foreach (var personId in attendedPersonIds)
+        {
+            if (!personAliasMap.TryGetValue(personId, out int personAliasId))
+            {
+                continue;
+            }
+
+            var attendance = existingAttendance.FirstOrDefault(a => a.PersonAliasId == personAliasId);
+
+            if (attendance is null)
+            {
+                attendance = new Attendance
+                {
+                    OccurrenceId = occurrence.Id,
+                    PersonAliasId = personAliasId,
+                    StartDateTime = occurrenceDateTime,
+                    DidAttend = true,
+                    CreatedDateTime = DateTime.UtcNow
+                };
+
+                await context.Attendances.AddAsync(attendance, ct);
+            }
+            else
+            {
+                attendance.DidAttend = true;
+                attendance.ModifiedDateTime = DateTime.UtcNow;
+            }
+        }
+
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation(
+            "Recorded attendance for group {GroupIdKey} on {OccurrenceDate} with {Count} attendees",
+            groupIdKey, request.OccurrenceDate, attendedPersonIds.Count);
+
+        return Result.Success();
+    }
+
+    private async Task<bool> IsGroupLeaderAsync(int groupId, CancellationToken ct)
+    {
+        var currentPersonId = userContext.CurrentPersonId;
+        if (!currentPersonId.HasValue)
+        {
+            return false;
+        }
+
+        // Check if user is a staff/admin role (can access all groups)
+        if (userContext.IsInRole("Staff") || userContext.IsInRole("Admin"))
+        {
+            return true;
+        }
+
+        // Check if user is a leader of this specific group
+        return await context.GroupMembers
+            .AsNoTracking()
+            .Include(gm => gm.GroupRole)
+            .AnyAsync(gm => gm.GroupId == groupId
+                && gm.PersonId == currentPersonId.Value
+                && gm.GroupMemberStatus == GroupMemberStatus.Active
+                && gm.GroupRole!.IsLeader, ct);
+    }
+}

--- a/src/Koinon.Application/Validators/RecordAttendanceRequestValidator.cs
+++ b/src/Koinon.Application/Validators/RecordAttendanceRequestValidator.cs
@@ -1,0 +1,24 @@
+using FluentValidation;
+using Koinon.Application.DTOs.Requests;
+
+namespace Koinon.Application.Validators;
+
+/// <summary>
+/// Validator for RecordAttendanceRequest.
+/// </summary>
+public class RecordAttendanceRequestValidator : AbstractValidator<RecordAttendanceRequest>
+{
+    public RecordAttendanceRequestValidator()
+    {
+        RuleFor(x => x.OccurrenceDate)
+            .NotEmpty().WithMessage("Occurrence date is required");
+
+        RuleFor(x => x.AttendedPersonIds)
+            .NotNull().WithMessage("Attended person IDs list is required")
+            .NotEmpty().WithMessage("At least one attendee must be recorded");
+
+        RuleFor(x => x.Notes)
+            .MaximumLength(2000).WithMessage("Notes cannot exceed 2000 characters")
+            .When(x => x.Notes != null);
+    }
+}

--- a/src/Koinon.Application/Validators/UpdateGroupMemberRequestValidator.cs
+++ b/src/Koinon.Application/Validators/UpdateGroupMemberRequestValidator.cs
@@ -1,0 +1,25 @@
+using FluentValidation;
+using Koinon.Application.DTOs.Requests;
+
+namespace Koinon.Application.Validators;
+
+/// <summary>
+/// Validator for UpdateGroupMemberRequest.
+/// </summary>
+public class UpdateGroupMemberRequestValidator : AbstractValidator<UpdateGroupMemberRequest>
+{
+    public UpdateGroupMemberRequestValidator()
+    {
+        RuleFor(x => x.Status)
+            .Must(status => status == null ||
+                           status == "Active" ||
+                           status == "Inactive" ||
+                           status == "Pending")
+            .WithMessage("Status must be one of: Active, Inactive, Pending")
+            .When(x => x.Status != null);
+
+        RuleFor(x => x.Note)
+            .MaximumLength(1000).WithMessage("Note cannot exceed 1000 characters")
+            .When(x => x.Note != null);
+    }
+}

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -34,6 +34,7 @@ import {
 } from './pages/admin/schedules';
 import { PWAUpdatePrompt, InstallPrompt } from './components/pwa';
 import { GroupFinderPage } from './pages/public/GroupFinderPage';
+import { MyGroupsPage } from './pages/MyGroupsPage';
 
 function HomePage() {
   const { isAuthenticated } = useAuth();
@@ -162,6 +163,16 @@ function App() {
 
         {/* Public routes (no auth required) */}
         <Route path="/groups" element={<GroupFinderPage />} />
+
+        {/* My Groups - Protected route for group leaders */}
+        <Route
+          path="/my-groups"
+          element={
+            <ProtectedRoute>
+              <MyGroupsPage />
+            </ProtectedRoute>
+          }
+        />
 
         {/* Legacy people route - redirect to admin */}
         <Route

--- a/src/web/src/components/mygroups/EditMemberModal.tsx
+++ b/src/web/src/components/mygroups/EditMemberModal.tsx
@@ -1,0 +1,155 @@
+/**
+ * Edit Member Modal Component
+ * Modal for editing member status and notes
+ */
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/Button';
+import type { MyGroupMemberDetailDto } from '@/services/api/types';
+
+interface EditMemberModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  member: MyGroupMemberDetailDto | null;
+  onSave: (data: {
+    roleId?: string;
+    status?: string;
+    note?: string;
+  }) => Promise<void>;
+  isSaving: boolean;
+}
+
+export function EditMemberModal({
+  isOpen,
+  onClose,
+  member,
+  onSave,
+  isSaving,
+}: EditMemberModalProps) {
+  const [status, setStatus] = useState<string>('Active');
+  const [note, setNote] = useState('');
+
+  // Initialize form when member changes
+  useEffect(() => {
+    if (member) {
+      setStatus(member.status);
+      setNote(member.note || '');
+    }
+  }, [member]);
+
+  // Add escape key handler
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      return () => document.removeEventListener('keydown', handleEscape);
+    }
+  }, [isOpen, onClose]);
+
+  const handleSave = async () => {
+    const data: {
+      roleId?: string;
+      status?: string;
+      note?: string;
+    } = {};
+
+    // Only send changed values
+    if (member) {
+      if (status !== member.status) data.status = status;
+      if (note !== (member.note || '')) data.note = note;
+    }
+
+    await onSave(data);
+  };
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  if (!isOpen || !member) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:p-0">
+        {/* Backdrop */}
+        <div
+          className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+          onClick={handleClose}
+        />
+
+        {/* Modal */}
+        <div className="relative inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+          <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+            <div className="flex items-start justify-between mb-4">
+              <h3 className="text-lg font-medium text-gray-900">
+                Edit Member: {member.firstName} {member.lastName}
+              </h3>
+              <button
+                onClick={handleClose}
+                className="text-gray-400 hover:text-gray-500"
+                aria-label="Close"
+              >
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            {/* Status Dropdown */}
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Status
+              </label>
+              <select
+                value={status}
+                onChange={(e) => setStatus(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              >
+                <option value="Active">Active</option>
+                <option value="Inactive">Inactive</option>
+                <option value="Pending">Pending</option>
+              </select>
+            </div>
+
+            {/* Note Textarea */}
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Note
+              </label>
+              <textarea
+                value={note}
+                onChange={(e) => setNote(e.target.value)}
+                rows={3}
+                placeholder="Add a note about this member..."
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse gap-3">
+            <Button onClick={handleSave} loading={isSaving} disabled={isSaving}>
+              Save Changes
+            </Button>
+            <Button variant="outline" onClick={handleClose} disabled={isSaving}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/mygroups/GroupMemberList.tsx
+++ b/src/web/src/components/mygroups/GroupMemberList.tsx
@@ -1,0 +1,185 @@
+/**
+ * Group Member List Component
+ * Displays and manages members of a group
+ */
+
+import { useState } from 'react';
+import { EditMemberModal } from './EditMemberModal';
+import { formatDate } from '@/lib/utils';
+import type { MyGroupMemberDetailDto } from '@/services/api/types';
+
+interface GroupMemberListProps {
+  members: MyGroupMemberDetailDto[];
+  onUpdateMember: (
+    memberIdKey: string,
+    data: {
+      roleId?: string;
+      status?: string;
+      note?: string;
+    }
+  ) => Promise<void>;
+  onRemoveMember: (memberIdKey: string) => Promise<void>;
+  isUpdating: boolean;
+  isRemoving: boolean;
+}
+
+export function GroupMemberList({
+  members,
+  onUpdateMember,
+  onRemoveMember,
+  isUpdating,
+  isRemoving,
+}: GroupMemberListProps) {
+  const [editingMember, setEditingMember] = useState<MyGroupMemberDetailDto | null>(null);
+  const [removingMemberId, setRemovingMemberId] = useState<string | null>(null);
+
+  const handleEditClick = (member: MyGroupMemberDetailDto) => {
+    setEditingMember(member);
+  };
+
+  const handleRemoveClick = async (member: MyGroupMemberDetailDto) => {
+    if (
+      window.confirm(
+        `Are you sure you want to remove ${member.firstName} ${member.lastName} from this group?`
+      )
+    ) {
+      setRemovingMemberId(member.idKey);
+      try {
+        await onRemoveMember(member.idKey);
+      } finally {
+        setRemovingMemberId(null);
+      }
+    }
+  };
+
+  const handleSaveEdit = async (data: {
+    roleId?: string;
+    status?: string;
+    note?: string;
+  }) => {
+    if (!editingMember) return;
+
+    await onUpdateMember(editingMember.idKey, data);
+    setEditingMember(null);
+  };
+
+  const getStatusBadgeClass = (status: string) => {
+    switch (status) {
+      case 'Active':
+        return 'bg-green-100 text-green-800';
+      case 'Inactive':
+        return 'bg-gray-100 text-gray-800';
+      case 'Pending':
+        return 'bg-yellow-100 text-yellow-800';
+      default:
+        return 'bg-gray-100 text-gray-800';
+    }
+  };
+
+  if (members.length === 0) {
+    return (
+      <div className="text-center py-12 bg-gray-50 rounded-lg">
+        <p className="text-gray-500">No members in this group yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Name
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Email
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Phone
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Role
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Status
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Joined
+              </th>
+              <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Actions
+              </th>
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-200">
+            {members.map((member) => (
+              <tr key={member.idKey} className="hover:bg-gray-50">
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className="text-sm font-medium text-gray-900">
+                    {member.firstName} {member.lastName}
+                  </div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className="text-sm text-gray-500">{member.email || '-'}</div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <div className="text-sm text-gray-500">{member.phone || '-'}</div>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  {member.role.isLeader && (
+                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                      {member.role.name}
+                    </span>
+                  )}
+                  {!member.role.isLeader && (
+                    <span className="text-sm text-gray-500">{member.role.name}</span>
+                  )}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap">
+                  <span
+                    className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusBadgeClass(
+                      member.status
+                    )}`}
+                  >
+                    {member.status}
+                  </span>
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                  {member.dateTimeAdded ? formatDate(member.dateTimeAdded) : '-'}
+                </td>
+                <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                  <div className="flex justify-end gap-2">
+                    <button
+                      onClick={() => handleEditClick(member)}
+                      disabled={isUpdating || isRemoving}
+                      className="text-blue-600 hover:text-blue-900 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      onClick={() => handleRemoveClick(member)}
+                      disabled={isRemoving || removingMemberId === member.idKey}
+                      className="text-red-600 hover:text-red-900 disabled:opacity-50 disabled:cursor-not-allowed"
+                    >
+                      {removingMemberId === member.idKey ? 'Removing...' : 'Remove'}
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <EditMemberModal
+        isOpen={!!editingMember}
+        onClose={() => setEditingMember(null)}
+        member={editingMember}
+        onSave={handleSaveEdit}
+        isSaving={isUpdating}
+      />
+    </>
+  );
+}

--- a/src/web/src/components/mygroups/TakeAttendanceModal.tsx
+++ b/src/web/src/components/mygroups/TakeAttendanceModal.tsx
@@ -1,0 +1,177 @@
+/**
+ * Take Attendance Modal Component
+ * Modal for recording attendance at a group meeting
+ */
+
+import { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/Button';
+import type { MyGroupMemberDetailDto } from '@/services/api/types';
+
+interface TakeAttendanceModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  members: MyGroupMemberDetailDto[];
+  onSubmit: (occurrenceDate: string, attendedPersonIds: string[]) => Promise<void>;
+  isSubmitting: boolean;
+}
+
+interface AttendanceState {
+  [personIdKey: string]: boolean;
+}
+
+export function TakeAttendanceModal({
+  isOpen,
+  onClose,
+  members,
+  onSubmit,
+  isSubmitting,
+}: TakeAttendanceModalProps) {
+  // Default to today
+  const today = new Date().toISOString().split('T')[0];
+  const [occurrenceDate, setOccurrenceDate] = useState(today);
+  const [attendance, setAttendance] = useState<AttendanceState>({});
+
+  // Add escape key handler
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    if (isOpen) {
+      document.addEventListener('keydown', handleEscape);
+      return () => document.removeEventListener('keydown', handleEscape);
+    }
+  }, [isOpen, onClose]);
+
+  const handleToggleAttendance = (personIdKey: string) => {
+    setAttendance((prev) => ({
+      ...prev,
+      [personIdKey]: !prev[personIdKey],
+    }));
+  };
+
+  const handleSubmit = async () => {
+    const attendedIds = members
+      .filter(m => attendance[m.personIdKey])
+      .map(m => m.personIdKey);
+
+    await onSubmit(occurrenceDate, attendedIds);
+
+    // Reset form
+    setOccurrenceDate(today);
+    setAttendance({});
+  };
+
+  const handleClose = () => {
+    // Reset form
+    setOccurrenceDate(today);
+    setAttendance({});
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  const attendedCount = Object.values(attendance).filter((a) => a).length;
+
+  return (
+    <div className="fixed inset-0 z-50 overflow-y-auto">
+      <div className="flex items-center justify-center min-h-screen px-4 pt-4 pb-20 text-center sm:p-0">
+        {/* Backdrop */}
+        <div
+          className="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity"
+          onClick={handleClose}
+        />
+
+        {/* Modal */}
+        <div className="relative inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-2xl sm:w-full">
+          <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
+            <div className="flex items-start justify-between mb-4">
+              <div>
+                <h3 className="text-lg font-medium text-gray-900">Take Attendance</h3>
+                <p className="text-sm text-gray-500 mt-1">
+                  {attendedCount} of {members.length} attended
+                </p>
+              </div>
+              <button
+                onClick={handleClose}
+                className="text-gray-400 hover:text-gray-500"
+                aria-label="Close"
+              >
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M6 18L18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            {/* Date Picker */}
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Meeting Date
+              </label>
+              <input
+                type="date"
+                value={occurrenceDate}
+                onChange={(e) => setOccurrenceDate(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              />
+            </div>
+
+            {/* Members List */}
+            <div className="mb-4 max-h-96 overflow-y-auto border border-gray-200 rounded-lg">
+              {members.length === 0 ? (
+                <div className="p-4 text-center text-gray-500">No members to record</div>
+              ) : (
+                <div className="divide-y divide-gray-200">
+                  {members.map((member) => (
+                    <div key={member.idKey} className="p-3">
+                      <div className="flex items-center gap-3">
+                        <input
+                          type="checkbox"
+                          id={`attend-${member.idKey}`}
+                          checked={attendance[member.personIdKey] || false}
+                          onChange={() => handleToggleAttendance(member.personIdKey)}
+                          className="w-4 h-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+                        />
+                        <label
+                          htmlFor={`attend-${member.idKey}`}
+                          className="flex-1 text-sm font-medium text-gray-900 cursor-pointer"
+                        >
+                          {member.firstName} {member.lastName}
+                          {member.role.isLeader && (
+                            <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                              {member.role.name}
+                            </span>
+                          )}
+                        </label>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Actions */}
+          <div className="bg-gray-50 px-4 py-3 sm:px-6 sm:flex sm:flex-row-reverse gap-3">
+            <Button onClick={handleSubmit} loading={isSubmitting} disabled={isSubmitting}>
+              Record Attendance
+            </Button>
+            <Button variant="outline" onClick={handleClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/hooks/useMyGroups.ts
+++ b/src/web/src/hooks/useMyGroups.ts
@@ -1,0 +1,90 @@
+/**
+ * My Groups hooks using TanStack Query
+ * For group leaders to manage their groups
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import * as myGroupsApi from '@/services/api/myGroups';
+import type { RecordGroupAttendanceRequest } from '@/services/api/types';
+
+/**
+ * Get all groups where current user is a leader
+ */
+export function useMyGroups() {
+  return useQuery({
+    queryKey: ['my-groups'],
+    queryFn: () => myGroupsApi.getMyGroups(),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}
+
+/**
+ * Get members of a specific group
+ */
+export function useMyGroupMembers(groupIdKey?: string) {
+  return useQuery({
+    queryKey: ['my-groups', groupIdKey, 'members'],
+    queryFn: () => myGroupsApi.getMyGroupMembers(groupIdKey!),
+    enabled: !!groupIdKey,
+    staleTime: 2 * 60 * 1000, // 2 minutes (fresher for member data)
+  });
+}
+
+/**
+ * Update a group member (role, status, note)
+ */
+export function useUpdateGroupMember(groupIdKey: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      memberIdKey,
+      data,
+    }: {
+      memberIdKey: string;
+      data: {
+        roleId?: string;
+        status?: string;
+        note?: string;
+      };
+    }) => myGroupsApi.updateGroupMember(groupIdKey, memberIdKey, data),
+    onSuccess: () => {
+      // Invalidate members list to refetch
+      queryClient.invalidateQueries({ queryKey: ['my-groups', groupIdKey, 'members'] });
+      queryClient.invalidateQueries({ queryKey: ['my-groups'] });
+    },
+  });
+}
+
+/**
+ * Remove a member from a group
+ */
+export function useRemoveGroupMember(groupIdKey: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (memberIdKey: string) =>
+      myGroupsApi.removeGroupMember(groupIdKey, memberIdKey),
+    onSuccess: () => {
+      // Invalidate members list to refetch
+      queryClient.invalidateQueries({ queryKey: ['my-groups', groupIdKey, 'members'] });
+      queryClient.invalidateQueries({ queryKey: ['my-groups'] });
+    },
+  });
+}
+
+/**
+ * Record attendance for a group meeting
+ */
+export function useRecordAttendance(groupIdKey: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: RecordGroupAttendanceRequest) =>
+      myGroupsApi.recordAttendance(groupIdKey, request),
+    onSuccess: () => {
+      // Invalidate groups list to update last meeting date
+      queryClient.invalidateQueries({ queryKey: ['my-groups'] });
+    },
+  });
+}

--- a/src/web/src/pages/MyGroupsPage.tsx
+++ b/src/web/src/pages/MyGroupsPage.tsx
@@ -1,0 +1,245 @@
+/**
+ * My Groups Page
+ * Dashboard for group leaders to manage their groups and members
+ */
+
+import { useState } from 'react';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { GroupMemberList } from '@/components/mygroups/GroupMemberList';
+import { TakeAttendanceModal } from '@/components/mygroups/TakeAttendanceModal';
+import {
+  useMyGroups,
+  useMyGroupMembers,
+  useUpdateGroupMember,
+  useRemoveGroupMember,
+  useRecordAttendance,
+} from '@/hooks/useMyGroups';
+import { formatDate } from '@/lib/utils';
+import type { MyGroupDto } from '@/services/api/types';
+
+export function MyGroupsPage() {
+  const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
+  const [attendanceGroupId, setAttendanceGroupId] = useState<string | null>(null);
+
+  const { data: groups = [], isLoading, error } = useMyGroups();
+
+  const { data: members = [] } = useMyGroupMembers(expandedGroupId || undefined);
+
+  const updateMemberMutation = useUpdateGroupMember(expandedGroupId || '');
+  const removeMemberMutation = useRemoveGroupMember(expandedGroupId || '');
+  const recordAttendanceMutation = useRecordAttendance(attendanceGroupId || '');
+
+  const handleToggleGroup = (groupIdKey: string) => {
+    setExpandedGroupId((prev) => (prev === groupIdKey ? null : groupIdKey));
+  };
+
+  const handleTakeAttendance = (groupIdKey: string) => {
+    setAttendanceGroupId(groupIdKey);
+  };
+
+  const handleSubmitAttendance = async (
+    occurrenceDate: string,
+    attendedPersonIds: string[]
+  ) => {
+    await recordAttendanceMutation.mutateAsync({
+      occurrenceDate,
+      attendedPersonIds,
+    });
+    setAttendanceGroupId(null);
+  };
+
+  const handleUpdateMember = async (
+    memberIdKey: string,
+    data: {
+      roleId?: string;
+      status?: string;
+      note?: string;
+    }
+  ) => {
+    await updateMemberMutation.mutateAsync({ memberIdKey, data });
+  };
+
+  const handleRemoveMember = async (memberIdKey: string) => {
+    await removeMemberMutation.mutateAsync(memberIdKey);
+  };
+
+  const getCapacityColor = (group: MyGroupDto) => {
+    if (!group.groupCapacity) return 'text-gray-600';
+    const percentage = (group.memberCount / group.groupCapacity) * 100;
+    if (percentage >= 90) return 'text-red-600';
+    if (percentage >= 75) return 'text-yellow-600';
+    return 'text-green-600';
+  };
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <p className="text-gray-600">Loading your groups...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+        <div className="text-center">
+          <p className="text-red-600 mb-4">Failed to load groups</p>
+          <Button onClick={() => window.location.reload()}>Retry</Button>
+        </div>
+      </div>
+    );
+  }
+
+  const attendanceMembers = attendanceGroupId === expandedGroupId ? members : [];
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">My Groups</h1>
+          <p className="mt-2 text-gray-600">
+            Manage your groups and track member attendance
+          </p>
+        </div>
+
+        {/* Groups List */}
+        {groups.length === 0 ? (
+          <Card>
+            <div className="text-center py-12">
+              <svg
+                className="mx-auto h-12 w-12 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                />
+              </svg>
+              <h3 className="mt-2 text-sm font-medium text-gray-900">No groups</h3>
+              <p className="mt-1 text-sm text-gray-500">
+                You are not currently a leader of any groups.
+              </p>
+            </div>
+          </Card>
+        ) : (
+          <div className="space-y-4">
+            {groups.map((group) => (
+              <Card key={group.idKey}>
+                <div>
+                  {/* Group Header */}
+                  <div className="flex items-start justify-between">
+                    <div className="flex-1">
+                      <h2 className="text-xl font-semibold text-gray-900">
+                        {group.name}
+                      </h2>
+                      {group.description && (
+                        <p className="mt-1 text-sm text-gray-600">{group.description}</p>
+                      )}
+
+                      <div className="mt-3 flex flex-wrap gap-4 text-sm">
+                        <div className="flex items-center gap-2">
+                          <svg
+                            className="w-5 h-5 text-gray-400"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            aria-hidden="true"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                            />
+                          </svg>
+                          <span className={getCapacityColor(group)}>
+                            {group.memberCount}
+                            {group.groupCapacity && ` / ${group.groupCapacity}`} members
+                          </span>
+                        </div>
+
+                        {group.lastMeetingDate && (
+                          <div className="flex items-center gap-2">
+                            <svg
+                              className="w-5 h-5 text-gray-400"
+                              fill="none"
+                              stroke="currentColor"
+                              viewBox="0 0 24 24"
+                              aria-hidden="true"
+                            >
+                              <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                              />
+                            </svg>
+                            <span className="text-gray-600">
+                              Last met: {formatDate(group.lastMeetingDate)}
+                            </span>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="flex gap-2 ml-4">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => handleTakeAttendance(group.idKey)}
+                      >
+                        Take Attendance
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => handleToggleGroup(group.idKey)}
+                      >
+                        {expandedGroupId === group.idKey ? 'Hide' : 'View'} Members
+                      </Button>
+                    </div>
+                  </div>
+
+                  {/* Expanded Members List */}
+                  {expandedGroupId === group.idKey && (
+                    <div className="mt-6 pt-6 border-t border-gray-200">
+                      <h3 className="text-lg font-medium text-gray-900 mb-4">
+                        Group Members
+                      </h3>
+                      <GroupMemberList
+                        members={members}
+                        onUpdateMember={handleUpdateMember}
+                        onRemoveMember={handleRemoveMember}
+                        isUpdating={updateMemberMutation.isPending}
+                        isRemoving={removeMemberMutation.isPending}
+                      />
+                    </div>
+                  )}
+                </div>
+              </Card>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Take Attendance Modal */}
+      <TakeAttendanceModal
+        isOpen={!!attendanceGroupId}
+        onClose={() => setAttendanceGroupId(null)}
+        members={attendanceMembers}
+        onSubmit={handleSubmitAttendance}
+        isSubmitting={recordAttendanceMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/src/web/src/services/api/myGroups.ts
+++ b/src/web/src/services/api/myGroups.ts
@@ -1,0 +1,64 @@
+/**
+ * My Groups API service
+ * Endpoints for group leaders to manage their groups
+ */
+
+import { get, put, del, post } from './client';
+import type {
+  MyGroupDto,
+  MyGroupMemberDetailDto,
+  UpdateGroupMemberRequest,
+  RecordGroupAttendanceRequest,
+} from './types';
+
+/**
+ * Get all groups where current user is a leader
+ */
+export async function getMyGroups(): Promise<MyGroupDto[]> {
+  return await get<MyGroupDto[]>('/my-groups');
+}
+
+/**
+ * Get members of a group where current user is a leader
+ */
+export async function getMyGroupMembers(
+  groupIdKey: string
+): Promise<MyGroupMemberDetailDto[]> {
+  return await get<MyGroupMemberDetailDto[]>(
+    `/my-groups/${groupIdKey}/members`
+  );
+}
+
+/**
+ * Update a group member (role, status, note)
+ */
+export async function updateGroupMember(
+  groupIdKey: string,
+  memberIdKey: string,
+  request: UpdateGroupMemberRequest
+): Promise<MyGroupMemberDetailDto> {
+  return await put<MyGroupMemberDetailDto>(
+    `/my-groups/${groupIdKey}/members/${memberIdKey}`,
+    request
+  );
+}
+
+/**
+ * Remove a member from a group
+ */
+export async function removeGroupMember(
+  groupIdKey: string,
+  memberIdKey: string
+): Promise<void> {
+  await del<void>(`/my-groups/${groupIdKey}/members/${memberIdKey}`);
+}
+
+/**
+ * Record attendance for a group meeting
+ */
+export async function recordAttendance(
+  groupIdKey: string,
+  request: RecordGroupAttendanceRequest
+): Promise<void> {
+  await post<void>(`/my-groups/${groupIdKey}/attendance`, request);
+}

--- a/src/web/src/services/api/types.ts
+++ b/src/web/src/services/api/types.ts
@@ -858,3 +858,52 @@ export enum CapacityStatus {
   Warning = 1,
   Full = 2,
 }
+
+// ============================================================================
+// My Groups Types (Group Leader Dashboard)
+// ============================================================================
+
+export interface MyGroupDto {
+  idKey: IdKey;
+  guid: string;
+  name: string;
+  description?: string;
+  groupTypeName: string;
+  isActive: boolean;
+  memberCount: number;
+  groupCapacity?: number;
+  lastMeetingDate?: DateTime;
+  campus?: CampusSummaryDto;
+  createdDateTime: DateTime;
+  modifiedDateTime?: DateTime;
+}
+
+export interface MyGroupMemberDetailDto {
+  idKey: IdKey;
+  personIdKey: IdKey;
+  firstName: string;
+  lastName: string;
+  fullName: string;
+  email?: string;
+  phone?: string;
+  photoUrl?: string;
+  age?: number;
+  gender: string;
+  role: GroupTypeRoleDto;
+  status: string;
+  dateTimeAdded?: DateTime;
+  inactiveDateTime?: DateTime;
+  note?: string;
+}
+
+export interface UpdateGroupMemberRequest {
+  roleId?: IdKey;
+  status?: string;
+  note?: string;
+}
+
+export interface RecordGroupAttendanceRequest {
+  occurrenceDate: DateOnly;
+  attendedPersonIds: IdKey[];
+  notes?: string;
+}


### PR DESCRIPTION
## Summary
- Implements group leader dashboard for managing groups and members
- Adds `/my-groups` route with full CRUD operations
- Leaders can view member contact info, update status, and record attendance

## Changes

### Backend (10 files)
- `MyGroupsController.cs` - REST API endpoints for leader dashboard
- `MyGroupsService.cs` - Business logic with authorization checks
- `GroupMemberDetailDto.cs` - Enhanced member DTO with contact info
- `MyGroupDto.cs` - Group summary DTO for leaders
- `RecordAttendanceRequest.cs` / `UpdateGroupMemberRequest.cs` - Request DTOs
- `RecordAttendanceRequestValidator.cs` / `UpdateGroupMemberRequestValidator.cs` - Validation
- `IMyGroupsService.cs` - Service interface
- `ServiceCollectionExtensions.cs` - DI registration

### Frontend (8 files)
- `MyGroupsPage.tsx` - Main dashboard page
- `GroupMemberList.tsx` - Member table with actions
- `TakeAttendanceModal.tsx` - Attendance recording modal
- `EditMemberModal.tsx` - Member status/note editing
- `useMyGroups.ts` - TanStack Query hooks
- `myGroups.ts` - API client functions
- `types.ts` - TypeScript interfaces
- `App.tsx` - Route registration

## API Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/v1/my-groups` | List groups where user is leader |
| GET | `/api/v1/my-groups/{idKey}/members` | Get members with contact info |
| PUT | `/api/v1/my-groups/{idKey}/members/{memberIdKey}` | Update member status/note |
| DELETE | `/api/v1/my-groups/{idKey}/members/{memberIdKey}` | Remove member |
| POST | `/api/v1/my-groups/{idKey}/attendance` | Record meeting attendance |

## Test plan
- [ ] Verify leaders can only see groups where they have leader role
- [ ] Verify Staff/Admin can see all groups
- [ ] Test member update (status, note changes)
- [ ] Test member removal (soft delete)
- [ ] Test attendance recording with date selection
- [ ] Verify IdKeys used in all URLs (no integer IDs)

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)