### PR TITLE
feat: Add SMS messaging for group communication (#116)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,6 +29,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="8.0.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.6.122" />

--- a/src/Koinon.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Koinon.Application/Extensions/ServiceCollectionExtensions.cs
@@ -78,8 +78,9 @@ public static class ServiceCollectionExtensions
         // Room roster service
         services.AddScoped<IRoomRosterService, RoomRosterService>();
 
-        // Communication service
+        // Communication services
         services.AddScoped<ICommunicationService, CommunicationService>();
+        services.AddScoped<ICommunicationSender, CommunicationSender>();
 
         // AutoMapper - register all mapping profiles
         services.AddAutoMapper(typeof(ServiceCollectionExtensions).Assembly);

--- a/src/Koinon.Application/Interfaces/IApplicationDbContext.cs
+++ b/src/Koinon.Application/Interfaces/IApplicationDbContext.cs
@@ -1,6 +1,7 @@
 using Koinon.Domain.Entities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Koinon.Application.Interfaces;
 
@@ -39,6 +40,7 @@ public interface IApplicationDbContext
     DbSet<Communication> Communications { get; }
     DbSet<CommunicationRecipient> CommunicationRecipients { get; }
 
+    DatabaseFacade Database { get; }
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
     EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class;
 }

--- a/src/Koinon.Application/Interfaces/ICommunicationSender.cs
+++ b/src/Koinon.Application/Interfaces/ICommunicationSender.cs
@@ -1,0 +1,16 @@
+namespace Koinon.Application.Interfaces;
+
+/// <summary>
+/// Service for sending communications (Email and SMS) to recipients.
+/// Processes pending communications and updates delivery status.
+/// </summary>
+public interface ICommunicationSender
+{
+    /// <summary>
+    /// Sends a communication to all its recipients.
+    /// </summary>
+    /// <param name="communicationId">The ID of the communication to send.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>Task representing the async operation.</returns>
+    Task SendCommunicationAsync(int communicationId, CancellationToken cancellationToken = default);
+}

--- a/src/Koinon.Application/Koinon.Application.csproj
+++ b/src/Koinon.Application/Koinon.Application.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="AutoMapper" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Konscious.Security.Cryptography.Argon2" />

--- a/src/Koinon.Application/Services/CommunicationSender.cs
+++ b/src/Koinon.Application/Services/CommunicationSender.cs
@@ -1,0 +1,226 @@
+using Koinon.Application.Interfaces;
+using Koinon.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Koinon.Application.Services;
+
+/// <summary>
+/// Service for sending communications (Email and SMS) to recipients.
+/// Processes pending communications and updates delivery status.
+/// </summary>
+public class CommunicationSender(
+    IApplicationDbContext context,
+    ISmsService smsService,
+    IEmailSender emailSender,
+    ILogger<CommunicationSender> logger) : ICommunicationSender
+{
+    /// <summary>
+    /// Sends a communication to all its recipients.
+    /// Uses atomic update to prevent race conditions, then processes each recipient
+    /// and updates delivery counts.
+    /// </summary>
+    public async Task SendCommunicationAsync(int communicationId, CancellationToken cancellationToken = default)
+    {
+        // BLOCKER FIX: Use atomic UPDATE with WHERE clause to prevent TOCTOU race condition
+        // This approach works with PostgreSQL and uses fallback for InMemory tests
+        int rowsAffected;
+        var isInMemory = context.Database.ProviderName == "Microsoft.EntityFrameworkCore.InMemory";
+
+        if (!isInMemory)
+        {
+            // Production: Use raw SQL for atomic update (works with PostgreSQL)
+            var sentDateTime = DateTime.UtcNow;
+            rowsAffected = await context.Database.ExecuteSqlRawAsync(
+                @"UPDATE communication
+                  SET status = {0}, sent_date_time = {1}, modified_date_time = {2}
+                  WHERE id = {3} AND status = {4}",
+                (int)CommunicationStatus.Sent,
+                sentDateTime,
+                sentDateTime,
+                communicationId,
+                (int)CommunicationStatus.Pending);
+        }
+        else
+        {
+            // Tests: Use traditional check-and-update for InMemory database
+            var tempComm = await context.Communications
+                .FirstOrDefaultAsync(c => c.Id == communicationId, cancellationToken);
+
+            if (tempComm != null && tempComm.Status == CommunicationStatus.Pending)
+            {
+                tempComm.Status = CommunicationStatus.Sent;
+                tempComm.SentDateTime = DateTime.UtcNow;
+                await context.SaveChangesAsync(cancellationToken);
+                rowsAffected = 1;
+            }
+            else
+            {
+                rowsAffected = 0;
+            }
+        }
+
+        if (rowsAffected == 0)
+        {
+            // Either doesn't exist or not Pending - another thread got it
+            logger.LogDebug("Communication {CommunicationId} not found or already processed", communicationId);
+            return;
+        }
+
+        // Now load with recipients for processing
+        var communication = await context.Communications
+            .Include(c => c.Recipients)
+            .FirstOrDefaultAsync(c => c.Id == communicationId, cancellationToken);
+
+        if (communication == null)
+        {
+            // Should not happen, but handle defensively
+            logger.LogWarning("Communication {CommunicationId} disappeared after status update", communicationId);
+            return;
+        }
+
+        logger.LogInformation(
+            "Starting send for Communication {CommunicationId} ({Type}) with {RecipientCount} recipients",
+            communicationId,
+            communication.CommunicationType,
+            communication.Recipients.Count);
+
+        // Process each recipient
+        int deliveredCount = 0;
+        int failedCount = 0;
+
+        foreach (var recipient in communication.Recipients)
+        {
+            if (recipient.Status != CommunicationRecipientStatus.Pending)
+            {
+                // Skip recipients already processed
+                continue;
+            }
+
+            bool success;
+            string? errorMessage = null;
+
+            try
+            {
+                if (communication.CommunicationType == CommunicationType.Sms)
+                {
+                    // CRITICAL FIX #2: Capture error message from SMS service
+                    (success, errorMessage) = await SendSmsToRecipientAsync(
+                        recipient.Address,
+                        communication.Body,
+                        cancellationToken);
+                }
+                else // Email
+                {
+                    success = await SendEmailToRecipientAsync(
+                        recipient.Address,
+                        recipient.RecipientName,
+                        communication.FromEmail ?? "noreply@koinon.app",
+                        communication.FromName,
+                        communication.Subject ?? "",
+                        communication.Body,
+                        communication.ReplyToEmail,
+                        cancellationToken);
+                }
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "Unexpected error sending {Type} to recipient {RecipientId} ({Address})",
+                    communication.CommunicationType,
+                    recipient.Id,
+                    recipient.Address);
+                success = false;
+                errorMessage = $"Unexpected error: {ex.Message}";
+            }
+
+            // Update recipient status
+            if (success)
+            {
+                recipient.Status = CommunicationRecipientStatus.Delivered;
+                recipient.DeliveredDateTime = DateTime.UtcNow;
+                recipient.ErrorMessage = null;
+                deliveredCount++;
+
+                logger.LogDebug(
+                    "Successfully sent {Type} to {Address}",
+                    communication.CommunicationType,
+                    recipient.Address);
+            }
+            else
+            {
+                recipient.Status = CommunicationRecipientStatus.Failed;
+                recipient.ErrorMessage = errorMessage ?? "Delivery failed";
+                failedCount++;
+
+                logger.LogWarning(
+                    "Failed to send {Type} to {Address}: {ErrorMessage}",
+                    communication.CommunicationType,
+                    recipient.Address,
+                    recipient.ErrorMessage);
+            }
+
+            // CRITICAL FIX #1: Save after each recipient to preserve partial progress
+            await context.SaveChangesAsync(cancellationToken);
+        }
+
+        // Update communication delivery counts
+        communication.DeliveredCount = deliveredCount;
+        communication.FailedCount = failedCount;
+
+        // If all recipients failed, set communication status to Failed
+        if (failedCount > 0 && deliveredCount == 0)
+        {
+            communication.Status = CommunicationStatus.Failed;
+            logger.LogWarning(
+                "All recipients failed for Communication {CommunicationId}. Marking as Failed",
+                communicationId);
+        }
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        logger.LogInformation(
+            "Completed sending Communication {CommunicationId}. Delivered: {Delivered}, Failed: {Failed}",
+            communicationId,
+            deliveredCount,
+            failedCount);
+    }
+
+    /// <summary>
+    /// Sends an SMS to a single recipient.
+    /// Returns success status and error message if failed.
+    /// </summary>
+    private async Task<(bool Success, string? ErrorMessage)> SendSmsToRecipientAsync(
+        string phoneNumber,
+        string message,
+        CancellationToken cancellationToken)
+    {
+        var result = await smsService.SendSmsAsync(phoneNumber, message, cancellationToken);
+        return (result.Success, result.ErrorMessage);
+    }
+
+    /// <summary>
+    /// Sends an email to a single recipient.
+    /// </summary>
+    private async Task<bool> SendEmailToRecipientAsync(
+        string toAddress,
+        string? toName,
+        string fromAddress,
+        string? fromName,
+        string subject,
+        string bodyHtml,
+        string? replyToAddress,
+        CancellationToken cancellationToken)
+    {
+        return await emailSender.SendEmailAsync(
+            toAddress,
+            toName,
+            fromAddress,
+            fromName,
+            subject,
+            bodyHtml,
+            replyToAddress,
+            cancellationToken);
+    }
+}

