### PR TITLE
feat: Add rate limiting for pickup verification endpoint (#106)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,6 +33,7 @@
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL.NetTopologySuite" Version="8.0.0" />
     <PackageVersion Include="StackExchange.Redis" Version="2.6.122" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="8.0.0" />
   </ItemGroup>
@@ -78,6 +79,7 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
     <PackageVersion Include="Serilog" Version="3.1.1" />
     <PackageVersion Include="Serilog.AspNetCore" Version="8.0.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="5.0.0" />

--- a/src/Koinon.Api/appsettings.json
+++ b/src/Koinon.Api/appsettings.json
@@ -17,5 +17,18 @@
     "Audience": "Koinon.Web",
     "AccessTokenExpirationMinutes": 15,
     "RefreshTokenExpirationDays": 7
+  },
+  "RateLimiting": {
+    "PickupVerification": {
+      "MaxAttempts": 5,
+      "WindowMinutes": 15
+    }
+  },
+  "ForwardedHeaders": {
+    "TrustedProxies": [],
+    "TrustedNetworks": []
+  },
+  "Comments": {
+    "ForwardedHeaders": "IMPORTANT: Configure TrustedProxies and TrustedNetworks in production with your reverse proxy IP(s). Example: TrustedProxies: ['10.0.1.50'], TrustedNetworks: ['10.0.1.0/24']. See docs/deployment/reverse-proxy.md"
   }
 }

--- a/src/Koinon.Application/Configuration/RateLimitOptions.cs
+++ b/src/Koinon.Application/Configuration/RateLimitOptions.cs
@@ -1,0 +1,26 @@
+namespace Koinon.Application.Configuration;
+
+/// <summary>
+/// Configuration options for pickup verification rate limiting.
+/// Controls how many failed attempts are allowed before blocking requests.
+/// </summary>
+public class RateLimitOptions
+{
+    /// <summary>
+    /// Configuration section name in appsettings.json
+    /// </summary>
+    public const string SectionName = "RateLimiting:PickupVerification";
+
+    /// <summary>
+    /// Maximum number of failed verification attempts allowed within the time window.
+    /// Default: 5 attempts
+    /// </summary>
+    public int MaxAttempts { get; set; } = 5;
+
+    /// <summary>
+    /// Time window in minutes for tracking failed attempts.
+    /// After this time expires, the counter resets.
+    /// Default: 15 minutes
+    /// </summary>
+    public int WindowMinutes { get; set; } = 15;
+}

--- a/src/Koinon.Application/Interfaces/IPickupRateLimitService.cs
+++ b/src/Koinon.Application/Interfaces/IPickupRateLimitService.cs
@@ -1,0 +1,41 @@
+namespace Koinon.Application.Interfaces;
+
+/// <summary>
+/// Service interface for rate limiting pickup verification attempts.
+/// Prevents brute-force attacks on 6-digit security codes by limiting failed attempts
+/// to 5 per 15 minutes per attendance record and client IP combination.
+/// </summary>
+public interface IPickupRateLimitService
+{
+    /// <summary>
+    /// Checks if the rate limit has been exceeded for a given attendance record and client IP.
+    /// </summary>
+    /// <param name="attendanceIdKey">The attendance record IdKey</param>
+    /// <param name="clientIp">The client IP address</param>
+    /// <returns>True if rate limited (max attempts exceeded), false otherwise</returns>
+    bool IsRateLimited(string attendanceIdKey, string clientIp);
+
+    /// <summary>
+    /// Records a failed verification attempt.
+    /// Increments the counter for the given attendance record and client IP.
+    /// </summary>
+    /// <param name="attendanceIdKey">The attendance record IdKey</param>
+    /// <param name="clientIp">The client IP address</param>
+    void RecordFailedAttempt(string attendanceIdKey, string clientIp);
+
+    /// <summary>
+    /// Resets the failed attempt counter for a given attendance record and client IP.
+    /// Called when a verification succeeds.
+    /// </summary>
+    /// <param name="attendanceIdKey">The attendance record IdKey</param>
+    /// <param name="clientIp">The client IP address</param>
+    void ResetAttempts(string attendanceIdKey, string clientIp);
+
+    /// <summary>
+    /// Gets the remaining time until the rate limit window expires.
+    /// </summary>
+    /// <param name="attendanceIdKey">The attendance record IdKey</param>
+    /// <param name="clientIp">The client IP address</param>
+    /// <returns>TimeSpan until window expires, or null if not rate limited</returns>
+    TimeSpan? GetRetryAfter(string attendanceIdKey, string clientIp);
+}

--- a/src/Koinon.Application/Koinon.Application.csproj
+++ b/src/Koinon.Application/Koinon.Application.csproj
@@ -21,6 +21,9 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />
     <PackageReference Include="Konscious.Security.Cryptography.Argon2" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" />

