### PR TITLE
feat: Add member self-service profile portal (#115)

### DIFF
--- a/src/Koinon.Api/Controllers/MyProfileController.cs
+++ b/src/Koinon.Api/Controllers/MyProfileController.cs
@@ -1,0 +1,141 @@
+using Koinon.Application.DTOs.Requests;
+using Koinon.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Koinon.Api.Controllers;
+
+/// <summary>
+/// API controller for self-service profile management.
+/// Allows authenticated users to view and update their own profile and family information.
+/// </summary>
+[Authorize]
+[ApiController]
+public class MyProfileController(IMyProfileService myProfileService) : ControllerBase
+{
+    /// <summary>
+    /// Gets the current user's profile details.
+    /// </summary>
+    [HttpGet("api/v1/my-profile")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetMyProfile(CancellationToken ct)
+    {
+        var result = await myProfileService.GetMyProfileAsync(ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.Error!.Code switch
+            {
+                "NOT_FOUND" => NotFound(result.Error),
+                "FORBIDDEN" => Unauthorized(result.Error),
+                _ => BadRequest(result.Error)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Updates the current user's profile with restricted fields.
+    /// </summary>
+    [HttpPut("api/v1/my-profile")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> UpdateMyProfile(
+        [FromBody] UpdateMyProfileRequest request,
+        CancellationToken ct)
+    {
+        var result = await myProfileService.UpdateMyProfileAsync(request, ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.Error!.Code switch
+            {
+                "NOT_FOUND" => NotFound(result.Error),
+                "FORBIDDEN" => Unauthorized(result.Error),
+                "VALIDATION_ERROR" => BadRequest(result.Error),
+                _ => BadRequest(result.Error)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Gets the current user's family members.
+    /// </summary>
+    [HttpGet("api/v1/my-family")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetMyFamily(CancellationToken ct)
+    {
+        var result = await myProfileService.GetMyFamilyAsync(ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.Error!.Code switch
+            {
+                "FORBIDDEN" => Unauthorized(result.Error),
+                _ => BadRequest(result.Error)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Updates a family member's information (limited fields).
+    /// Only allowed if current user is an adult in the family AND target person is a child.
+    /// </summary>
+    [HttpPut("api/v1/my-family/members/{personIdKey}")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> UpdateFamilyMember(
+        string personIdKey,
+        [FromBody] UpdateFamilyMemberRequest request,
+        CancellationToken ct)
+    {
+        var result = await myProfileService.UpdateFamilyMemberAsync(personIdKey, request, ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.Error!.Code switch
+            {
+                "NOT_FOUND" => NotFound(result.Error),
+                "FORBIDDEN" => StatusCode(StatusCodes.Status403Forbidden, result.Error),
+                "VALIDATION_ERROR" => BadRequest(result.Error),
+                _ => BadRequest(result.Error)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Gets the current user's involvement (groups and attendance summary).
+    /// </summary>
+    [HttpGet("api/v1/my-involvement")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+    public async Task<IActionResult> GetMyInvolvement(CancellationToken ct)
+    {
+        var result = await myProfileService.GetMyInvolvementAsync(ct);
+
+        if (!result.IsSuccess)
+        {
+            return result.Error!.Code switch
+            {
+                "FORBIDDEN" => Unauthorized(result.Error),
+                _ => BadRequest(result.Error)
+            };
+        }
+
+        return Ok(result.Value);
+    }
+}

--- a/src/Koinon.Application/DTOs/MyFamilyMemberDto.cs
+++ b/src/Koinon.Application/DTOs/MyFamilyMemberDto.cs
@@ -1,0 +1,25 @@
+namespace Koinon.Application.DTOs;
+
+/// <summary>
+/// DTO for family member information in self-service profile context.
+/// Contains person details and edit permissions for the current user.
+/// </summary>
+public record MyFamilyMemberDto
+{
+    public required string IdKey { get; init; }
+    public required string FirstName { get; init; }
+    public string? NickName { get; init; }
+    public required string LastName { get; init; }
+    public required string FullName { get; init; }
+    public DateOnly? BirthDate { get; init; }
+    public int? Age { get; init; }
+    public required string Gender { get; init; }
+    public string? Email { get; init; }
+    public required IReadOnlyList<PhoneNumberDto> PhoneNumbers { get; init; }
+    public string? PhotoUrl { get; init; }
+    public required string FamilyRole { get; init; }
+    public bool CanEdit { get; init; }
+    public string? Allergies { get; init; }
+    public bool HasCriticalAllergies { get; init; }
+    public string? SpecialNeeds { get; init; }
+}

--- a/src/Koinon.Application/DTOs/MyInvolvementDto.cs
+++ b/src/Koinon.Application/DTOs/MyInvolvementDto.cs
@@ -1,0 +1,58 @@
+namespace Koinon.Application.DTOs;
+
+/// <summary>
+/// DTO for current user's involvement summary (groups and attendance).
+/// </summary>
+public record MyInvolvementDto
+{
+    /// <summary>
+    /// Groups the user belongs to (excluding family).
+    /// </summary>
+    public required IReadOnlyList<MyInvolvementGroupDto> Groups { get; init; }
+
+    /// <summary>
+    /// Recent attendance summary count (last 30 days).
+    /// </summary>
+    public int RecentAttendanceCount { get; init; }
+
+    /// <summary>
+    /// Total group memberships count.
+    /// </summary>
+    public int TotalGroupsCount { get; init; }
+}
+
+/// <summary>
+/// DTO for a group in the user's involvement list.
+/// </summary>
+public record MyInvolvementGroupDto
+{
+    public required string IdKey { get; init; }
+    public required string GroupName { get; init; }
+    public string? Description { get; init; }
+    public required string GroupTypeName { get; init; }
+
+    /// <summary>
+    /// User's role in this group.
+    /// </summary>
+    public required string Role { get; init; }
+
+    /// <summary>
+    /// Whether the user is a leader of this group.
+    /// </summary>
+    public bool IsLeader { get; init; }
+
+    /// <summary>
+    /// Last attendance date for this group (if available).
+    /// </summary>
+    public DateTime? LastAttendanceDate { get; init; }
+
+    /// <summary>
+    /// Date when the user joined this group.
+    /// </summary>
+    public DateTime? JoinedDate { get; init; }
+
+    /// <summary>
+    /// Campus associated with this group.
+    /// </summary>
+    public CampusSummaryDto? Campus { get; init; }
+}

--- a/src/Koinon.Application/DTOs/MyProfileDto.cs
+++ b/src/Koinon.Application/DTOs/MyProfileDto.cs
@@ -1,0 +1,28 @@
+namespace Koinon.Application.DTOs;
+
+/// <summary>
+/// DTO for current user's profile information.
+/// Extends PersonDto with self-service-specific fields.
+/// </summary>
+public record MyProfileDto
+{
+    public required string IdKey { get; init; }
+    public required Guid Guid { get; init; }
+    public required string FirstName { get; init; }
+    public string? NickName { get; init; }
+    public string? MiddleName { get; init; }
+    public required string LastName { get; init; }
+    public required string FullName { get; init; }
+    public DateOnly? BirthDate { get; init; }
+    public int? Age { get; init; }
+    public required string Gender { get; init; }
+    public string? Email { get; init; }
+    public bool IsEmailActive { get; init; }
+    public required string EmailPreference { get; init; }
+    public required IReadOnlyList<PhoneNumberDto> PhoneNumbers { get; init; }
+    public FamilySummaryDto? PrimaryFamily { get; init; }
+    public CampusSummaryDto? PrimaryCampus { get; init; }
+    public string? PhotoUrl { get; init; }
+    public required DateTime CreatedDateTime { get; init; }
+    public DateTime? ModifiedDateTime { get; init; }
+}

--- a/src/Koinon.Application/DTOs/Requests/UpdateFamilyMemberRequest.cs
+++ b/src/Koinon.Application/DTOs/Requests/UpdateFamilyMemberRequest.cs
@@ -1,0 +1,34 @@
+namespace Koinon.Application.DTOs.Requests;
+
+/// <summary>
+/// Request DTO for updating a family member's information.
+/// Only allows updating limited fields for children by their parents.
+/// </summary>
+public record UpdateFamilyMemberRequest
+{
+    /// <summary>
+    /// Preferred name or nickname.
+    /// </summary>
+    public string? NickName { get; init; }
+
+    /// <summary>
+    /// Phone numbers to update (replaces existing).
+    /// Typically used for teen children's mobile phones.
+    /// </summary>
+    public IReadOnlyList<UpdatePhoneNumberRequest>? PhoneNumbers { get; init; }
+
+    /// <summary>
+    /// Known allergies.
+    /// </summary>
+    public string? Allergies { get; init; }
+
+    /// <summary>
+    /// Whether the child has critical allergies.
+    /// </summary>
+    public bool? HasCriticalAllergies { get; init; }
+
+    /// <summary>
+    /// Special needs or additional care notes.
+    /// </summary>
+    public string? SpecialNeeds { get; init; }
+}

--- a/src/Koinon.Application/DTOs/Requests/UpdateMyProfileRequest.cs
+++ b/src/Koinon.Application/DTOs/Requests/UpdateMyProfileRequest.cs
@@ -1,0 +1,64 @@
+namespace Koinon.Application.DTOs.Requests;
+
+/// <summary>
+/// Request DTO for updating the current user's profile.
+/// Only allows updating "safe" fields - does not allow changing status or role fields.
+/// </summary>
+public record UpdateMyProfileRequest
+{
+    /// <summary>
+    /// Email address.
+    /// </summary>
+    public string? Email { get; init; }
+
+    /// <summary>
+    /// Email communication preference.
+    /// </summary>
+    public string? EmailPreference { get; init; }
+
+    /// <summary>
+    /// Preferred name or nickname.
+    /// </summary>
+    public string? NickName { get; init; }
+
+    /// <summary>
+    /// Phone numbers to update (replaces existing).
+    /// </summary>
+    public IReadOnlyList<UpdatePhoneNumberRequest>? PhoneNumbers { get; init; }
+}
+
+/// <summary>
+/// Request DTO for updating a phone number.
+/// </summary>
+public record UpdatePhoneNumberRequest
+{
+    /// <summary>
+    /// IdKey of existing phone number (null if creating new).
+    /// </summary>
+    public string? IdKey { get; init; }
+
+    /// <summary>
+    /// Phone number (digits only).
+    /// </summary>
+    public required string Number { get; init; }
+
+    /// <summary>
+    /// Phone extension.
+    /// </summary>
+    public string? Extension { get; init; }
+
+    /// <summary>
+    /// Phone type IdKey (Mobile, Home, Work).
+    /// </summary>
+    public string? PhoneTypeIdKey { get; init; }
+
+    /// <summary>
+    /// Whether SMS messaging is enabled for this number.
+    /// </summary>
+    public bool IsMessagingEnabled { get; init; }
+
+    /// <summary>
+    /// Whether this phone number should be hidden from directories.
+    /// </summary>
+    public bool IsUnlisted { get; init; }
+}

--- a/src/Koinon.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Koinon.Application/Extensions/ServiceCollectionExtensions.cs
@@ -82,6 +82,9 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ICommunicationService, CommunicationService>();
         services.AddScoped<ICommunicationSender, CommunicationSender>();
 
+        // Self-service profile service
+        services.AddScoped<IMyProfileService, MyProfileService>();
+
         // AutoMapper - register all mapping profiles
         services.AddAutoMapper(typeof(ServiceCollectionExtensions).Assembly);
 

--- a/src/Koinon.Application/Interfaces/IMyProfileService.cs
+++ b/src/Koinon.Application/Interfaces/IMyProfileService.cs
@@ -1,0 +1,44 @@
+using Koinon.Application.Common;
+using Koinon.Application.DTOs;
+using Koinon.Application.DTOs.Requests;
+
+namespace Koinon.Application.Interfaces;
+
+/// <summary>
+/// Service interface for self-service profile management.
+/// Allows authenticated users to view and update their own profile and family information.
+/// </summary>
+public interface IMyProfileService
+{
+    /// <summary>
+    /// Gets the current user's profile details.
+    /// </summary>
+    Task<Result<MyProfileDto>> GetMyProfileAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates the current user's profile with restricted fields.
+    /// Users can only update safe fields: Email, PhoneNumbers, NickName, EmailPreference.
+    /// </summary>
+    Task<Result<MyProfileDto>> UpdateMyProfileAsync(
+        UpdateMyProfileRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the current user's family members.
+    /// </summary>
+    Task<Result<IReadOnlyList<MyFamilyMemberDto>>> GetMyFamilyAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates a family member's information (limited fields).
+    /// Only allowed if current user is an adult in the family AND target person is a child.
+    /// </summary>
+    Task<Result<MyFamilyMemberDto>> UpdateFamilyMemberAsync(
+        string personIdKey,
+        UpdateFamilyMemberRequest request,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the current user's involvement (groups and attendance summary).
+    /// </summary>
+    Task<Result<MyInvolvementDto>> GetMyInvolvementAsync(CancellationToken ct = default);
+}

--- a/src/Koinon.Application/Services/MyProfileService.cs
+++ b/src/Koinon.Application/Services/MyProfileService.cs
@@ -1,0 +1,637 @@
+using FluentValidation;
+using Koinon.Application.Common;
+using Koinon.Application.DTOs;
+using Koinon.Application.DTOs.Requests;
+using Koinon.Application.Interfaces;
+using Koinon.Domain.Data;
+using Koinon.Domain.Entities;
+using Koinon.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Koinon.Application.Services;
+
+/// <summary>
+/// Service for self-service profile management.
+/// Allows authenticated users to view and update their own profile and family information.
+/// </summary>
+public class MyProfileService(
+    IApplicationDbContext context,
+    IUserContext userContext,
+    IValidator<UpdateMyProfileRequest> updateProfileValidator,
+    IValidator<UpdateFamilyMemberRequest> updateFamilyMemberValidator,
+    ILogger<MyProfileService> logger) : IMyProfileService
+{
+    public async Task<Result<MyProfileDto>> GetMyProfileAsync(CancellationToken ct = default)
+    {
+        var currentPersonId = userContext.CurrentPersonId;
+        if (!currentPersonId.HasValue)
+        {
+            return Result<MyProfileDto>.Failure(
+                Error.Forbidden("User is not authenticated"));
+        }
+
+        var person = await context.People
+            .AsNoTracking()
+            .Include(p => p.PhoneNumbers)
+                .ThenInclude(pn => pn.NumberTypeValue)
+            .Include(p => p.PrimaryFamily)
+            .Include(p => p.PrimaryCampus)
+            .FirstOrDefaultAsync(p => p.Id == currentPersonId.Value, ct);
+
+        if (person == null)
+        {
+            return Result<MyProfileDto>.Failure(
+                Error.NotFound("Person", IdKeyHelper.Encode(currentPersonId.Value)));
+        }
+
+        var dto = MapToMyProfileDto(person);
+
+        logger.LogInformation(
+            "Retrieved profile for PersonIdKey={PersonIdKey}",
+            person.IdKey);
+
+        return Result<MyProfileDto>.Success(dto);
+    }
+
+    public async Task<Result<MyProfileDto>> UpdateMyProfileAsync(
+        UpdateMyProfileRequest request,
+        CancellationToken ct = default)
+    {
+        // Validate request
+        var validationResult = await updateProfileValidator.ValidateAsync(request, ct);
+        if (!validationResult.IsValid)
+        {
+            return Result<MyProfileDto>.Failure(Error.FromFluentValidation(validationResult));
+        }
+
+        var currentPersonId = userContext.CurrentPersonId;
+        if (!currentPersonId.HasValue)
+        {
+            return Result<MyProfileDto>.Failure(
+                Error.Forbidden("User is not authenticated"));
+        }
+
+        var person = await context.People
+            .Include(p => p.PhoneNumbers)
+                .ThenInclude(pn => pn.NumberTypeValue)
+            .Include(p => p.PrimaryFamily)
+            .Include(p => p.PrimaryCampus)
+            .FirstOrDefaultAsync(p => p.Id == currentPersonId.Value, ct);
+
+        if (person == null)
+        {
+            return Result<MyProfileDto>.Failure(
+                Error.NotFound("Person", IdKeyHelper.Encode(currentPersonId.Value)));
+        }
+
+        // Update allowed fields only
+        if (request.Email != null)
+        {
+            person.Email = request.Email;
+        }
+
+        if (request.EmailPreference != null)
+        {
+            person.EmailPreference = request.EmailPreference switch
+            {
+                "EmailAllowed" => EmailPreference.EmailAllowed,
+                "NoMassEmails" => EmailPreference.NoMassEmails,
+                "DoNotEmail" => EmailPreference.DoNotEmail,
+                _ => person.EmailPreference
+            };
+        }
+
+        if (request.NickName != null)
+        {
+            person.NickName = request.NickName;
+        }
+
+        // Update phone numbers
+        if (request.PhoneNumbers != null)
+        {
+            await UpdatePhoneNumbersAsync(person, request.PhoneNumbers, ct);
+        }
+
+        person.ModifiedDateTime = DateTime.UtcNow;
+        await context.SaveChangesAsync(ct);
+
+        // Reload to get updated data with navigation properties
+        await context.Entry(person).ReloadAsync(ct);
+        await context.Entry(person)
+            .Collection(p => p.PhoneNumbers)
+            .Query()
+            .Include(pn => pn.NumberTypeValue)
+            .LoadAsync(ct);
+
+        var dto = MapToMyProfileDto(person);
+
+        logger.LogInformation(
+            "Updated profile for PersonIdKey={PersonIdKey}",
+            person.IdKey);
+
+        return Result<MyProfileDto>.Success(dto);
+    }
+
+    public async Task<Result<IReadOnlyList<MyFamilyMemberDto>>> GetMyFamilyAsync(CancellationToken ct = default)
+    {
+        var currentPersonId = userContext.CurrentPersonId;
+        if (!currentPersonId.HasValue)
+        {
+            return Result<IReadOnlyList<MyFamilyMemberDto>>.Failure(
+                Error.Forbidden("User is not authenticated"));
+        }
+
+        var person = await context.People
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == currentPersonId.Value, ct);
+
+        if (person == null || !person.PrimaryFamilyId.HasValue)
+        {
+            return Result<IReadOnlyList<MyFamilyMemberDto>>.Success(
+                Array.Empty<MyFamilyMemberDto>());
+        }
+
+        // Get current user's role in family to determine edit permissions
+        var currentUserRole = await context.GroupMembers
+            .AsNoTracking()
+            .Include(gm => gm.GroupRole)
+            .Where(gm => gm.GroupId == person.PrimaryFamilyId.Value
+                && gm.PersonId == currentPersonId.Value
+                && gm.GroupMemberStatus == GroupMemberStatus.Active)
+            .Select(gm => gm.GroupRole)
+            .FirstOrDefaultAsync(ct);
+
+        bool currentUserIsAdult = currentUserRole?.Guid == SystemGuid.GroupTypeRole.FamilyAdult;
+
+        // Get family members
+        var familyMembers = await context.GroupMembers
+            .AsNoTracking()
+            .Include(gm => gm.Person)
+                .ThenInclude(p => p!.PhoneNumbers)
+                    .ThenInclude(pn => pn.NumberTypeValue)
+            .Include(gm => gm.GroupRole)
+            .Where(gm => gm.GroupId == person.PrimaryFamilyId.Value
+                && gm.GroupMemberStatus == GroupMemberStatus.Active)
+            .OrderByDescending(gm => gm.GroupRole!.Guid == SystemGuid.GroupTypeRole.FamilyAdult)
+            .ThenBy(gm => gm.Person!.BirthYear)
+            .ThenBy(gm => gm.Person!.BirthMonth)
+            .ThenBy(gm => gm.Person!.BirthDay)
+            .ToListAsync(ct);
+
+        var dtos = familyMembers.Select(fm =>
+        {
+            var isChild = fm.GroupRole?.Guid == SystemGuid.GroupTypeRole.FamilyChild;
+            var canEdit = currentUserIsAdult && isChild;
+
+            return new MyFamilyMemberDto
+            {
+                IdKey = fm.Person!.IdKey,
+                FirstName = fm.Person.FirstName,
+                NickName = fm.Person.NickName,
+                LastName = fm.Person.LastName,
+                FullName = fm.Person.FullName,
+                BirthDate = fm.Person.BirthDate,
+                Age = fm.Person.BirthDate.HasValue
+                    ? DateTime.UtcNow.Year - fm.Person.BirthDate.Value.Year
+                    : null,
+                Gender = fm.Person.Gender.ToString(),
+                Email = fm.Person.Email,
+                PhoneNumbers = fm.Person.PhoneNumbers
+                    .OrderBy(pn => pn.NumberTypeValue?.Order ?? 999)
+                    .Select(pn => new PhoneNumberDto
+                    {
+                        IdKey = pn.IdKey,
+                        Number = pn.Number,
+                        NumberFormatted = FormatPhoneNumber(pn.Number),
+                        Extension = pn.Extension,
+                        PhoneType = pn.NumberTypeValue != null ? new DefinedValueDto
+                        {
+                            IdKey = pn.NumberTypeValue.IdKey,
+                            Guid = pn.NumberTypeValue.Guid,
+                            Value = pn.NumberTypeValue.Value,
+                            Description = pn.NumberTypeValue.Description,
+                            IsActive = pn.NumberTypeValue.IsActive,
+                            Order = pn.NumberTypeValue.Order
+                        } : null,
+                        IsMessagingEnabled = pn.IsMessagingEnabled,
+                        IsUnlisted = pn.IsUnlisted
+                    })
+                    .ToList(),
+                PhotoUrl = null, // TODO(#116): Implement photo URLs
+                FamilyRole = fm.GroupRole?.Name ?? "Unknown",
+                CanEdit = canEdit,
+                Allergies = fm.Person.Allergies,
+                HasCriticalAllergies = fm.Person.HasCriticalAllergies,
+                SpecialNeeds = fm.Person.SpecialNeeds
+            };
+        }).ToList();
+
+        logger.LogInformation(
+            "Retrieved {Count} family members for PersonIdKey={PersonIdKey}",
+            dtos.Count,
+            IdKeyHelper.Encode(currentPersonId.Value));
+
+        return Result<IReadOnlyList<MyFamilyMemberDto>>.Success(dtos);
+    }
+
+    public async Task<Result<MyFamilyMemberDto>> UpdateFamilyMemberAsync(
+        string personIdKey,
+        UpdateFamilyMemberRequest request,
+        CancellationToken ct = default)
+    {
+        // Validate request
+        var validationResult = await updateFamilyMemberValidator.ValidateAsync(request, ct);
+        if (!validationResult.IsValid)
+        {
+            return Result<MyFamilyMemberDto>.Failure(Error.FromFluentValidation(validationResult));
+        }
+
+        var currentPersonId = userContext.CurrentPersonId;
+        if (!currentPersonId.HasValue)
+        {
+            return Result<MyFamilyMemberDto>.Failure(
+                Error.Forbidden("User is not authenticated"));
+        }
+
+        if (!IdKeyHelper.TryDecode(personIdKey, out int targetPersonId))
+        {
+            return Result<MyFamilyMemberDto>.Failure(Error.NotFound("Person", personIdKey));
+        }
+
+        // Get current user
+        var currentPerson = await context.People
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == currentPersonId.Value, ct);
+
+        if (currentPerson == null || !currentPerson.PrimaryFamilyId.HasValue)
+        {
+            return Result<MyFamilyMemberDto>.Failure(
+                Error.Forbidden("You must be part of a family to update family members"));
+        }
+
+        // Get current user's role
+        var currentUserMembership = await context.GroupMembers
+            .AsNoTracking()
+            .Include(gm => gm.GroupRole)
+            .Where(gm => gm.GroupId == currentPerson.PrimaryFamilyId.Value
+                && gm.PersonId == currentPersonId.Value
+                && gm.GroupMemberStatus == GroupMemberStatus.Active)
+            .FirstOrDefaultAsync(ct);
+
+        if (currentUserMembership?.GroupRole?.Guid != SystemGuid.GroupTypeRole.FamilyAdult)
+        {
+            return Result<MyFamilyMemberDto>.Failure(
+                Error.Forbidden("Only adults can update family member information"));
+        }
+
+        // Get target person
+        var targetPerson = await context.People
+            .Include(p => p.PhoneNumbers)
+                .ThenInclude(pn => pn.NumberTypeValue)
+            .FirstOrDefaultAsync(p => p.Id == targetPersonId, ct);
+
+        if (targetPerson == null)
+        {
+            return Result<MyFamilyMemberDto>.Failure(Error.NotFound("Person", personIdKey));
+        }
+
+        // Verify target person is in same family
+        var targetMembership = await context.GroupMembers
+            .AsNoTracking()
+            .Include(gm => gm.GroupRole)
+            .Where(gm => gm.GroupId == currentPerson.PrimaryFamilyId.Value
+                && gm.PersonId == targetPersonId
+                && gm.GroupMemberStatus == GroupMemberStatus.Active)
+            .FirstOrDefaultAsync(ct);
+
+        if (targetMembership == null)
+        {
+            return Result<MyFamilyMemberDto>.Failure(
+                Error.Forbidden("Person is not part of your family"));
+        }
+
+        // Verify target is a child
+        if (targetMembership.GroupRole?.Guid != SystemGuid.GroupTypeRole.FamilyChild)
+        {
+            return Result<MyFamilyMemberDto>.Failure(
+                Error.Forbidden("You can only update information for children in your family"));
+        }
+
+        // Update allowed fields
+        if (request.NickName != null)
+        {
+            targetPerson.NickName = request.NickName;
+        }
+
+        if (request.Allergies != null)
+        {
+            targetPerson.Allergies = request.Allergies;
+        }
+
+        if (request.HasCriticalAllergies.HasValue)
+        {
+            targetPerson.HasCriticalAllergies = request.HasCriticalAllergies.Value;
+        }
+
+        if (request.SpecialNeeds != null)
+        {
+            targetPerson.SpecialNeeds = request.SpecialNeeds;
+        }
+
+        // Update phone numbers
+        if (request.PhoneNumbers != null)
+        {
+            await UpdatePhoneNumbersAsync(targetPerson, request.PhoneNumbers, ct);
+        }
+
+        targetPerson.ModifiedDateTime = DateTime.UtcNow;
+        await context.SaveChangesAsync(ct);
+
+        // Reload to get updated data
+        await context.Entry(targetPerson).ReloadAsync(ct);
+        await context.Entry(targetPerson)
+            .Collection(p => p.PhoneNumbers)
+            .Query()
+            .Include(pn => pn.NumberTypeValue)
+            .LoadAsync(ct);
+
+        var dto = new MyFamilyMemberDto
+        {
+            IdKey = targetPerson.IdKey,
+            FirstName = targetPerson.FirstName,
+            NickName = targetPerson.NickName,
+            LastName = targetPerson.LastName,
+            FullName = targetPerson.FullName,
+            BirthDate = targetPerson.BirthDate,
+            Age = targetPerson.BirthDate.HasValue
+                ? DateTime.UtcNow.Year - targetPerson.BirthDate.Value.Year
+                : null,
+            Gender = targetPerson.Gender.ToString(),
+            Email = targetPerson.Email,
+            PhoneNumbers = targetPerson.PhoneNumbers
+                .OrderBy(pn => pn.NumberTypeValue?.Order ?? 999)
+                .Select(pn => new PhoneNumberDto
+                {
+                    IdKey = pn.IdKey,
+                    Number = pn.Number,
+                    NumberFormatted = FormatPhoneNumber(pn.Number),
+                    Extension = pn.Extension,
+                    PhoneType = pn.NumberTypeValue != null ? new DefinedValueDto
+                    {
+                        IdKey = pn.NumberTypeValue.IdKey,
+                        Guid = pn.NumberTypeValue.Guid,
+                        Value = pn.NumberTypeValue.Value,
+                        Description = pn.NumberTypeValue.Description,
+                        IsActive = pn.NumberTypeValue.IsActive,
+                        Order = pn.NumberTypeValue.Order
+                    } : null,
+                    IsMessagingEnabled = pn.IsMessagingEnabled,
+                    IsUnlisted = pn.IsUnlisted
+                })
+                .ToList(),
+            PhotoUrl = null,
+            FamilyRole = targetMembership.GroupRole?.Name ?? "Child",
+            CanEdit = true,
+            Allergies = targetPerson.Allergies,
+            HasCriticalAllergies = targetPerson.HasCriticalAllergies,
+            SpecialNeeds = targetPerson.SpecialNeeds
+        };
+
+        logger.LogInformation(
+            "Updated family member PersonIdKey={PersonIdKey} by PersonIdKey={CurrentPersonIdKey}",
+            targetPerson.IdKey,
+            IdKeyHelper.Encode(currentPersonId.Value));
+
+        return Result<MyFamilyMemberDto>.Success(dto);
+    }
+
+    public async Task<Result<MyInvolvementDto>> GetMyInvolvementAsync(CancellationToken ct = default)
+    {
+        var currentPersonId = userContext.CurrentPersonId;
+        if (!currentPersonId.HasValue)
+        {
+            return Result<MyInvolvementDto>.Failure(
+                Error.Forbidden("User is not authenticated"));
+        }
+
+        // Get groups (excluding family)
+        var groupMemberships = await context.GroupMembers
+            .AsNoTracking()
+            .Include(gm => gm.Group)
+                .ThenInclude(g => g!.GroupType)
+            .Include(gm => gm.Group)
+                .ThenInclude(g => g!.Campus)
+            .Include(gm => gm.GroupRole)
+            .Where(gm => gm.PersonId == currentPersonId.Value
+                && gm.GroupMemberStatus == GroupMemberStatus.Active
+                && !gm.Group!.IsArchived
+                && !gm.Group.GroupType!.IsFamilyGroupType)
+            .ToListAsync(ct);
+
+        var groupIds = groupMemberships.Select(gm => gm.GroupId).ToList();
+
+        // Get last attendance dates for these groups
+        var lastAttendances = await context.Attendances
+            .AsNoTracking()
+            .Include(a => a.Occurrence)
+            .Where(a => a.PersonAliasId.HasValue
+                && a.Occurrence != null
+                && a.Occurrence.GroupId.HasValue
+                && groupIds.Contains(a.Occurrence.GroupId.Value))
+            .GroupBy(a => a.Occurrence!.GroupId!.Value)
+            .Select(g => new
+            {
+                GroupId = g.Key,
+                LastAttendance = g.Max(a => a.StartDateTime)
+            })
+            .ToDictionaryAsync(x => x.GroupId, x => (DateTime?)x.LastAttendance, ct);
+
+        // Get recent attendance count (last 30 days)
+        var thirtyDaysAgo = DateTime.UtcNow.AddDays(-30);
+        var recentAttendanceCount = await context.Attendances
+            .AsNoTracking()
+            .Include(a => a.PersonAlias)
+            .Where(a => a.PersonAliasId.HasValue
+                && a.PersonAlias!.PersonId == currentPersonId.Value
+                && a.StartDateTime >= thirtyDaysAgo
+                && a.DidAttend == true)
+            .CountAsync(ct);
+
+        var groupDtos = groupMemberships.Select(gm => new MyInvolvementGroupDto
+        {
+            IdKey = gm.Group!.IdKey,
+            GroupName = gm.Group.Name,
+            Description = gm.Group.Description,
+            GroupTypeName = gm.Group.GroupType?.Name ?? "Unknown",
+            Role = gm.GroupRole?.Name ?? "Member",
+            IsLeader = gm.GroupRole?.IsLeader ?? false,
+            LastAttendanceDate = lastAttendances.ContainsKey(gm.GroupId)
+                ? lastAttendances[gm.GroupId]
+                : null,
+            JoinedDate = gm.DateTimeAdded,
+            Campus = gm.Group.Campus != null ? new CampusSummaryDto
+            {
+                IdKey = gm.Group.Campus.IdKey,
+                Name = gm.Group.Campus.Name,
+                ShortCode = gm.Group.Campus.ShortCode
+            } : null
+        }).OrderBy(g => g.GroupName).ToList();
+
+        var dto = new MyInvolvementDto
+        {
+            Groups = groupDtos,
+            RecentAttendanceCount = recentAttendanceCount,
+            TotalGroupsCount = groupDtos.Count
+        };
+
+        logger.LogInformation(
+            "Retrieved involvement for PersonIdKey={PersonIdKey}: {GroupCount} groups, {AttendanceCount} recent attendances",
+            IdKeyHelper.Encode(currentPersonId.Value), dto.TotalGroupsCount, dto.RecentAttendanceCount);
+
+        return Result<MyInvolvementDto>.Success(dto);
+    }
+
+    // Private helper methods
+
+    private static MyProfileDto MapToMyProfileDto(Person person)
+    {
+        return new MyProfileDto
+        {
+            IdKey = person.IdKey,
+            Guid = person.Guid,
+            FirstName = person.FirstName,
+            NickName = person.NickName,
+            MiddleName = person.MiddleName,
+            LastName = person.LastName,
+            FullName = person.FullName,
+            BirthDate = person.BirthDate,
+            Age = person.BirthDate.HasValue
+                ? DateTime.UtcNow.Year - person.BirthDate.Value.Year
+                : null,
+            Gender = person.Gender.ToString(),
+            Email = person.Email,
+            IsEmailActive = person.IsEmailActive,
+            EmailPreference = person.EmailPreference.ToString(),
+            PhoneNumbers = person.PhoneNumbers
+                .OrderBy(pn => pn.NumberTypeValue?.Order ?? 999)
+                .Select(pn => new PhoneNumberDto
+                {
+                    IdKey = pn.IdKey,
+                    Number = pn.Number,
+                    NumberFormatted = FormatPhoneNumber(pn.Number),
+                    Extension = pn.Extension,
+                    PhoneType = pn.NumberTypeValue != null ? new DefinedValueDto
+                    {
+                        IdKey = pn.NumberTypeValue.IdKey,
+                        Guid = pn.NumberTypeValue.Guid,
+                        Value = pn.NumberTypeValue.Value,
+                        Description = pn.NumberTypeValue.Description,
+                        IsActive = pn.NumberTypeValue.IsActive,
+                        Order = pn.NumberTypeValue.Order
+                    } : null,
+                    IsMessagingEnabled = pn.IsMessagingEnabled,
+                    IsUnlisted = pn.IsUnlisted
+                })
+                .ToList(),
+            PrimaryFamily = person.PrimaryFamily != null ? new FamilySummaryDto
+            {
+                IdKey = person.PrimaryFamily.IdKey,
+                Name = person.PrimaryFamily.Name,
+                MemberCount = 0 // Will be populated separately if needed
+            } : null,
+            PrimaryCampus = person.PrimaryCampus != null ? new CampusSummaryDto
+            {
+                IdKey = person.PrimaryCampus.IdKey,
+                Name = person.PrimaryCampus.Name,
+                ShortCode = person.PrimaryCampus.ShortCode
+            } : null,
+            PhotoUrl = null, // TODO(#116): Implement photo URLs
+            CreatedDateTime = person.CreatedDateTime,
+            ModifiedDateTime = person.ModifiedDateTime
+        };
+    }
+
+    private Task UpdatePhoneNumbersAsync(
+        Person person,
+        IReadOnlyList<UpdatePhoneNumberRequest> phoneNumberRequests,
+        CancellationToken ct)
+    {
+        // Get existing phone numbers
+        var existingPhoneNumbers = person.PhoneNumbers.ToList();
+
+        // Remove phone numbers not in the request
+        var requestIdKeys = phoneNumberRequests
+            .Where(pn => !string.IsNullOrWhiteSpace(pn.IdKey))
+            .Select(pn => pn.IdKey!)
+            .ToHashSet();
+
+        foreach (var existingPhone in existingPhoneNumbers)
+        {
+            if (!requestIdKeys.Contains(existingPhone.IdKey))
+            {
+                context.PhoneNumbers.Remove(existingPhone);
+            }
+        }
+
+        // Update or add phone numbers
+        foreach (var phoneRequest in phoneNumberRequests)
+        {
+            PhoneNumber? phoneNumber;
+
+            if (!string.IsNullOrWhiteSpace(phoneRequest.IdKey)
+                && IdKeyHelper.TryDecode(phoneRequest.IdKey, out int phoneId))
+            {
+                // Update existing
+                phoneNumber = existingPhoneNumbers.FirstOrDefault(pn => pn.Id == phoneId);
+                if (phoneNumber == null)
+                {
+                    continue;
+                }
+            }
+            else
+            {
+                // Create new
+                phoneNumber = new PhoneNumber
+                {
+                    Number = phoneRequest.Number,
+                    PersonId = person.Id,
+                    Guid = Guid.NewGuid(),
+                    CreatedDateTime = DateTime.UtcNow
+                };
+                person.PhoneNumbers.Add(phoneNumber);
+            }
+
+            phoneNumber.Number = phoneRequest.Number;
+            phoneNumber.Extension = phoneRequest.Extension;
+            phoneNumber.IsMessagingEnabled = phoneRequest.IsMessagingEnabled;
+            phoneNumber.IsUnlisted = phoneRequest.IsUnlisted;
+            phoneNumber.ModifiedDateTime = DateTime.UtcNow;
+
+            // Set phone type
+            if (!string.IsNullOrWhiteSpace(phoneRequest.PhoneTypeIdKey)
+                && IdKeyHelper.TryDecode(phoneRequest.PhoneTypeIdKey, out int phoneTypeId))
+            {
+                phoneNumber.NumberTypeValueId = phoneTypeId;
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private static string FormatPhoneNumber(string number)
+    {
+        // Simple US phone number formatting using range operators
+        if (number.Length == 10)
+        {
+            return $"({number[..3]}) {number[3..6]}-{number[6..]}";
+        }
+
+        if (number.Length == 11 && number.StartsWith('1'))
+        {
+            return $"+1 ({number[1..4]}) {number[4..7]}-{number[7..]}";
+        }
+
+        return number;
+    }
+}

--- a/src/Koinon.Application/Validators/UpdateFamilyMemberRequestValidator.cs
+++ b/src/Koinon.Application/Validators/UpdateFamilyMemberRequestValidator.cs
@@ -1,0 +1,81 @@
+using FluentValidation;
+using Koinon.Application.DTOs.Requests;
+
+namespace Koinon.Application.Validators;
+
+/// <summary>
+/// Validator for UpdateFamilyMemberRequest.
+/// Ensures field constraints for updating family member information.
+/// </summary>
+public class UpdateFamilyMemberRequestValidator : AbstractValidator<UpdateFamilyMemberRequest>
+{
+    public UpdateFamilyMemberRequestValidator()
+    {
+        When(x => !string.IsNullOrWhiteSpace(x.NickName), () =>
+        {
+            RuleFor(x => x.NickName)
+                .MaximumLength(50)
+                .WithMessage("NickName cannot exceed 50 characters");
+        });
+
+        When(x => !string.IsNullOrWhiteSpace(x.Allergies), () =>
+        {
+            RuleFor(x => x.Allergies)
+                .MaximumLength(500)
+                .WithMessage("Allergies cannot exceed 500 characters")
+                .Must(ContainNoHtmlOrScripts!)
+                .WithMessage("Allergies field cannot contain HTML or script tags");
+        });
+
+        When(x => !string.IsNullOrWhiteSpace(x.SpecialNeeds), () =>
+        {
+            RuleFor(x => x.SpecialNeeds)
+                .MaximumLength(2000)
+                .WithMessage("SpecialNeeds cannot exceed 2000 characters")
+                .Must(ContainNoHtmlOrScripts!)
+                .WithMessage("Special needs field cannot contain HTML or script tags");
+        });
+
+        RuleFor(x => x.PhoneNumbers)
+            .Must(phones => phones == null || phones.Count <= 10)
+            .WithMessage("Maximum of 10 phone numbers allowed");
+
+        When(x => x.PhoneNumbers != null && x.PhoneNumbers.Any(), () =>
+        {
+            RuleForEach(x => x.PhoneNumbers)
+                .SetValidator(new UpdatePhoneNumberRequestValidator());
+        });
+    }
+
+    private static bool ContainNoHtmlOrScripts(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            return true;
+        }
+
+        // Check for HTML tags
+        if (System.Text.RegularExpressions.Regex.IsMatch(value, @"<[^>]+>"))
+        {
+            return false;
+        }
+
+        // Check for script patterns
+        if (value.Contains("javascript:", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (value.Contains("onclick", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (value.Contains("onerror", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Koinon.Application/Validators/UpdateMyProfileRequestValidator.cs
+++ b/src/Koinon.Application/Validators/UpdateMyProfileRequestValidator.cs
@@ -1,0 +1,67 @@
+using FluentValidation;
+using Koinon.Application.DTOs.Requests;
+
+namespace Koinon.Application.Validators;
+
+/// <summary>
+/// Validator for UpdateMyProfileRequest.
+/// Ensures email format and phone number formats are valid.
+/// </summary>
+public class UpdateMyProfileRequestValidator : AbstractValidator<UpdateMyProfileRequest>
+{
+    public UpdateMyProfileRequestValidator()
+    {
+        When(x => !string.IsNullOrWhiteSpace(x.Email), () =>
+        {
+            RuleFor(x => x.Email)
+                .EmailAddress()
+                .WithMessage("Email must be a valid email address");
+        });
+
+        When(x => !string.IsNullOrWhiteSpace(x.EmailPreference), () =>
+        {
+            RuleFor(x => x.EmailPreference)
+                .Must(ep => ep == "EmailAllowed" || ep == "NoMassEmails" || ep == "DoNotEmail")
+                .WithMessage("EmailPreference must be EmailAllowed, NoMassEmails, or DoNotEmail");
+        });
+
+        When(x => !string.IsNullOrWhiteSpace(x.NickName), () =>
+        {
+            RuleFor(x => x.NickName)
+                .MaximumLength(50)
+                .WithMessage("NickName cannot exceed 50 characters");
+        });
+
+        RuleFor(x => x.PhoneNumbers)
+            .Must(phones => phones == null || phones.Count <= 10)
+            .WithMessage("Maximum of 10 phone numbers allowed");
+
+        When(x => x.PhoneNumbers != null && x.PhoneNumbers.Any(), () =>
+        {
+            RuleForEach(x => x.PhoneNumbers)
+                .SetValidator(new UpdatePhoneNumberRequestValidator());
+        });
+    }
+}
+
+/// <summary>
+/// Validator for UpdatePhoneNumberRequest.
+/// </summary>
+public class UpdatePhoneNumberRequestValidator : AbstractValidator<UpdatePhoneNumberRequest>
+{
+    public UpdatePhoneNumberRequestValidator()
+    {
+        RuleFor(x => x.Number)
+            .NotEmpty()
+            .WithMessage("Phone number is required")
+            .Matches(@"^\d{10,15}$")
+            .WithMessage("Phone number must be 10-15 digits");
+
+        When(x => !string.IsNullOrWhiteSpace(x.Extension), () =>
+        {
+            RuleFor(x => x.Extension)
+                .MaximumLength(20)
+                .WithMessage("Extension cannot exceed 20 characters");
+        });
+    }
+}

--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -37,6 +37,7 @@ import { PWAUpdatePrompt, InstallPrompt } from './components/pwa';
 import { GroupFinderPage } from './pages/public/GroupFinderPage';
 import { MyGroupsPage } from './pages/MyGroupsPage';
 import { CommunicationsPage } from './pages/communications/CommunicationsPage';
+import { MyProfilePage } from './pages/profile';
 
 function HomePage() {
   const { isAuthenticated } = useAuth();
@@ -172,6 +173,16 @@ function App() {
           element={
             <ProtectedRoute>
               <MyGroupsPage />
+            </ProtectedRoute>
+          }
+        />
+
+        {/* My Profile - Protected route for authenticated users */}
+        <Route
+          path="/my-profile"
+          element={
+            <ProtectedRoute>
+              <MyProfilePage />
             </ProtectedRoute>
           }
         />

--- a/src/web/src/components/profile/FamilyMemberCard.tsx
+++ b/src/web/src/components/profile/FamilyMemberCard.tsx
@@ -1,0 +1,217 @@
+/**
+ * FamilyMemberCard
+ * Display and edit family member information
+ */
+
+import { useState } from 'react';
+import { useUpdateFamilyMember } from '@/hooks/useProfile';
+import type { FamilyMemberDto } from '@/types/profile';
+
+interface FamilyMemberCardProps {
+  member: FamilyMemberDto;
+}
+
+export function FamilyMemberCard({ member }: FamilyMemberCardProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [nickName, setNickName] = useState(member.nickName || '');
+  const [allergies, setAllergies] = useState(member.allergies || '');
+  const [specialNeeds, setSpecialNeeds] = useState(member.specialNeeds || '');
+
+  const updateMutation = useUpdateFamilyMember();
+
+  const handleSave = async () => {
+    try {
+      await updateMutation.mutateAsync({
+        personIdKey: member.idKey,
+        data: {
+          nickName: nickName || undefined,
+          allergies: allergies || undefined,
+          specialNeeds: specialNeeds || undefined,
+        },
+      });
+      setIsEditing(false);
+    } catch (error) {
+      // Error is handled by TanStack Query mutation state
+    }
+  };
+
+  const handleCancel = () => {
+    setNickName(member.nickName || '');
+    setAllergies(member.allergies || '');
+    setSpecialNeeds(member.specialNeeds || '');
+    setIsEditing(false);
+  };
+
+  if (!isEditing) {
+    // View Mode
+    return (
+      <div className="bg-white border border-gray-200 rounded-lg p-4">
+        <div className="flex items-start gap-4">
+          {member.photoUrl ? (
+            <img
+              src={member.photoUrl}
+              alt={member.fullName}
+              className="w-16 h-16 rounded-full object-cover"
+            />
+          ) : (
+            <div className="w-16 h-16 rounded-full bg-primary-100 flex items-center justify-center">
+              <span className="text-xl font-semibold text-primary-700">
+                {member.firstName[0]}
+                {member.lastName[0]}
+              </span>
+            </div>
+          )}
+
+          <div className="flex-1 min-w-0">
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <h3 className="text-lg font-semibold text-gray-900">{member.fullName}</h3>
+                {member.nickName && (
+                  <p className="text-sm text-gray-600">Prefers: {member.nickName}</p>
+                )}
+                <div className="flex items-center gap-2 mt-1">
+                  <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                    {member.familyRole}
+                  </span>
+                  {member.age && (
+                    <span className="text-sm text-gray-600">{member.age} years old</span>
+                  )}
+                </div>
+              </div>
+
+              {member.canEdit && (
+                <button
+                  onClick={() => setIsEditing(true)}
+                  className="text-sm text-primary-600 hover:text-primary-700 font-medium"
+                >
+                  Edit
+                </button>
+              )}
+            </div>
+
+            {(member.allergies || member.specialNeeds) && (
+              <div className="mt-3 space-y-1">
+                {member.allergies && (
+                  <div className="text-sm">
+                    <span className="font-medium text-gray-700">Allergies:</span>{' '}
+                    <span className="text-gray-900">{member.allergies}</span>
+                  </div>
+                )}
+                {member.specialNeeds && (
+                  <div className="text-sm">
+                    <span className="font-medium text-gray-700">Special Needs:</span>{' '}
+                    <span className="text-gray-900">{member.specialNeeds}</span>
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Edit Mode
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-4">
+      <div className="flex items-start gap-4 mb-4">
+        {member.photoUrl ? (
+          <img
+            src={member.photoUrl}
+            alt={member.fullName}
+            className="w-16 h-16 rounded-full object-cover"
+          />
+        ) : (
+          <div className="w-16 h-16 rounded-full bg-primary-100 flex items-center justify-center">
+            <span className="text-xl font-semibold text-primary-700">
+              {member.firstName[0]}
+              {member.lastName[0]}
+            </span>
+          </div>
+        )}
+
+        <div className="flex-1 min-w-0">
+          <h3 className="text-lg font-semibold text-gray-900">{member.fullName}</h3>
+          <div className="flex items-center gap-2 mt-1">
+            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+              {member.familyRole}
+            </span>
+            {member.age && (
+              <span className="text-sm text-gray-600">{member.age} years old</span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <label htmlFor={`nickName-${member.idKey}`} className="block text-sm font-medium text-gray-700 mb-1">
+            Preferred Name (Nickname)
+          </label>
+          <input
+            type="text"
+            id={`nickName-${member.idKey}`}
+            value={nickName}
+            onChange={(e) => setNickName(e.target.value)}
+            placeholder={member.firstName}
+            disabled={updateMutation.isPending}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:bg-gray-100"
+          />
+        </div>
+
+        <div>
+          <label htmlFor={`allergies-${member.idKey}`} className="block text-sm font-medium text-gray-700 mb-1">
+            Allergies
+          </label>
+          <textarea
+            id={`allergies-${member.idKey}`}
+            value={allergies}
+            onChange={(e) => setAllergies(e.target.value)}
+            placeholder="Any allergies or dietary restrictions"
+            rows={2}
+            disabled={updateMutation.isPending}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:bg-gray-100"
+          />
+        </div>
+
+        <div>
+          <label htmlFor={`specialNeeds-${member.idKey}`} className="block text-sm font-medium text-gray-700 mb-1">
+            Special Needs
+          </label>
+          <textarea
+            id={`specialNeeds-${member.idKey}`}
+            value={specialNeeds}
+            onChange={(e) => setSpecialNeeds(e.target.value)}
+            placeholder="Any special needs or accommodations"
+            rows={2}
+            disabled={updateMutation.isPending}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:bg-gray-100"
+          />
+        </div>
+
+        <div className="flex gap-2 pt-2">
+          <button
+            onClick={handleSave}
+            disabled={updateMutation.isPending}
+            className="px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50 text-sm"
+          >
+            {updateMutation.isPending ? 'Saving...' : 'Save'}
+          </button>
+          <button
+            onClick={handleCancel}
+            disabled={updateMutation.isPending}
+            className="px-4 py-2 text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50 text-sm"
+          >
+            Cancel
+          </button>
+        </div>
+
+        {updateMutation.isError && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-2 text-sm text-red-800">
+            Failed to update. Please try again.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/profile/FamilySection.tsx
+++ b/src/web/src/components/profile/FamilySection.tsx
@@ -1,0 +1,45 @@
+/**
+ * FamilySection
+ * Grid display of family members
+ */
+
+import { FamilyMemberCard } from './FamilyMemberCard';
+import type { FamilyMemberDto } from '@/types/profile';
+
+interface FamilySectionProps {
+  members: FamilyMemberDto[];
+}
+
+export function FamilySection({ members }: FamilySectionProps) {
+  if (members.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-12 text-center">
+        <svg
+          className="w-12 h-12 text-gray-400 mx-auto mb-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+          />
+        </svg>
+        <p className="text-gray-500">No family members found</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-lg font-semibold text-gray-900">Your Family</h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {members.map((member) => (
+          <FamilyMemberCard key={member.idKey} member={member} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/profile/InvolvementSummary.tsx
+++ b/src/web/src/components/profile/InvolvementSummary.tsx
@@ -1,0 +1,107 @@
+/**
+ * InvolvementSummary
+ * Display user's group memberships and attendance summary
+ */
+
+import type { MyInvolvementDto } from '@/types/profile';
+
+interface InvolvementSummaryProps {
+  involvement: MyInvolvementDto;
+}
+
+export function InvolvementSummary({ involvement }: InvolvementSummaryProps) {
+  const formatDate = (dateValue: string | Date | undefined | null): string => {
+    if (!dateValue) return 'N/A';
+    const date = typeof dateValue === 'string' ? new Date(dateValue) : dateValue;
+    if (isNaN(date.getTime())) return 'N/A';
+    return date.toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Attendance Summary */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Attendance Summary</h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="bg-primary-50 rounded-lg p-4">
+            <div className="text-3xl font-bold text-primary-700">
+              {involvement.recentAttendanceCount}
+            </div>
+            <div className="text-sm text-gray-600 mt-1">Check-ins (Last 30 days)</div>
+          </div>
+
+          <div className="bg-gray-50 rounded-lg p-4">
+            <div className="text-3xl font-bold text-gray-900">
+              {involvement.totalGroupsCount}
+            </div>
+            <div className="text-sm text-gray-600 mt-1">Total Groups</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Groups */}
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h3 className="text-lg font-semibold text-gray-900 mb-4">Group Memberships</h3>
+
+        {involvement.groups.length === 0 ? (
+          <div className="text-center py-8">
+            <svg
+              className="w-12 h-12 text-gray-400 mx-auto mb-3"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+              />
+            </svg>
+            <p className="text-gray-500">You're not a member of any groups yet</p>
+            <a
+              href="/groups"
+              className="inline-block mt-3 text-sm text-primary-600 hover:text-primary-700 font-medium"
+            >
+              Browse Groups
+            </a>
+          </div>
+        ) : (
+          <div className="space-y-3">
+            {involvement.groups.map((group) => (
+              <div
+                key={group.idKey}
+                className="border border-gray-200 rounded-lg p-4 hover:border-primary-300 transition-colors"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <h4 className="text-base font-semibold text-gray-900 mb-1">
+                      {group.groupName}
+                    </h4>
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                        {group.groupTypeName}
+                      </span>
+                      <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-gray-100 text-gray-800">
+                        {group.role}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div className="text-right text-sm text-gray-600">
+                    <div className="text-xs text-gray-500">Joined</div>
+                    <div>{formatDate(group.joinedDate)}</div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/profile/PhoneNumberEditor.tsx
+++ b/src/web/src/components/profile/PhoneNumberEditor.tsx
@@ -1,0 +1,126 @@
+/**
+ * PhoneNumberEditor
+ * Edit phone numbers with add/edit/remove functionality
+ */
+
+import { useState } from 'react';
+import type { PhoneNumberDto, PhoneNumberRequestDto } from '@/types/profile';
+
+interface PhoneNumberEditorProps {
+  phoneNumbers: PhoneNumberDto[];
+  onChange: (phoneNumbers: PhoneNumberRequestDto[]) => void;
+  disabled?: boolean;
+}
+
+interface EditablePhoneNumber extends PhoneNumberRequestDto {
+  tempId?: string;
+  isNew?: boolean;
+}
+
+export function PhoneNumberEditor({
+  phoneNumbers,
+  onChange,
+  disabled = false,
+}: PhoneNumberEditorProps) {
+  const [editableNumbers, setEditableNumbers] = useState<EditablePhoneNumber[]>(
+    phoneNumbers.map((p) => ({
+      idKey: p.idKey,  // Preserve idKey from existing phones
+      number: p.number,
+      extension: p.extension,
+      // Preserve existing phone type but don't allow editing (no DefinedValues API yet)
+      phoneTypeIdKey: p.phoneType?.idKey,
+      isMessagingEnabled: p.isMessagingEnabled,
+      isUnlisted: p.isUnlisted,
+    }))
+  );
+
+  const handleAdd = () => {
+    const newNumber: EditablePhoneNumber = {
+      // No idKey for new phones - backend will create new record
+      number: '',
+      isMessagingEnabled: true,
+      isNew: true,
+      tempId: Date.now().toString(),
+    };
+    const updated = [...editableNumbers, newNumber];
+    setEditableNumbers(updated);
+  };
+
+  const handleRemove = (index: number) => {
+    const updated = editableNumbers.filter((_, i) => i !== index);
+    setEditableNumbers(updated);
+    onChange(updated);
+  };
+
+  const handleChange = (index: number, field: keyof EditablePhoneNumber, value: string | boolean) => {
+    const updated = [...editableNumbers];
+    updated[index] = { ...updated[index], [field]: value };
+    setEditableNumbers(updated);
+    onChange(updated);
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <label className="block text-sm font-medium text-gray-700">Phone Numbers</label>
+        <button
+          type="button"
+          onClick={handleAdd}
+          disabled={disabled}
+          className="text-sm text-primary-600 hover:text-primary-700 font-medium disabled:opacity-50"
+        >
+          + Add Phone
+        </button>
+      </div>
+
+      {editableNumbers.length === 0 ? (
+        <div className="text-sm text-gray-500 italic">No phone numbers</div>
+      ) : (
+        <div className="space-y-3">
+          {editableNumbers.map((phone, index) => (
+            <div
+              key={phone.tempId || index}
+              className="border border-gray-200 rounded-lg p-3 space-y-2"
+            >
+              <div>
+                <label className="block text-xs font-medium text-gray-700 mb-1">
+                  Number
+                </label>
+                <input
+                  type="tel"
+                  value={phone.number}
+                  onChange={(e) => handleChange(index, 'number', e.target.value)}
+                  disabled={disabled}
+                  placeholder="(555) 123-4567"
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 disabled:bg-gray-100"
+                />
+              </div>
+
+              <div className="flex items-center justify-between">
+                <label className="flex items-center gap-2">
+                  <input
+                    type="checkbox"
+                    checked={phone.isMessagingEnabled || false}
+                    onChange={(e) => handleChange(index, 'isMessagingEnabled', e.target.checked)}
+                    disabled={disabled}
+                    className="w-4 h-4 text-primary-600 border-gray-300 rounded focus:ring-primary-500"
+                  />
+                  <span className="text-sm text-gray-700">Enable SMS</span>
+                </label>
+
+                <button
+                  type="button"
+                  onClick={() => handleRemove(index)}
+                  disabled={disabled}
+                  className="text-sm text-red-600 hover:text-red-700 font-medium disabled:opacity-50"
+                >
+                  Remove
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/web/src/components/profile/ProfileEditor.tsx
+++ b/src/web/src/components/profile/ProfileEditor.tsx
@@ -1,0 +1,255 @@
+/**
+ * ProfileEditor
+ * View/Edit toggle for user profile with form fields
+ */
+
+import { useState, useEffect } from 'react';
+import { PhoneNumberEditor } from './PhoneNumberEditor';
+import { useUpdateMyProfile } from '@/hooks/useProfile';
+import type { MyProfileDto, PhoneNumberRequestDto } from '@/types/profile';
+
+interface ProfileEditorProps {
+  profile: MyProfileDto;
+}
+
+export function ProfileEditor({ profile }: ProfileEditorProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [nickName, setNickName] = useState(profile.nickName || '');
+  const [email, setEmail] = useState(profile.email || '');
+  const [emailPreference, setEmailPreference] = useState(profile.emailPreference || 'EmailAllowed');
+  const [phoneNumbers, setPhoneNumbers] = useState<PhoneNumberRequestDto[]>(() =>
+    profile.phoneNumbers?.map((p) => ({
+      idKey: p.idKey,
+      number: p.number,
+      extension: p.extension,
+      phoneTypeIdKey: p.phoneType?.idKey,
+      isMessagingEnabled: p.isMessagingEnabled,
+      isUnlisted: p.isUnlisted,
+    })) || []
+  );
+
+  const updateMutation = useUpdateMyProfile();
+
+  // Reset form when profile changes or editing is cancelled
+  useEffect(() => {
+    setNickName(profile.nickName || '');
+    setEmail(profile.email || '');
+    setEmailPreference(profile.emailPreference || 'EmailAllowed');
+    setPhoneNumbers(
+      profile.phoneNumbers?.map((p) => ({
+        idKey: p.idKey,
+        number: p.number,
+        extension: p.extension,
+        phoneTypeIdKey: p.phoneType?.idKey,
+        isMessagingEnabled: p.isMessagingEnabled,
+        isUnlisted: p.isUnlisted,
+      })) || []
+    );
+  }, [profile, isEditing]);
+
+  const handleSave = async () => {
+    try {
+      await updateMutation.mutateAsync({
+        nickName: nickName || undefined,
+        email: email || undefined,
+        emailPreference,
+        phoneNumbers: phoneNumbers.length > 0 ? phoneNumbers : undefined,
+      });
+      setIsEditing(false);
+    } catch (error) {
+      // Error is handled by TanStack Query mutation state
+    }
+  };
+
+  const handleCancel = () => {
+    setNickName(profile.nickName || '');
+    setEmail(profile.email || '');
+    setEmailPreference(profile.emailPreference || 'EmailAllowed');
+    setIsEditing(false);
+  };
+
+  if (!isEditing) {
+    // View Mode
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <div className="flex items-start justify-between mb-6">
+          <div className="flex items-center gap-4">
+            {profile.photoUrl ? (
+              <img
+                src={profile.photoUrl}
+                alt={profile.fullName}
+                className="w-16 h-16 rounded-full object-cover"
+              />
+            ) : (
+              <div className="w-16 h-16 rounded-full bg-primary-100 flex items-center justify-center">
+                <span className="text-2xl font-semibold text-primary-700">
+                  {profile.firstName[0]}
+                  {profile.lastName[0]}
+                </span>
+              </div>
+            )}
+            <div>
+              <h2 className="text-2xl font-bold text-gray-900">{profile.fullName}</h2>
+              {profile.nickName && (
+                <p className="text-sm text-gray-600">Prefers: {profile.nickName}</p>
+              )}
+            </div>
+          </div>
+          <button
+            onClick={() => setIsEditing(true)}
+            className="px-4 py-2 text-primary-600 border border-primary-600 rounded-lg hover:bg-primary-50 transition-colors"
+          >
+            Edit Profile
+          </button>
+        </div>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <div>
+            <label className="block text-sm font-medium text-gray-500 mb-1">Email</label>
+            <p className="text-gray-900">{profile.email || 'Not provided'}</p>
+            {profile.email && (
+              <p className="text-xs text-gray-500 mt-1">
+                Status: {profile.isEmailActive ? 'Active' : 'Inactive'} • Preference:{' '}
+                {profile.emailPreference}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-500 mb-1">
+              Phone Numbers
+            </label>
+            {profile.phoneNumbers.length > 0 ? (
+              <div className="space-y-1">
+                {profile.phoneNumbers.map((phone) => (
+                  <div key={phone.idKey} className="text-gray-900">
+                    {phone.numberFormatted}
+                    {phone.phoneType && (
+                      <span className="text-xs text-gray-500 ml-2">
+                        ({phone.phoneType.value})
+                      </span>
+                    )}
+                    {phone.isMessagingEnabled && (
+                      <span className="text-xs text-green-600 ml-2">SMS enabled</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-gray-900">Not provided</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-500 mb-1">Birth Date</label>
+            <p className="text-gray-900">
+              {profile.birthDate || 'Not provided'}
+              {profile.age && <span className="text-gray-500 ml-2">({profile.age} years)</span>}
+            </p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-500 mb-1">Gender</label>
+            <p className="text-gray-900">{profile.gender}</p>
+          </div>
+
+          {profile.primaryFamily && (
+            <div>
+              <label className="block text-sm font-medium text-gray-500 mb-1">Family</label>
+              <p className="text-gray-900">{profile.primaryFamily.name}</p>
+            </div>
+          )}
+
+          {profile.primaryCampus && (
+            <div>
+              <label className="block text-sm font-medium text-gray-500 mb-1">Campus</label>
+              <p className="text-gray-900">{profile.primaryCampus.name}</p>
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  }
+
+  // Edit Mode
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="text-xl font-bold text-gray-900 mb-6">Edit Profile</h2>
+
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="nickName" className="block text-sm font-medium text-gray-700 mb-1">
+            Preferred Name (Nickname)
+          </label>
+          <input
+            type="text"
+            id="nickName"
+            value={nickName}
+            onChange={(e) => setNickName(e.target.value)}
+            placeholder={profile.firstName}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+            Email Address
+          </label>
+          <input
+            type="email"
+            id="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="your.email@example.com"
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          />
+        </div>
+
+        <div>
+          <label htmlFor="emailPreference" className="block text-sm font-medium text-gray-700 mb-1">
+            Email Preference
+          </label>
+          <select
+            id="emailPreference"
+            value={emailPreference}
+            onChange={(e) => setEmailPreference(e.target.value)}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          >
+            <option value="EmailAllowed">Email Allowed</option>
+            <option value="NoMassEmails">No Mass Emails</option>
+            <option value="DoNotEmail">Do Not Email</option>
+          </select>
+        </div>
+
+        <PhoneNumberEditor
+          phoneNumbers={profile.phoneNumbers}
+          onChange={setPhoneNumbers}
+          disabled={updateMutation.isPending}
+        />
+
+        <div className="flex gap-3 pt-4">
+          <button
+            onClick={handleSave}
+            disabled={updateMutation.isPending}
+            className="px-6 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors disabled:opacity-50"
+          >
+            {updateMutation.isPending ? 'Saving...' : 'Save Changes'}
+          </button>
+          <button
+            onClick={handleCancel}
+            disabled={updateMutation.isPending}
+            className="px-6 py-2 text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+        </div>
+
+        {updateMutation.isError && (
+          <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-800">
+            Failed to update profile. Please try again.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/profile/index.ts
+++ b/src/web/src/components/profile/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Profile components
+ */
+
+export { ProfileEditor } from './ProfileEditor';
+export { PhoneNumberEditor } from './PhoneNumberEditor';
+export { FamilyMemberCard } from './FamilyMemberCard';
+export { FamilySection } from './FamilySection';
+export { InvolvementSummary } from './InvolvementSummary';

--- a/src/web/src/hooks/useProfile.ts
+++ b/src/web/src/hooks/useProfile.ts
@@ -1,0 +1,74 @@
+/**
+ * Profile management hooks using TanStack Query
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import * as profileApi from '@/services/api/profile';
+import type {
+  UpdateMyProfileRequest,
+  UpdateFamilyMemberRequest,
+} from '@/types/profile';
+
+/**
+ * Get the current user's profile
+ */
+export function useMyProfile() {
+  return useQuery({
+    queryKey: ['profile', 'me'],
+    queryFn: () => profileApi.getMyProfile(),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}
+
+/**
+ * Update the current user's profile
+ */
+export function useUpdateMyProfile() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: UpdateMyProfileRequest) => profileApi.updateMyProfile(data),
+    onSuccess: () => {
+      // Invalidate profile to refetch
+      queryClient.invalidateQueries({ queryKey: ['profile', 'me'] });
+    },
+  });
+}
+
+/**
+ * Get the current user's family members
+ */
+export function useMyFamily() {
+  return useQuery({
+    queryKey: ['profile', 'me', 'family'],
+    queryFn: () => profileApi.getMyFamily(),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}
+
+/**
+ * Update a family member's editable fields
+ */
+export function useUpdateFamilyMember() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ personIdKey, data }: { personIdKey: string; data: UpdateFamilyMemberRequest }) =>
+      profileApi.updateFamilyMember(personIdKey, data),
+    onSuccess: () => {
+      // Invalidate family list to refetch
+      queryClient.invalidateQueries({ queryKey: ['profile', 'me', 'family'] });
+    },
+  });
+}
+
+/**
+ * Get the current user's involvement (groups and attendance)
+ */
+export function useMyInvolvement() {
+  return useQuery({
+    queryKey: ['profile', 'me', 'involvement'],
+    queryFn: () => profileApi.getMyInvolvement(),
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}

--- a/src/web/src/pages/profile/MyProfilePage.tsx
+++ b/src/web/src/pages/profile/MyProfilePage.tsx
@@ -1,0 +1,198 @@
+/**
+ * MyProfilePage
+ * Self-service member profile portal with tabs for Profile, Family, and Involvement
+ */
+
+import { useState } from 'react';
+import { useMyProfile, useMyFamily, useMyInvolvement } from '@/hooks/useProfile';
+import { ProfileEditor, FamilySection, InvolvementSummary } from '@/components/profile';
+
+type TabType = 'profile' | 'family' | 'involvement';
+
+export function MyProfilePage() {
+  const [activeTab, setActiveTab] = useState<TabType>('profile');
+
+  const {
+    data: profile,
+    isLoading: isLoadingProfile,
+    error: profileError,
+  } = useMyProfile();
+
+  const {
+    data: family,
+    isLoading: isLoadingFamily,
+    error: familyError,
+  } = useMyFamily();
+
+  const {
+    data: involvement,
+    isLoading: isLoadingInvolvement,
+    error: involvementError,
+  } = useMyInvolvement();
+
+  const tabs = [
+    { id: 'profile' as TabType, label: 'Profile', icon: 'user' },
+    { id: 'family' as TabType, label: 'Family', icon: 'users' },
+    { id: 'involvement' as TabType, label: 'Involvement', icon: 'calendar' },
+  ];
+
+  const renderTabIcon = (icon: string) => {
+    switch (icon) {
+      case 'user':
+        return (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+            />
+          </svg>
+        );
+      case 'users':
+        return (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+            />
+          </svg>
+        );
+      case 'calendar':
+        return (
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+        );
+      default:
+        return null;
+    }
+  };
+
+  const renderContent = () => {
+    switch (activeTab) {
+      case 'profile':
+        if (isLoadingProfile) {
+          return <LoadingSkeleton />;
+        }
+        if (profileError) {
+          return <ErrorState message="Failed to load profile" />;
+        }
+        if (!profile) {
+          return <ErrorState message="Profile not found" />;
+        }
+        return <ProfileEditor profile={profile} />;
+
+      case 'family':
+        if (isLoadingFamily) {
+          return <LoadingSkeleton />;
+        }
+        if (familyError) {
+          return <ErrorState message="Failed to load family members" />;
+        }
+        return <FamilySection members={family || []} />;
+
+      case 'involvement':
+        if (isLoadingInvolvement) {
+          return <LoadingSkeleton />;
+        }
+        if (involvementError) {
+          return <ErrorState message="Failed to load involvement data" />;
+        }
+        if (!involvement) {
+          return <ErrorState message="Involvement data not found" />;
+        }
+        return <InvolvementSummary involvement={involvement} />;
+
+      default:
+        return null;
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        {/* Header */}
+        <div className="mb-6">
+          <h1 className="text-3xl font-bold text-gray-900">My Profile</h1>
+          <p className="mt-2 text-gray-600">Manage your profile, family, and involvement</p>
+        </div>
+
+        {/* Tabs */}
+        <div className="bg-white rounded-lg border border-gray-200 mb-6">
+          <div className="border-b border-gray-200">
+            <nav className="flex -mb-px overflow-x-auto" aria-label="Tabs">
+              {tabs.map((tab) => (
+                <button
+                  key={tab.id}
+                  onClick={() => setActiveTab(tab.id)}
+                  className={`
+                    flex items-center gap-2 px-6 py-4 text-sm font-medium whitespace-nowrap
+                    border-b-2 transition-colors
+                    ${
+                      activeTab === tab.id
+                        ? 'border-primary-600 text-primary-600'
+                        : 'border-transparent text-gray-600 hover:text-gray-900 hover:border-gray-300'
+                    }
+                  `}
+                >
+                  {renderTabIcon(tab.icon)}
+                  {tab.label}
+                </button>
+              ))}
+            </nav>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div>{renderContent()}</div>
+      </div>
+    </div>
+  );
+}
+
+function LoadingSkeleton() {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <div className="animate-pulse space-y-4">
+        <div className="flex items-center gap-4">
+          <div className="w-16 h-16 bg-gray-200 rounded-full" />
+          <div className="flex-1 space-y-2">
+            <div className="h-6 bg-gray-200 rounded w-1/3" />
+            <div className="h-4 bg-gray-200 rounded w-1/4" />
+          </div>
+        </div>
+        <div className="space-y-3">
+          <div className="h-4 bg-gray-200 rounded w-full" />
+          <div className="h-4 bg-gray-200 rounded w-5/6" />
+          <div className="h-4 bg-gray-200 rounded w-4/6" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ErrorState({ message }: { message: string }) {
+  return (
+    <div className="bg-white rounded-lg border border-red-200 p-6">
+      <div className="flex items-center gap-3 text-red-800">
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          />
+        </svg>
+        <p className="font-medium">{message}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/pages/profile/index.ts
+++ b/src/web/src/pages/profile/index.ts
@@ -1,0 +1,5 @@
+/**
+ * Profile pages
+ */
+
+export { MyProfilePage } from './MyProfilePage';

--- a/src/web/src/services/api/index.ts
+++ b/src/web/src/services/api/index.ts
@@ -28,3 +28,4 @@ export * as familiesApi from './families';
 export * as groupsApi from './groups';
 export * as checkinApi from './checkin';
 export * as referenceApi from './reference';
+export * as profileApi from './profile';

--- a/src/web/src/services/api/profile.ts
+++ b/src/web/src/services/api/profile.ts
@@ -1,0 +1,64 @@
+/**
+ * Profile API service
+ */
+
+import { get, put } from './client';
+import type {
+  MyProfileDto,
+  UpdateMyProfileRequest,
+  FamilyMemberDto,
+  UpdateFamilyMemberRequest,
+  MyInvolvementDto,
+} from '@/types/profile';
+
+// ============================================================================
+// API Functions
+// ============================================================================
+
+/**
+ * Get the current user's profile
+ */
+export async function getMyProfile(): Promise<MyProfileDto> {
+  const response = await get<{ data: MyProfileDto }>('/api/v1/my-profile');
+  return response.data;
+}
+
+/**
+ * Update the current user's profile
+ */
+export async function updateMyProfile(
+  data: UpdateMyProfileRequest
+): Promise<MyProfileDto> {
+  const response = await put<{ data: MyProfileDto }>('/api/v1/my-profile', data);
+  return response.data;
+}
+
+/**
+ * Get the current user's family members
+ */
+export async function getMyFamily(): Promise<FamilyMemberDto[]> {
+  const response = await get<{ data: FamilyMemberDto[] }>('/api/v1/my-family');
+  return response.data;
+}
+
+/**
+ * Update a family member's editable fields
+ */
+export async function updateFamilyMember(
+  personIdKey: string,
+  data: UpdateFamilyMemberRequest
+): Promise<FamilyMemberDto> {
+  const response = await put<{ data: FamilyMemberDto }>(
+    `/api/v1/my-family/members/${personIdKey}`,
+    data
+  );
+  return response.data;
+}
+
+/**
+ * Get the current user's group involvement and attendance summary
+ */
+export async function getMyInvolvement(): Promise<MyInvolvementDto> {
+  const response = await get<{ data: MyInvolvementDto }>('/api/v1/my-involvement');
+  return response.data;
+}

--- a/src/web/src/types/profile.ts
+++ b/src/web/src/types/profile.ts
@@ -1,0 +1,124 @@
+/**
+ * Profile-related TypeScript types
+ */
+
+import type { IdKey, DateTime, DateOnly } from '@/services/api/types';
+
+// ============================================================================
+// Phone Number Types
+// ============================================================================
+
+export interface PhoneNumberDto {
+  idKey: IdKey;
+  number: string;
+  numberFormatted: string;
+  extension?: string;
+  phoneType?: {
+    idKey: IdKey;
+    value: string;
+  };
+  isMessagingEnabled: boolean;
+  isUnlisted: boolean;
+}
+
+export interface PhoneNumberRequestDto {
+  idKey?: IdKey;  // IdKey of existing phone (null/undefined for new)
+  number: string;
+  extension?: string;
+  phoneTypeIdKey?: IdKey;
+  isMessagingEnabled?: boolean;
+  isUnlisted?: boolean;
+}
+
+// ============================================================================
+// Profile Types
+// ============================================================================
+
+export interface CampusSummaryDto {
+  idKey: IdKey;
+  name: string;
+  shortCode?: string;
+}
+
+export interface FamilySummaryDto {
+  idKey: IdKey;
+  name: string;
+  memberCount: number;
+}
+
+export interface MyProfileDto {
+  idKey: IdKey;
+  guid: string;
+  firstName: string;
+  nickName?: string;
+  lastName: string;
+  fullName: string;
+  email?: string;
+  isEmailActive: boolean;
+  emailPreference: string;
+  phoneNumbers: PhoneNumberDto[];
+  birthDate?: DateOnly;
+  age?: number;
+  gender: string;
+  photoUrl?: string;
+  primaryFamily?: FamilySummaryDto;
+  primaryCampus?: CampusSummaryDto;
+}
+
+export interface UpdateMyProfileRequest {
+  nickName?: string;
+  email?: string;
+  emailPreference?: string;
+  phoneNumbers?: PhoneNumberRequestDto[];
+}
+
+// ============================================================================
+// Family Member Types
+// ============================================================================
+
+export interface FamilyMemberDto {
+  idKey: IdKey;
+  firstName: string;
+  nickName?: string;
+  lastName: string;
+  fullName: string;
+  birthDate?: DateOnly;
+  age?: number;
+  gender: string;
+  email?: string;
+  phoneNumbers: PhoneNumberDto[];
+  photoUrl?: string;
+  familyRole: string; // "Adult" | "Child"
+  canEdit: boolean;
+  allergies?: string;
+  hasCriticalAllergies: boolean;
+  specialNeeds?: string;
+}
+
+export interface UpdateFamilyMemberRequest {
+  nickName?: string;
+  allergies?: string;
+  specialNeeds?: string;
+}
+
+// ============================================================================
+// Involvement Types
+// ============================================================================
+
+export interface GroupMembershipDto {
+  idKey: IdKey;
+  groupName: string;
+  description?: string;
+  groupTypeName: string;
+  role: string;
+  isLeader: boolean;
+  joinedDate: DateTime;
+  lastAttendanceDate?: DateTime;
+  campus?: CampusSummaryDto;
+}
+
+export interface MyInvolvementDto {
+  groups: GroupMembershipDto[];
+  recentAttendanceCount: number;
+  totalGroupsCount: number;
+}


### PR DESCRIPTION
## Summary
- Implements self-service profile management for church members
- Allows viewing/editing profile, family members, and group involvement
- Includes XSS protection and FluentValidation

## Changes
### Backend
- IMyProfileService / MyProfileService - Profile CRUD operations
- MyProfileController - 5 REST endpoints
- DTOs for profile, family, and involvement data
- Validators with phone number limits and XSS prevention

### Frontend
- ProfileEditor - Edit nickname, email, phone numbers
- PhoneNumberEditor - Add/edit/remove phone numbers
- FamilyMemberCard / FamilySection - View and edit children
- InvolvementSummary - Group memberships and attendance
- MyProfilePage - Main profile page at /profile

## Test Plan
- [ ] View own profile with correct data
- [ ] Edit profile fields and verify save
- [ ] Add/edit/remove phone numbers
- [ ] View family members
- [ ] Edit child info (allergies, special needs)
- [ ] View group involvement summary

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)