--- a/src/Koinon.Application/Validators/CreateCommunicationDtoValidator.cs
+++ b/src/Koinon.Application/Validators/CreateCommunicationDtoValidator.cs
@@ -27,10 +27,20 @@ public class CreateCommunicationDtoValidator : AbstractValidator<CreateCommunica
             .NotEmpty().WithMessage("Body is required")
             .MaximumLength(100000).WithMessage("Body cannot exceed 100,000 characters");
 
+        // SMS-specific body validation (10 segments max @ 160 chars per segment)
+        RuleFor(x => x.Body)
+            .MaximumLength(1600).WithMessage("SMS body cannot exceed 1600 characters (10 segments)")
+            .When(x => x.CommunicationType == "Sms");
+
         RuleFor(x => x.CommunicationType)
             .NotEmpty().WithMessage("Communication type is required")
             .Must(x => x == "Email" || x == "Sms")
             .WithMessage("Communication type must be Email or Sms");
+
+        // SMS should not have subject
+        RuleFor(x => x.Subject)
+            .Empty().WithMessage("Subject should not be set for SMS communications")
+            .When(x => x.CommunicationType == "Sms");
 
         RuleFor(x => x.FromEmail)
             .NotEmpty().WithMessage("FromEmail is required for email communications")

--- a/src/Koinon.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Koinon.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -85,6 +85,9 @@ public static class ServiceCollectionExtensions
         // Register email sender service
         services.AddScoped<IEmailSender, SmtpEmailSender>();
 
+        // Register background service for sending communications
+        services.AddHostedService<CommunicationSenderBackgroundService>();
+
         // Future: Register repositories and unit of work (WU-1.3.4)
         // services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
         // services.AddScoped<IUnitOfWork, UnitOfWork>();
@@ -160,6 +163,9 @@ public static class ServiceCollectionExtensions
 
         // Register email sender service
         services.AddScoped<IEmailSender, SmtpEmailSender>();
+
+        // Register background service for sending communications
+        services.AddHostedService<CommunicationSenderBackgroundService>();
 
         // Future: Register repositories and unit of work
         // services.AddScoped(typeof(IRepository<>), typeof(Repository<>));