--- a/src/Koinon.Application/Services/PickupRateLimitService.cs
+++ b/src/Koinon.Application/Services/PickupRateLimitService.cs
@@ -1,0 +1,129 @@
+using Koinon.Application.Configuration;
+using Koinon.Application.Interfaces;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Koinon.Application.Services;
+
+/// <summary>
+/// Service for rate limiting pickup verification attempts to prevent brute-force attacks on security codes.
+/// Tracks failed verification attempts by {AttendanceIdKey}:{ClientIP} and enforces a configurable maximum
+/// number of attempts per time window to prevent attackers from trying all 1,000,000 possible 6-digit security codes.
+/// Uses IMemoryCache with automatic TTL expiration to prevent memory leaks.
+/// </summary>
+public class PickupRateLimitService : IPickupRateLimitService
+{
+    private readonly IMemoryCache _cache;
+    private readonly RateLimitOptions _options;
+    private readonly ILogger<PickupRateLimitService> _logger;
+
+    public PickupRateLimitService(
+        IMemoryCache cache,
+        IOptions<RateLimitOptions> options,
+        ILogger<PickupRateLimitService> logger)
+    {
+        _cache = cache;
+        _options = options.Value;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Checks if the rate limit has been exceeded for a given attendance record and client IP.
+    /// </summary>
+    /// <param name="attendanceIdKey">The attendance record IdKey</param>
+    /// <param name="clientIp">The client IP address</param>
+    /// <returns>True if rate limited (max attempts exceeded), false otherwise</returns>
+    public bool IsRateLimited(string attendanceIdKey, string clientIp)
+    {
+        var key = GetCacheKey(attendanceIdKey, clientIp);
+
+        if (_cache.TryGetValue<int>(key, out var failedAttempts))
+        {
+            if (failedAttempts >= _options.MaxAttempts)
+            {
+                _logger.LogWarning(
+                    "Rate limit exceeded for pickup verification: AttendanceIdKey={AttendanceIdKey}, ClientIP={ClientIp}, Attempts={Attempts}",
+                    attendanceIdKey, clientIp, failedAttempts);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Records a failed verification attempt.
+    /// </summary>
+    /// <param name="attendanceIdKey">The attendance record IdKey</param>
+    /// <param name="clientIp">The client IP address</param>
+    public void RecordFailedAttempt(string attendanceIdKey, string clientIp)
+    {
+        var key = GetCacheKey(attendanceIdKey, clientIp);
+        var window = TimeSpan.FromMinutes(_options.WindowMinutes);
+
+        var currentAttempts = _cache.GetOrCreate(key, entry =>
+        {
+            entry.AbsoluteExpirationRelativeToNow = window;
+            return 0;
+        });
+
+        var newAttempts = currentAttempts + 1;
+        _cache.Set(key, newAttempts, new MemoryCacheEntryOptions
+        {
+            AbsoluteExpirationRelativeToNow = window
+        });
+
+        _logger.LogWarning(
+            "Failed pickup verification attempt recorded: AttendanceIdKey={AttendanceIdKey}, ClientIp={ClientIp}, AttemptCount={AttemptCount}",
+            attendanceIdKey, clientIp, newAttempts);
+    }
+
+    /// <summary>
+    /// Resets the failed attempt counter for a given attendance record and client IP.
+    /// Called when a verification succeeds.
+    /// </summary>
+    /// <param name="attendanceIdKey">The attendance record IdKey</param>
+    /// <param name="clientIp">The client IP address</param>
+    public void ResetAttempts(string attendanceIdKey, string clientIp)
+    {
+        var key = GetCacheKey(attendanceIdKey, clientIp);
+        _cache.Remove(key);
+
+        _logger.LogInformation(
+            "Pickup rate limit reset: AttendanceIdKey={AttendanceIdKey}, ClientIp={ClientIp}",
+            attendanceIdKey, clientIp);
+    }
+
+    /// <summary>
+    /// Gets the remaining time until the rate limit window expires.
+    /// Note: With IMemoryCache, we cannot get exact expiration time, so we return
+    /// the full window as a conservative estimate.
+    /// </summary>
+    /// <param name="attendanceIdKey">The attendance record IdKey</param>
+    /// <param name="clientIp">The client IP address</param>
+    /// <returns>TimeSpan until window expires, or null if not rate limited</returns>
+    public TimeSpan? GetRetryAfter(string attendanceIdKey, string clientIp)
+    {
+        var key = GetCacheKey(attendanceIdKey, clientIp);
+
+        if (_cache.TryGetValue<int>(key, out var failedAttempts) && failedAttempts >= _options.MaxAttempts)
+        {
+            // Return the full window as conservative estimate
+            return TimeSpan.FromMinutes(_options.WindowMinutes);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Generates the cache key for tracking rate limit attempts.
+    /// </summary>
+    /// <param name="attendanceIdKey">The attendance record IdKey</param>
+    /// <param name="clientIp">The client IP address</param>
+    /// <returns>Cache key in format "pickup-ratelimit:{attendanceIdKey}:{clientIp}"</returns>
+    private string GetCacheKey(string attendanceIdKey, string clientIp)
+    {
+        return $"pickup-ratelimit:{attendanceIdKey}:{clientIp}";
+    }
+}

--- a/tests/Koinon.Application.Tests/Services/PickupRateLimitServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/PickupRateLimitServiceTests.cs
@@ -1,0 +1,372 @@
+using FluentAssertions;
+using Koinon.Application.Configuration;
+using Koinon.Application.Services;
+using Koinon.Domain.Data;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Koinon.Application.Tests.Services;
+
+public class PickupRateLimitServiceTests
+{
+    private readonly IMemoryCache _cache;
+    private readonly Mock<IOptions<RateLimitOptions>> _optionsMock;
+    private readonly Mock<ILogger<PickupRateLimitService>> _loggerMock;
+    private readonly PickupRateLimitService _service;
+
+    // Use unique keys for each test to avoid interference between tests
+    private string GetUniqueAttendanceId() => IdKeyHelper.Encode(Random.Shared.Next(1000000, 9999999));
+    private string GetUniqueClientIp() => $"192.168.{Random.Shared.Next(1, 255)}.{Random.Shared.Next(1, 255)}";
+
+    public PickupRateLimitServiceTests()
+    {
+        // Use real MemoryCache for testing (simpler than mocking)
+        _cache = new MemoryCache(new MemoryCacheOptions());
+
+        // Mock options with default values
+        _optionsMock = new Mock<IOptions<RateLimitOptions>>();
+        _optionsMock.Setup(o => o.Value).Returns(new RateLimitOptions
+        {
+            MaxAttempts = 5,
+            WindowMinutes = 15
+        });
+
+        _loggerMock = new Mock<ILogger<PickupRateLimitService>>();
+
+        _service = new PickupRateLimitService(_cache, _optionsMock.Object, _loggerMock.Object);
+    }
+
+    [Fact]
+    public void IsRateLimited_WithNoAttempts_ReturnsFalse()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        // Act
+        var result = _service.IsRateLimited(attendanceIdKey, clientIp);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRateLimited_WithFourAttempts_ReturnsFalse()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        for (int i = 0; i < 4; i++)
+        {
+            _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+        }
+
+        // Act
+        var result = _service.IsRateLimited(attendanceIdKey, clientIp);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRateLimited_WithFiveAttempts_ReturnsTrue()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        for (int i = 0; i < 5; i++)
+        {
+            _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+        }
+
+        // Act
+        var result = _service.IsRateLimited(attendanceIdKey, clientIp);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsRateLimited_WithSixAttempts_ReturnsTrue()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        for (int i = 0; i < 6; i++)
+        {
+            _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+        }
+
+        // Act
+        var result = _service.IsRateLimited(attendanceIdKey, clientIp);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void RecordFailedAttempt_TracksMultipleAttempts()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        // Act & Assert
+        _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+        var result1 = _service.IsRateLimited(attendanceIdKey, clientIp);
+
+        _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+        _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+        _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+        _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+        var result2 = _service.IsRateLimited(attendanceIdKey, clientIp);
+
+        // Assert
+        result1.Should().BeFalse();
+        result2.Should().BeTrue();
+    }
+
+    [Fact]
+    public void ResetAttempts_ClearsFailedAttempts()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        for (int i = 0; i < 5; i++)
+        {
+            _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+        }
+        var beforeReset = _service.IsRateLimited(attendanceIdKey, clientIp);
+
+        // Act
+        _service.ResetAttempts(attendanceIdKey, clientIp);
+        var afterReset = _service.IsRateLimited(attendanceIdKey, clientIp);
+
+        // Assert
+        beforeReset.Should().BeTrue();
+        afterReset.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRateLimited_TracksSeparatelyPerAttendanceIdKey()
+    {
+        // Arrange
+        var attendance1 = GetUniqueAttendanceId();
+        var attendance2 = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        for (int i = 0; i < 5; i++)
+        {
+            _service.RecordFailedAttempt(attendance1, clientIp);
+        }
+
+        // Act
+        var result1 = _service.IsRateLimited(attendance1, clientIp);
+        var result2 = _service.IsRateLimited(attendance2, clientIp);
+
+        // Assert
+        result1.Should().BeTrue();
+        result2.Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRateLimited_TracksSeparatelyPerClientIp()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var ip1 = GetUniqueClientIp();
+        var ip2 = GetUniqueClientIp();
+
+        for (int i = 0; i < 5; i++)
+        {
+            _service.RecordFailedAttempt(attendanceIdKey, ip1);
+        }
+
+        // Act
+        var result1 = _service.IsRateLimited(attendanceIdKey, ip1);
+        var result2 = _service.IsRateLimited(attendanceIdKey, ip2);
+
+        // Assert
+        result1.Should().BeTrue();
+        result2.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetRetryAfter_WhenNotRateLimited_ReturnsNull()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        // Act
+        var result = _service.GetRetryAfter(attendanceIdKey, clientIp);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void GetRetryAfter_WhenRateLimited_ReturnsTimeSpan()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        for (int i = 0; i < 5; i++)
+        {
+            _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+        }
+
+        // Act
+        var result = _service.GetRetryAfter(attendanceIdKey, clientIp);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeGreaterThan(TimeSpan.Zero);
+        result.Should().BeLessThanOrEqualTo(TimeSpan.FromMinutes(15));
+    }
+
+    [Fact]
+    public void GetRetryAfter_WithFourAttempts_ReturnsNull()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        for (int i = 0; i < 4; i++)
+        {
+            _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+        }
+
+        // Act
+        var result = _service.GetRetryAfter(attendanceIdKey, clientIp);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void ResetAttempts_WithNoExistingAttempts_DoesNotThrow()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        // Act
+        var act = () => _service.ResetAttempts(attendanceIdKey, clientIp);
+
+        // Assert
+        act.Should().NotThrow();
+    }
+
+    [Fact]
+    public void RecordFailedAttempt_WithDifferentCombinations_TracksIndependently()
+    {
+        // Arrange
+        var attendance1 = GetUniqueAttendanceId();
+        var attendance2 = GetUniqueAttendanceId();
+        var ip1 = GetUniqueClientIp();
+        var ip2 = GetUniqueClientIp();
+
+        // Record 5 attempts for attendance1 + ip1
+        for (int i = 0; i < 5; i++)
+        {
+            _service.RecordFailedAttempt(attendance1, ip1);
+        }
+
+        // Record 3 attempts for attendance1 + ip2
+        for (int i = 0; i < 3; i++)
+        {
+            _service.RecordFailedAttempt(attendance1, ip2);
+        }
+
+        // Record 2 attempts for attendance2 + ip1
+        for (int i = 0; i < 2; i++)
+        {
+            _service.RecordFailedAttempt(attendance2, ip1);
+        }
+
+        // Act & Assert
+        _service.IsRateLimited(attendance1, ip1).Should().BeTrue();
+        _service.IsRateLimited(attendance1, ip2).Should().BeFalse();
+        _service.IsRateLimited(attendance2, ip1).Should().BeFalse();
+        _service.IsRateLimited(attendance2, ip2).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsRateLimited_LogsWarning_WhenRateLimitExceeded()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        for (int i = 0; i < 5; i++)
+        {
+            _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+        }
+
+        // Act
+        _service.IsRateLimited(attendanceIdKey, clientIp);
+
+        // Assert
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Rate limit exceeded")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void RecordFailedAttempt_LogsWarning()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        // Act
+        _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+
+        // Assert
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Failed pickup verification attempt recorded")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public void ResetAttempts_LogsInformation_WhenAttemptsExist()
+    {
+        // Arrange
+        var attendanceIdKey = GetUniqueAttendanceId();
+        var clientIp = GetUniqueClientIp();
+
+        _service.RecordFailedAttempt(attendanceIdKey, clientIp);
+
+        // Act
+        _service.ResetAttempts(attendanceIdKey, clientIp);
+
+        // Assert
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Information,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Pickup rate limit reset")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- Implement IP-based rate limiting to prevent brute-force attacks on 6-digit security codes
- Rate limit: 5 failed attempts per IP per attendance per 15 minutes
- Secure ForwardedHeaders configuration to prevent IP spoofing
- Uses IMemoryCache with automatic TTL expiration (no memory leaks)

## Security Features
- Uses `HttpContext.Connection.RemoteIpAddress` (set by ForwardedHeaders middleware)
- ForwardedHeaders configured securely: `KnownProxies` cleared in production
- `ForwardLimit=1` prevents proxy chain attacks
- Empty `TrustedNetworks` by default (operators must configure)
- Returns 429 Too Many Requests with `Retry-After` header

## Configuration
```json
{
  "RateLimiting": {
    "PickupVerification": {
      "MaxAttempts": 5,
      "WindowMinutes": 15
    }
  },
  "ForwardedHeaders": {
    "TrustedProxies": [],
    "TrustedNetworks": []
  }
}
```

## Test plan
- [x] 16 unit tests for PickupRateLimitService
- [x] 6 controller tests including IP spoofing prevention test
- [x] 782 total tests passing
- [x] Code-critic approved

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)