--- a/src/Koinon.Infrastructure/Services/CommunicationSenderBackgroundService.cs
+++ b/src/Koinon.Infrastructure/Services/CommunicationSenderBackgroundService.cs
@@ -1,0 +1,90 @@
+using Koinon.Application.Interfaces;
+using Koinon.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Koinon.Infrastructure.Services;
+
+/// <summary>
+/// Background service that polls for pending communications and sends them.
+/// Polls every 30 seconds and processes one communication at a time to respect rate limits.
+/// </summary>
+public class CommunicationSenderBackgroundService(
+    IServiceScopeFactory serviceScopeFactory,
+    ILogger<CommunicationSenderBackgroundService> logger) : BackgroundService
+{
+    private const int PollingIntervalSeconds = 30;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        logger.LogInformation("Communication Sender Background Service started");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                await ProcessPendingCommunicationsAsync(stoppingToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Error processing pending communications");
+            }
+
+            // Wait before next poll
+            await Task.Delay(TimeSpan.FromSeconds(PollingIntervalSeconds), stoppingToken);
+        }
+
+        logger.LogInformation("Communication Sender Background Service stopped");
+    }
+
+    /// <summary>
+    /// Polls for pending communications and sends them one at a time.
+    /// </summary>
+    private async Task ProcessPendingCommunicationsAsync(CancellationToken cancellationToken)
+    {
+        using var scope = serviceScopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<IApplicationDbContext>();
+        var communicationSender = scope.ServiceProvider.GetRequiredService<ICommunicationSender>();
+
+        // Query for pending communications
+        var pendingCommunications = await context.Communications
+            .Where(c => c.Status == CommunicationStatus.Pending)
+            .OrderBy(c => c.CreatedDateTime)
+            .Select(c => c.Id)
+            .ToListAsync(cancellationToken);
+
+        if (pendingCommunications.Count == 0)
+        {
+            return; // No pending communications
+        }
+
+        logger.LogInformation(
+            "Found {Count} pending communication(s) to process",
+            pendingCommunications.Count);
+
+        // Process one communication at a time to respect rate limits
+        foreach (var communicationId in pendingCommunications)
+        {
+            if (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            try
+            {
+                await communicationSender.SendCommunicationAsync(communicationId, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(
+                    ex,
+                    "Failed to send communication {CommunicationId}",
+                    communicationId);
+
+                // Continue with next communication instead of stopping the whole process
+            }
+        }
+    }
+}

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -36,6 +36,7 @@ import { GroupTypesPage } from './pages/admin/settings/GroupTypesPage';
 import { PWAUpdatePrompt, InstallPrompt } from './components/pwa';
 import { GroupFinderPage } from './pages/public/GroupFinderPage';
 import { MyGroupsPage } from './pages/MyGroupsPage';
+import { CommunicationsPage } from './pages/communications/CommunicationsPage';
 
 function HomePage() {
   const { isAuthenticated } = useAuth();
@@ -213,6 +214,7 @@ function App() {
           <Route path="schedules/:idKey" element={<ScheduleDetailPage />} />
           <Route path="schedules/:idKey/edit" element={<ScheduleFormPage />} />
           <Route path="analytics" element={<AnalyticsPage />} />
+          <Route path="communications" element={<CommunicationsPage />} />
           <Route path="settings" element={<SettingsPage />} />
           <Route path="settings/group-types" element={<GroupTypesPage />} />
         </Route>

--- a/src/web/src/components/communication/CommunicationComposer.tsx
+++ b/src/web/src/components/communication/CommunicationComposer.tsx
@@ -1,0 +1,270 @@
+/**
+ * CommunicationComposer Component
+ * Full composer modal for creating and sending communications
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+import { MessageTypeToggle } from './MessageTypeToggle';
+import { EmailComposer } from './EmailComposer';
+import { SmsComposer } from './SmsComposer';
+import { useCreateCommunication, useSendCommunication } from '@/hooks/useCommunications';
+import type { GroupSummaryDto } from '@/services/api/types';
+import type { CreateCommunicationRequest } from '@/services/api/communications';
+
+interface CommunicationComposerProps {
+  groups: GroupSummaryDto[];
+  onSend: () => void;
+  onClose: () => void;
+}
+
+export function CommunicationComposer({ groups, onSend, onClose }: CommunicationComposerProps) {
+  const [communicationType, setCommunicationType] = useState<'Email' | 'Sms'>('Email');
+  const [subject, setSubject] = useState('');
+  const [body, setBody] = useState('');
+  const [fromEmail, setFromEmail] = useState('');
+  const [fromName, setFromName] = useState('');
+  const [replyToEmail, setReplyToEmail] = useState('');
+  const [note, setNote] = useState('');
+  const [selectedGroupIdKeys, setSelectedGroupIdKeys] = useState<string[]>([]);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const createMutation = useCreateCommunication();
+  const sendMutation = useSendCommunication();
+
+  // Calculate recipient count (simplified - just sum of group members)
+  const recipientCount = useMemo(
+    () =>
+      selectedGroupIdKeys.reduce((sum, idKey) => {
+        const group = groups.find((g) => g.idKey === idKey);
+        return sum + (group?.memberCount || 0);
+      }, 0),
+    [selectedGroupIdKeys, groups]
+  );
+
+  const validateForm = useCallback((): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    if (selectedGroupIdKeys.length === 0) {
+      newErrors.groups = 'Please select at least one group';
+    }
+
+    if (!body.trim()) {
+      newErrors.body = 'Message body is required';
+    }
+
+    if (communicationType === 'Email') {
+      if (!subject.trim()) {
+        newErrors.subject = 'Subject is required for emails';
+      }
+    }
+
+    if (communicationType === 'Sms' && body.length > 1600) {
+      newErrors.body = 'SMS message is too long (max 1600 characters)';
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }, [communicationType, subject, body, selectedGroupIdKeys]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!validateForm()) {
+      return;
+    }
+
+    try {
+      const request: CreateCommunicationRequest = {
+        communicationType,
+        subject: communicationType === 'Email' ? subject : undefined,
+        body,
+        fromEmail: communicationType === 'Email' && fromEmail ? fromEmail : undefined,
+        fromName: communicationType === 'Email' && fromName ? fromName : undefined,
+        replyToEmail: communicationType === 'Email' && replyToEmail ? replyToEmail : undefined,
+        note: note || undefined,
+        groupIdKeys: selectedGroupIdKeys,
+      };
+
+      const communication = await createMutation.mutateAsync(request);
+      await sendMutation.mutateAsync(communication.idKey);
+
+      onSend();
+    } catch {
+      // Error is captured by mutation state and displayed in UI
+    }
+  };
+
+  const handleGroupToggle = (idKey: string) => {
+    setSelectedGroupIdKeys((prev) =>
+      prev.includes(idKey) ? prev.filter((id) => id !== idKey) : [...prev, idKey]
+    );
+  };
+
+  const isPending = createMutation.isPending || sendMutation.isPending;
+  const error = createMutation.error || sendMutation.error;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
+      <div className="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+        <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4">
+          <div className="flex items-center justify-between">
+            <h2 className="text-2xl font-bold text-gray-900">New Communication</h2>
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600 transition-colors"
+              aria-label="Close"
+            >
+              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <form onSubmit={handleSubmit} className="p-6 space-y-6">
+          {/* Message Type Toggle */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Communication Type
+            </label>
+            <MessageTypeToggle value={communicationType} onChange={setCommunicationType} />
+          </div>
+
+          {/* Group Selection */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Send To <span className="text-red-500">*</span>
+            </label>
+            <div className="border border-gray-300 rounded-lg max-h-48 overflow-y-auto">
+              {groups.length === 0 ? (
+                <div className="p-4 text-center text-gray-500">No groups available</div>
+              ) : (
+                <div className="divide-y divide-gray-200">
+                  {groups.map((group) => (
+                    <label
+                      key={group.idKey}
+                      className="flex items-center gap-3 p-3 hover:bg-gray-50 cursor-pointer"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={selectedGroupIdKeys.includes(group.idKey)}
+                        onChange={() => handleGroupToggle(group.idKey)}
+                        className="w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+                      />
+                      <div className="flex-1">
+                        <div className="font-medium text-gray-900">{group.name}</div>
+                        <div className="text-sm text-gray-500">
+                          {group.memberCount} {group.memberCount === 1 ? 'member' : 'members'}
+                        </div>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              )}
+            </div>
+            {errors.groups && <p className="mt-1 text-sm text-red-600">{errors.groups}</p>}
+
+            {/* Recipient Count Preview */}
+            {selectedGroupIdKeys.length > 0 && (
+              <div className="mt-2 flex items-center gap-2 text-sm text-gray-600">
+                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                  />
+                </svg>
+                <span className="font-medium">
+                  {recipientCount} {recipientCount === 1 ? 'recipient' : 'recipients'}
+                </span>
+              </div>
+            )}
+          </div>
+
+          {/* Message Composer */}
+          {communicationType === 'Email' ? (
+            <EmailComposer
+              subject={subject}
+              body={body}
+              fromEmail={fromEmail}
+              fromName={fromName}
+              replyToEmail={replyToEmail}
+              onSubjectChange={setSubject}
+              onBodyChange={setBody}
+              onFromEmailChange={setFromEmail}
+              onFromNameChange={setFromName}
+              onReplyToEmailChange={setReplyToEmail}
+              errors={errors}
+            />
+          ) : (
+            <SmsComposer value={body} onChange={setBody} error={errors.body} />
+          )}
+
+          {/* Note */}
+          <div>
+            <label htmlFor="note" className="block text-sm font-medium text-gray-700 mb-1">
+              Internal Note (optional)
+            </label>
+            <textarea
+              id="note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              rows={2}
+              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+              placeholder="Add an internal note about this communication..."
+            />
+          </div>
+
+          {/* Error Display */}
+          {error && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+              <div className="flex items-center gap-2">
+                <svg
+                  className="w-5 h-5 text-red-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <p className="text-sm font-medium text-red-800">
+                  Failed to send communication. Please try again.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* Actions */}
+          <div className="flex justify-end gap-3 pt-4 border-t border-gray-200">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isPending}
+              className="px-4 py-2 text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isPending}
+              className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50 transition-colors"
+            >
+              {isPending ? 'Sending...' : 'Send'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/communication/EmailComposer.tsx
+++ b/src/web/src/components/communication/EmailComposer.tsx
@@ -1,0 +1,132 @@
+/**
+ * EmailComposer Component
+ * Form fields for composing email messages
+ */
+
+interface EmailComposerProps {
+  subject: string;
+  body: string;
+  fromEmail?: string;
+  fromName?: string;
+  replyToEmail?: string;
+  onSubjectChange: (value: string) => void;
+  onBodyChange: (value: string) => void;
+  onFromEmailChange: (value: string) => void;
+  onFromNameChange: (value: string) => void;
+  onReplyToEmailChange: (value: string) => void;
+  errors?: {
+    subject?: string;
+    body?: string;
+    fromEmail?: string;
+    fromName?: string;
+    replyToEmail?: string;
+  };
+}
+
+export function EmailComposer({
+  subject,
+  body,
+  fromEmail,
+  fromName,
+  replyToEmail,
+  onSubjectChange,
+  onBodyChange,
+  onFromEmailChange,
+  onFromNameChange,
+  onReplyToEmailChange,
+  errors = {},
+}: EmailComposerProps) {
+  return (
+    <div className="space-y-4">
+      {/* From Name */}
+      <div>
+        <label htmlFor="fromName" className="block text-sm font-medium text-gray-700 mb-1">
+          From Name
+        </label>
+        <input
+          type="text"
+          id="fromName"
+          value={fromName || ''}
+          onChange={(e) => onFromNameChange(e.target.value)}
+          className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 ${
+            errors.fromName ? 'border-red-500' : 'border-gray-300'
+          }`}
+          placeholder="Your Name or Organization"
+        />
+        {errors.fromName && <p className="mt-1 text-sm text-red-600">{errors.fromName}</p>}
+      </div>
+
+      {/* From Email */}
+      <div>
+        <label htmlFor="fromEmail" className="block text-sm font-medium text-gray-700 mb-1">
+          From Email
+        </label>
+        <input
+          type="email"
+          id="fromEmail"
+          value={fromEmail || ''}
+          onChange={(e) => onFromEmailChange(e.target.value)}
+          className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 ${
+            errors.fromEmail ? 'border-red-500' : 'border-gray-300'
+          }`}
+          placeholder="sender@example.com"
+        />
+        {errors.fromEmail && <p className="mt-1 text-sm text-red-600">{errors.fromEmail}</p>}
+      </div>
+
+      {/* Reply-To Email */}
+      <div>
+        <label htmlFor="replyToEmail" className="block text-sm font-medium text-gray-700 mb-1">
+          Reply-To Email
+        </label>
+        <input
+          type="email"
+          id="replyToEmail"
+          value={replyToEmail || ''}
+          onChange={(e) => onReplyToEmailChange(e.target.value)}
+          className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 ${
+            errors.replyToEmail ? 'border-red-500' : 'border-gray-300'
+          }`}
+          placeholder="reply@example.com"
+        />
+        {errors.replyToEmail && <p className="mt-1 text-sm text-red-600">{errors.replyToEmail}</p>}
+      </div>
+
+      {/* Subject */}
+      <div>
+        <label htmlFor="subject" className="block text-sm font-medium text-gray-700 mb-1">
+          Subject <span className="text-red-500">*</span>
+        </label>
+        <input
+          type="text"
+          id="subject"
+          value={subject}
+          onChange={(e) => onSubjectChange(e.target.value)}
+          className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 ${
+            errors.subject ? 'border-red-500' : 'border-gray-300'
+          }`}
+          placeholder="Email subject line"
+        />
+        {errors.subject && <p className="mt-1 text-sm text-red-600">{errors.subject}</p>}
+      </div>
+
+      {/* Body */}
+      <div>
+        <label htmlFor="email-body" className="block text-sm font-medium text-gray-700 mb-1">
+          Message <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          id="email-body"
+          value={body}
+          onChange={(e) => onBodyChange(e.target.value)}
+          rows={10}
+          className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 ${
+            errors.body ? 'border-red-500' : 'border-gray-300'
+          }`}
+          placeholder="Enter your email message..."
+        />
+        {errors.body && <p className="mt-1 text-sm text-red-600">{errors.body}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/communication/MessageTypeToggle.tsx
+++ b/src/web/src/components/communication/MessageTypeToggle.tsx
@@ -1,0 +1,66 @@
+/**
+ * MessageTypeToggle Component
+ * Toggle between Email and SMS communication types
+ */
+
+interface MessageTypeToggleProps {
+  value: 'Email' | 'Sms';
+  onChange: (type: 'Email' | 'Sms') => void;
+}
+
+export function MessageTypeToggle({ value, onChange }: MessageTypeToggleProps) {
+  return (
+    <div className="inline-flex rounded-lg border border-gray-300 bg-white p-1">
+      <button
+        type="button"
+        onClick={() => onChange('Email')}
+        className={`flex items-center gap-2 px-4 py-2 rounded-md font-medium transition-colors ${
+          value === 'Email'
+            ? 'bg-primary-600 text-white'
+            : 'text-gray-700 hover:bg-gray-100'
+        }`}
+      >
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+          />
+        </svg>
+        Email
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange('Sms')}
+        className={`flex items-center gap-2 px-4 py-2 rounded-md font-medium transition-colors ${
+          value === 'Sms'
+            ? 'bg-primary-600 text-white'
+            : 'text-gray-700 hover:bg-gray-100'
+        }`}
+      >
+        <svg
+          className="w-5 h-5"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+          />
+        </svg>
+        SMS
+      </button>
+    </div>
+  );
+}

--- a/src/web/src/components/communication/SmsComposer.tsx
+++ b/src/web/src/components/communication/SmsComposer.tsx
@@ -1,0 +1,91 @@
+/**
+ * SmsComposer Component
+ * Text area for composing SMS messages with character counting
+ */
+
+import { useMemo } from 'react';
+
+interface SmsComposerProps {
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+}
+
+const SMS_SEGMENT_SIZE = 160;
+const SMS_MAX_LENGTH = 1600;
+
+export function SmsComposer({ value, onChange, error }: SmsComposerProps) {
+  const characterCount = value.length;
+  const segments = Math.ceil(characterCount / SMS_SEGMENT_SIZE) || 1;
+  const isTooLong = characterCount > SMS_MAX_LENGTH;
+  const isMultiSegment = characterCount > SMS_SEGMENT_SIZE;
+
+  const warningMessage = useMemo(() => {
+    if (isTooLong) {
+      return `Message too long (max ${SMS_MAX_LENGTH} characters)`;
+    }
+    if (isMultiSegment) {
+      return `This message will be sent as ${segments} segments`;
+    }
+    return null;
+  }, [isTooLong, isMultiSegment, segments]);
+
+  return (
+    <div className="space-y-2">
+      <label htmlFor="sms-body" className="block text-sm font-medium text-gray-700">
+        Message <span className="text-red-500">*</span>
+      </label>
+      <textarea
+        id="sms-body"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        rows={6}
+        maxLength={SMS_MAX_LENGTH}
+        className={`w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 ${
+          error || isTooLong ? 'border-red-500' : 'border-gray-300'
+        }`}
+        placeholder="Enter your SMS message..."
+      />
+
+      {/* Character Counter */}
+      <div className="flex items-center justify-between text-sm">
+        <span className={`font-medium ${isTooLong ? 'text-red-600' : 'text-gray-600'}`}>
+          {characterCount} / {SMS_SEGMENT_SIZE}
+          {isMultiSegment && ` (${segments} segments)`}
+        </span>
+      </div>
+
+      {/* Warning Message */}
+      {warningMessage && (
+        <div
+          className={`flex items-center gap-2 p-3 rounded-lg ${
+            isTooLong
+              ? 'bg-red-50 border border-red-200'
+              : 'bg-amber-50 border border-amber-200'
+          }`}
+        >
+          <svg
+            className={`w-5 h-5 flex-shrink-0 ${isTooLong ? 'text-red-600' : 'text-amber-600'}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
+          <p className={`text-sm font-medium ${isTooLong ? 'text-red-800' : 'text-amber-800'}`}>
+            {warningMessage}
+          </p>
+        </div>
+      )}
+
+      {/* Error Message */}
+      {error && <p className="text-sm text-red-600">{error}</p>}
+    </div>
+  );
+}

--- a/src/web/src/components/communication/index.ts
+++ b/src/web/src/components/communication/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Communication Components
+ * Re-export all communication components
+ */
+
+export { MessageTypeToggle } from './MessageTypeToggle';
+export { SmsComposer } from './SmsComposer';
+export { EmailComposer } from './EmailComposer';
+export { CommunicationComposer } from './CommunicationComposer';

--- a/src/web/src/hooks/useCommunications.ts
+++ b/src/web/src/hooks/useCommunications.ts
@@ -1,0 +1,65 @@
+/**
+ * Communications management hooks using TanStack Query
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import * as communicationsApi from '@/services/api/communications';
+import type {
+  CreateCommunicationRequest,
+  CommunicationsParams,
+} from '@/services/api/communications';
+
+/**
+ * Get a single communication by IdKey
+ */
+export function useCommunication(idKey?: string) {
+  return useQuery({
+    queryKey: ['communications', idKey],
+    queryFn: () => communicationsApi.getCommunication(idKey!),
+    enabled: !!idKey,
+    staleTime: 30 * 1000, // 30 seconds - communications status can change
+  });
+}
+
+/**
+ * List communications with filters
+ */
+export function useCommunications(params: CommunicationsParams = {}) {
+  return useQuery({
+    queryKey: ['communications', params],
+    queryFn: () => communicationsApi.getCommunications(params),
+    staleTime: 30 * 1000, // 30 seconds
+  });
+}
+
+/**
+ * Create a new communication
+ */
+export function useCreateCommunication() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateCommunicationRequest) =>
+      communicationsApi.createCommunication(request),
+    onSuccess: () => {
+      // Invalidate communications list to refetch
+      queryClient.invalidateQueries({ queryKey: ['communications'] });
+    },
+  });
+}
+
+/**
+ * Send (queue) a communication for delivery
+ */
+export function useSendCommunication() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (idKey: string) => communicationsApi.sendCommunication(idKey),
+    onSuccess: (_, idKey) => {
+      // Invalidate specific communication and list
+      queryClient.invalidateQueries({ queryKey: ['communications', idKey] });
+      queryClient.invalidateQueries({ queryKey: ['communications'] });
+    },
+  });
+}

--- a/src/web/src/pages/communications/CommunicationsPage.tsx
+++ b/src/web/src/pages/communications/CommunicationsPage.tsx
@@ -1,0 +1,262 @@
+/**
+ * CommunicationsPage
+ * List and manage communications with filtering
+ */
+
+import { useState } from 'react';
+import { useCommunications } from '@/hooks/useCommunications';
+import { useGroups } from '@/hooks/useGroups';
+import { CommunicationComposer } from '@/components/communication/CommunicationComposer';
+import type { CommunicationSummaryDto } from '@/services/api/communications';
+
+const STATUS_OPTIONS = [
+  { value: '', label: 'All' },
+  { value: 'Draft', label: 'Draft' },
+  { value: 'Pending', label: 'Pending' },
+  { value: 'Sent', label: 'Sent' },
+  { value: 'Failed', label: 'Failed' },
+];
+
+function CommunicationStatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    Draft: 'bg-gray-100 text-gray-800',
+    Pending: 'bg-blue-100 text-blue-800',
+    Sent: 'bg-green-100 text-green-800',
+    Failed: 'bg-red-100 text-red-800',
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+        colors[status] || 'bg-gray-100 text-gray-800'
+      }`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function CommunicationTypeBadge({ type }: { type: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 text-sm text-gray-600">
+      {type === 'Email' ? (
+        <>
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+            />
+          </svg>
+          Email
+        </>
+      ) : (
+        <>
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+            />
+          </svg>
+          SMS
+        </>
+      )}
+    </span>
+  );
+}
+
+function CommunicationRow({ communication }: { communication: CommunicationSummaryDto }) {
+  const date = new Date(communication.createdDateTime);
+  const sentDate = communication.sentDateTime ? new Date(communication.sentDateTime) : null;
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4 hover:border-primary-300 transition-colors">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-3 mb-2">
+            <CommunicationStatusBadge status={communication.status} />
+            <CommunicationTypeBadge type={communication.communicationType} />
+          </div>
+
+          {communication.subject && (
+            <h3 className="text-lg font-semibold text-gray-900 mb-1 truncate">
+              {communication.subject}
+            </h3>
+          )}
+
+          <div className="flex items-center gap-4 text-sm text-gray-600">
+            <span className="flex items-center gap-1">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                />
+              </svg>
+              {communication.recipientCount}{' '}
+              {communication.recipientCount === 1 ? 'recipient' : 'recipients'}
+            </span>
+
+            {communication.status === 'Sent' && (
+              <>
+                <span className="text-green-600">
+                  {communication.deliveredCount} delivered
+                </span>
+                {communication.failedCount > 0 && (
+                  <span className="text-red-600">{communication.failedCount} failed</span>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="text-right text-sm text-gray-600">
+          <div>{sentDate ? sentDate.toLocaleDateString() : date.toLocaleDateString()}</div>
+          <div className="text-xs text-gray-500">
+            {sentDate ? sentDate.toLocaleTimeString() : date.toLocaleTimeString()}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function CommunicationsPage() {
+  const [statusFilter, setStatusFilter] = useState('');
+  const [isComposerOpen, setIsComposerOpen] = useState(false);
+
+  const { data: communicationsData, isLoading, error } = useCommunications({
+    status: statusFilter || undefined,
+    pageSize: 50,
+  });
+
+  const { data: groupsData, isLoading: isLoadingGroups } = useGroups({
+    includeInactive: false,
+    pageSize: 100,
+  });
+
+  const communications = communicationsData?.data || [];
+  const groups = groupsData?.data || [];
+
+  const handleSend = () => {
+    setIsComposerOpen(false);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900">Communications</h1>
+          <p className="mt-2 text-gray-600">Send and manage email and SMS communications</p>
+        </div>
+        <button
+          onClick={() => setIsComposerOpen(true)}
+          disabled={isLoadingGroups}
+          className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50"
+        >
+          New Communication
+        </button>
+      </div>
+
+      {/* Filters */}
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <div className="flex items-center gap-4">
+          <label htmlFor="status-filter" className="text-sm font-medium text-gray-700">
+            Status:
+          </label>
+          <select
+            id="status-filter"
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            className="px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          >
+            {STATUS_OPTIONS.map((option) => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Loading State */}
+      {isLoading && (
+        <div className="flex items-center justify-center py-12">
+          <div className="inline-block w-8 h-8 border-4 border-gray-200 border-t-primary-600 rounded-full animate-spin" />
+        </div>
+      )}
+
+      {/* Error State */}
+      {error && (
+        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
+          <div className="flex items-center gap-2">
+            <svg
+              className="w-5 h-5 text-red-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            <p className="text-sm font-medium text-red-800">Failed to load communications</p>
+          </div>
+        </div>
+      )}
+
+      {/* Communications List */}
+      {!isLoading && !error && (
+        <div className="space-y-4">
+          {communications.length === 0 ? (
+            <div className="bg-white rounded-lg border border-gray-200 p-12 text-center">
+              <svg
+                className="w-12 h-12 text-gray-400 mx-auto mb-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+                />
+              </svg>
+              <p className="text-gray-500 mb-4">No communications found</p>
+              <button
+                onClick={() => setIsComposerOpen(true)}
+                className="inline-block px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
+              >
+                Send First Communication
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-3">
+              {communications.map((communication) => (
+                <CommunicationRow key={communication.idKey} communication={communication} />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Composer Modal */}
+      {isComposerOpen && (
+        <CommunicationComposer
+          groups={groups}
+          onSend={handleSend}
+          onClose={() => setIsComposerOpen(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/web/src/pages/communications/index.ts
+++ b/src/web/src/pages/communications/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Communications Pages
+ * Re-export all communications page components
+ */
+
+export { CommunicationsPage } from './CommunicationsPage';

--- a/src/web/src/services/api/communications.ts
+++ b/src/web/src/services/api/communications.ts
@@ -1,0 +1,129 @@
+/**
+ * Communications API service
+ */
+
+import { get, post } from './client';
+import type { PagedResult, IdKey } from './types';
+
+// ============================================================================
+// Request Types
+// ============================================================================
+
+export interface CreateCommunicationRequest {
+  communicationType: 'Email' | 'Sms';
+  subject?: string;
+  body: string;
+  fromEmail?: string;
+  fromName?: string;
+  replyToEmail?: string;
+  note?: string;
+  groupIdKeys: string[];
+}
+
+// ============================================================================
+// Response Types
+// ============================================================================
+
+export interface CommunicationRecipientDto {
+  idKey: IdKey;
+  personIdKey: IdKey;
+  address: string;
+  recipientName?: string;
+  status: string;
+  deliveredDateTime?: string;
+  openedDateTime?: string;
+  errorMessage?: string;
+  groupIdKey?: IdKey;
+}
+
+export interface CommunicationDto {
+  idKey: IdKey;
+  guid: string;
+  communicationType: string;
+  status: string;
+  subject?: string;
+  body: string;
+  fromEmail?: string;
+  fromName?: string;
+  replyToEmail?: string;
+  sentDateTime?: string;
+  recipientCount: number;
+  deliveredCount: number;
+  failedCount: number;
+  openedCount: number;
+  note?: string;
+  createdDateTime: string;
+  modifiedDateTime?: string;
+  recipients: CommunicationRecipientDto[];
+}
+
+export interface CommunicationSummaryDto {
+  idKey: IdKey;
+  guid: string;
+  communicationType: string;
+  status: string;
+  subject?: string;
+  sentDateTime?: string;
+  recipientCount: number;
+  deliveredCount: number;
+  failedCount: number;
+  createdDateTime: string;
+}
+
+// ============================================================================
+// Query Parameters
+// ============================================================================
+
+export interface CommunicationsParams {
+  page?: number;
+  pageSize?: number;
+  status?: string;
+}
+
+// ============================================================================
+// API Functions
+// ============================================================================
+
+/**
+ * Create a new communication
+ */
+export async function createCommunication(
+  request: CreateCommunicationRequest
+): Promise<CommunicationDto> {
+  const response = await post<{ data: CommunicationDto }>('/communications', request);
+  return response.data;
+}
+
+/**
+ * Send (queue) a communication for delivery
+ */
+export async function sendCommunication(idKey: string): Promise<CommunicationDto> {
+  const response = await post<{ data: CommunicationDto }>(`/communications/${idKey}/send`);
+  return response.data;
+}
+
+/**
+ * Get a single communication by IdKey
+ */
+export async function getCommunication(idKey: string): Promise<CommunicationDto> {
+  const response = await get<{ data: CommunicationDto }>(`/communications/${idKey}`);
+  return response.data;
+}
+
+/**
+ * List communications with optional filters
+ */
+export async function getCommunications(
+  params: CommunicationsParams = {}
+): Promise<PagedResult<CommunicationSummaryDto>> {
+  const queryParams = new URLSearchParams();
+
+  if (params.page) queryParams.set('page', String(params.page));
+  if (params.pageSize) queryParams.set('pageSize', String(params.pageSize));
+  if (params.status) queryParams.set('status', params.status);
+
+  const query = queryParams.toString();
+  const endpoint = `/communications${query ? `?${query}` : ''}`;
+
+  return get<PagedResult<CommunicationSummaryDto>>(endpoint);
+}

--- a/tests/Koinon.Application.Tests/Services/CommunicationSenderTests.cs
+++ b/tests/Koinon.Application.Tests/Services/CommunicationSenderTests.cs
@@ -1,0 +1,480 @@
+using FluentAssertions;
+using Koinon.Application.Interfaces;
+using Koinon.Application.Services;
+using Koinon.Domain.Entities;
+using Koinon.Domain.Enums;
+using Koinon.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Application.Tests.Services;
+
+/// <summary>
+/// Tests for CommunicationSender service.
+/// </summary>
+public class CommunicationSenderTests : IDisposable
+{
+    private readonly KoinonDbContext _context;
+    private readonly Mock<ISmsService> _mockSmsService;
+    private readonly Mock<IEmailSender> _mockEmailSender;
+    private readonly Mock<ILogger<CommunicationSender>> _mockLogger;
+    private readonly CommunicationSender _service;
+
+    public CommunicationSenderTests()
+    {
+        // Setup in-memory database
+        var options = new DbContextOptionsBuilder<KoinonDbContext>()
+            .UseInMemoryDatabase(databaseName: $"KoinonTestDb_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _context = new KoinonDbContext(options);
+        _context.Database.EnsureCreated();
+
+        // Setup mocks
+        _mockSmsService = new Mock<ISmsService>();
+        _mockEmailSender = new Mock<IEmailSender>();
+        _mockLogger = new Mock<ILogger<CommunicationSender>>();
+
+        // Create service
+        _service = new CommunicationSender(
+            _context,
+            _mockSmsService.Object,
+            _mockEmailSender.Object,
+            _mockLogger.Object);
+
+        // Seed test data
+        SeedTestData();
+    }
+
+    private void SeedTestData()
+    {
+        // Create people
+        var person1 = new Person
+        {
+            Id = 1,
+            FirstName = "John",
+            LastName = "Doe",
+            Email = "john@example.com",
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        var person2 = new Person
+        {
+            Id = 2,
+            FirstName = "Jane",
+            LastName = "Smith",
+            Email = "jane@example.com",
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        _context.People.AddRange(person1, person2);
+
+        // Add phone number for SMS tests
+        var phone = new PhoneNumber
+        {
+            Id = 1,
+            PersonId = 1,
+            Number = "+15551234567",
+            NumberTypeValueId = 1,
+            CreatedDateTime = DateTime.UtcNow
+        };
+        _context.PhoneNumbers.Add(phone);
+
+        _context.SaveChanges();
+    }
+
+    [Fact]
+    public async Task SendCommunicationAsync_WithPendingSmsCommuncation_SendsSmsToAllRecipients()
+    {
+        // Arrange
+        var communication = new Communication
+        {
+            Id = 1,
+            CommunicationType = CommunicationType.Sms,
+            Status = CommunicationStatus.Pending,
+            Body = "Test SMS message",
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        var recipient1 = new CommunicationRecipient
+        {
+            Id = 1,
+            CommunicationId = 1,
+            PersonId = 1,
+            Address = "+15551234567",
+            RecipientName = "John Doe",
+            Status = CommunicationRecipientStatus.Pending,
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        var recipient2 = new CommunicationRecipient
+        {
+            Id = 2,
+            CommunicationId = 1,
+            PersonId = 2,
+            Address = "+15559876543",
+            RecipientName = "Jane Smith",
+            Status = CommunicationRecipientStatus.Pending,
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        communication.Recipients = new List<CommunicationRecipient> { recipient1, recipient2 };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        // Mock successful SMS sends
+        _mockSmsService
+            .Setup(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SmsResult(Success: true, MessageId: "test-sid", ErrorMessage: null));
+
+        // Act
+        await _service.SendCommunicationAsync(1);
+
+        // Assert
+        var sentCommunication = await _context.Communications
+            .Include(c => c.Recipients)
+            .FirstAsync(c => c.Id == 1);
+
+        sentCommunication.Status.Should().Be(CommunicationStatus.Sent);
+        sentCommunication.SentDateTime.Should().NotBeNull();
+        sentCommunication.DeliveredCount.Should().Be(2);
+        sentCommunication.FailedCount.Should().Be(0);
+
+        sentCommunication.Recipients.Should().AllSatisfy(r =>
+        {
+            r.Status.Should().Be(CommunicationRecipientStatus.Delivered);
+            r.DeliveredDateTime.Should().NotBeNull();
+            r.ErrorMessage.Should().BeNull();
+        });
+
+        _mockSmsService.Verify(
+            s => s.SendSmsAsync("+15551234567", "Test SMS message", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockSmsService.Verify(
+            s => s.SendSmsAsync("+15559876543", "Test SMS message", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendCommunicationAsync_WithPendingEmailCommunication_SendsEmailToAllRecipients()
+    {
+        // Arrange
+        var communication = new Communication
+        {
+            Id = 2,
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Pending,
+            Subject = "Test Subject",
+            Body = "<p>Test email body</p>",
+            FromEmail = "noreply@example.com",
+            FromName = "Test Sender",
+            ReplyToEmail = "reply@example.com",
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        var recipient = new CommunicationRecipient
+        {
+            Id = 3,
+            CommunicationId = 2,
+            PersonId = 1,
+            Address = "john@example.com",
+            RecipientName = "John Doe",
+            Status = CommunicationRecipientStatus.Pending,
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        communication.Recipients = new List<CommunicationRecipient> { recipient };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        // Mock successful email send
+        _mockEmailSender
+            .Setup(e => e.SendEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        await _service.SendCommunicationAsync(2);
+
+        // Assert
+        var sentCommunication = await _context.Communications
+            .Include(c => c.Recipients)
+            .FirstAsync(c => c.Id == 2);
+
+        sentCommunication.Status.Should().Be(CommunicationStatus.Sent);
+        sentCommunication.DeliveredCount.Should().Be(1);
+        sentCommunication.FailedCount.Should().Be(0);
+
+        var sentRecipient = sentCommunication.Recipients.First();
+        sentRecipient.Status.Should().Be(CommunicationRecipientStatus.Delivered);
+        sentRecipient.DeliveredDateTime.Should().NotBeNull();
+
+        _mockEmailSender.Verify(
+            e => e.SendEmailAsync(
+                "john@example.com",
+                "John Doe",
+                "noreply@example.com",
+                "Test Sender",
+                "Test Subject",
+                "<p>Test email body</p>",
+                "reply@example.com",
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendCommunicationAsync_WithSmsFailure_MarksRecipientAsFailed()
+    {
+        // Arrange
+        var communication = new Communication
+        {
+            Id = 3,
+            CommunicationType = CommunicationType.Sms,
+            Status = CommunicationStatus.Pending,
+            Body = "Test message",
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        var recipient = new CommunicationRecipient
+        {
+            Id = 4,
+            CommunicationId = 3,
+            PersonId = 1,
+            Address = "+15551234567",
+            Status = CommunicationRecipientStatus.Pending,
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        communication.Recipients = new List<CommunicationRecipient> { recipient };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        // Mock failed SMS send
+        _mockSmsService
+            .Setup(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SmsResult(Success: false, MessageId: null, ErrorMessage: "Invalid phone number"));
+
+        // Act
+        await _service.SendCommunicationAsync(3);
+
+        // Assert
+        var sentCommunication = await _context.Communications
+            .Include(c => c.Recipients)
+            .FirstAsync(c => c.Id == 3);
+
+        sentCommunication.Status.Should().Be(CommunicationStatus.Failed);
+        sentCommunication.DeliveredCount.Should().Be(0);
+        sentCommunication.FailedCount.Should().Be(1);
+
+        var failedRecipient = sentCommunication.Recipients.First();
+        failedRecipient.Status.Should().Be(CommunicationRecipientStatus.Failed);
+        failedRecipient.DeliveredDateTime.Should().BeNull();
+        failedRecipient.ErrorMessage.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task SendCommunicationAsync_WithMixedSuccessAndFailure_UpdatesCountsCorrectly()
+    {
+        // Arrange
+        var communication = new Communication
+        {
+            Id = 4,
+            CommunicationType = CommunicationType.Sms,
+            Status = CommunicationStatus.Pending,
+            Body = "Test message",
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        var recipient1 = new CommunicationRecipient
+        {
+            Id = 5,
+            CommunicationId = 4,
+            PersonId = 1,
+            Address = "+15551234567",
+            Status = CommunicationRecipientStatus.Pending,
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        var recipient2 = new CommunicationRecipient
+        {
+            Id = 6,
+            CommunicationId = 4,
+            PersonId = 2,
+            Address = "+15559999999",
+            Status = CommunicationRecipientStatus.Pending,
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        communication.Recipients = new List<CommunicationRecipient> { recipient1, recipient2 };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        // Mock mixed results
+        _mockSmsService
+            .Setup(s => s.SendSmsAsync("+15551234567", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SmsResult(Success: true, MessageId: "sid1", ErrorMessage: null));
+
+        _mockSmsService
+            .Setup(s => s.SendSmsAsync("+15559999999", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SmsResult(Success: false, MessageId: null, ErrorMessage: "Failed"));
+
+        // Act
+        await _service.SendCommunicationAsync(4);
+
+        // Assert
+        var sentCommunication = await _context.Communications
+            .Include(c => c.Recipients)
+            .FirstAsync(c => c.Id == 4);
+
+        sentCommunication.Status.Should().Be(CommunicationStatus.Sent);
+        sentCommunication.DeliveredCount.Should().Be(1);
+        sentCommunication.FailedCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SendCommunicationAsync_WithDraftStatus_SkipsSending()
+    {
+        // Arrange
+        var communication = new Communication
+        {
+            Id = 5,
+            CommunicationType = CommunicationType.Sms,
+            Status = CommunicationStatus.Draft,
+            Body = "Test message",
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        // Act
+        await _service.SendCommunicationAsync(5);
+
+        // Assert
+        var draftCommunication = await _context.Communications.FirstAsync(c => c.Id == 5);
+        draftCommunication.Status.Should().Be(CommunicationStatus.Draft);
+        draftCommunication.SentDateTime.Should().BeNull();
+
+        _mockSmsService.Verify(
+            s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SendCommunicationAsync_WithAlreadySentStatus_SkipsSending()
+    {
+        // Arrange
+        var communication = new Communication
+        {
+            Id = 6,
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Sent,
+            Subject = "Already sent",
+            Body = "Body",
+            SentDateTime = DateTime.UtcNow.AddHours(-1),
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        // Act
+        await _service.SendCommunicationAsync(6);
+
+        // Assert
+        _mockEmailSender.Verify(
+            e => e.SendEmailAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SendCommunicationAsync_WithNonExistentCommunication_DoesNotThrow()
+    {
+        // Act
+        var act = async () => await _service.SendCommunicationAsync(999);
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task SendCommunicationAsync_SkipsAlreadyProcessedRecipients()
+    {
+        // Arrange
+        var communication = new Communication
+        {
+            Id = 7,
+            CommunicationType = CommunicationType.Sms,
+            Status = CommunicationStatus.Pending,
+            Body = "Test message",
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        var deliveredRecipient = new CommunicationRecipient
+        {
+            Id = 7,
+            CommunicationId = 7,
+            PersonId = 1,
+            Address = "+15551111111",
+            Status = CommunicationRecipientStatus.Delivered, // Already delivered
+            DeliveredDateTime = DateTime.UtcNow.AddMinutes(-5),
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        var pendingRecipient = new CommunicationRecipient
+        {
+            Id = 8,
+            CommunicationId = 7,
+            PersonId = 2,
+            Address = "+15552222222",
+            Status = CommunicationRecipientStatus.Pending,
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        communication.Recipients = new List<CommunicationRecipient> { deliveredRecipient, pendingRecipient };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        _mockSmsService
+            .Setup(s => s.SendSmsAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SmsResult(Success: true, MessageId: "sid", ErrorMessage: null));
+
+        // Act
+        await _service.SendCommunicationAsync(7);
+
+        // Assert
+        _mockSmsService.Verify(
+            s => s.SendSmsAsync("+15552222222", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Should NOT attempt to send to already-delivered recipient
+        _mockSmsService.Verify(
+            s => s.SendSmsAsync("+15551111111", It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    public void Dispose()
+    {
+        _context?.Database.EnsureDeleted();
+        _context?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
## Summary
- Created CommunicationSender service with atomic double-send prevention
- Added CommunicationSenderBackgroundService for polling and sending
- Extended CreateCommunicationDtoValidator with SMS-specific rules
- Built frontend UI: MessageTypeToggle, SmsComposer, EmailComposer, CommunicationComposer
- Added CommunicationsPage at /admin/communications

## Technical Details
- Uses atomic SQL UPDATE to prevent race conditions on concurrent sends
- Saves recipient status after each send for crash recovery
- Captures Twilio error messages for failed SMS deliveries
- SMS validation: max 1600 chars (10 segments), no subject allowed

## Test plan
- [ ] Verify SMS messages send to mobile numbers
- [ ] Verify character counter shows segment count
- [ ] Verify email sends with subject and HTML body
- [ ] Verify communication list shows status and delivery counts
- [ ] Test double-send prevention under concurrent load

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)