### PR TITLE
test: Add comprehensive unit tests for Communication feature (#128)

### DIFF
--- a/tests/Koinon.Api.Tests/Controllers/CommunicationsControllerTests.cs
+++ b/tests/Koinon.Api.Tests/Controllers/CommunicationsControllerTests.cs
@@ -1,0 +1,194 @@
+using FluentAssertions;
+using Koinon.Api.Controllers;
+using Koinon.Application.Common;
+using Koinon.Application.DTOs;
+using Koinon.Application.DTOs.Communication;
+using Koinon.Application.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Api.Tests.Controllers;
+
+public class CommunicationsControllerTests
+{
+    private readonly Mock<ICommunicationService> _communicationServiceMock;
+    private readonly Mock<ICommunicationAnalyticsService> _analyticsServiceMock;
+    private readonly Mock<ILogger<CommunicationsController>> _loggerMock;
+    private readonly CommunicationsController _controller;
+
+    public CommunicationsControllerTests()
+    {
+        _communicationServiceMock = new Mock<ICommunicationService>();
+        _analyticsServiceMock = new Mock<ICommunicationAnalyticsService>();
+        _loggerMock = new Mock<ILogger<CommunicationsController>>();
+        _controller = new CommunicationsController(
+            _communicationServiceMock.Object,
+            _analyticsServiceMock.Object,
+            _loggerMock.Object);
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+    }
+
+    [Fact]
+    public async Task Create_WithValidDto_ReturnsCreatedResult()
+    {
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Test",
+            Body = "Test Body",
+            FromEmail = "test@example.com",
+            GroupIdKeys = new List<string> { "ABC123" }
+        };
+        var communicationDto = new CommunicationDto
+        {
+            IdKey = "XYZ789",
+            Guid = Guid.NewGuid(),
+            CommunicationType = "Email",
+            Status = "Draft",
+            Subject = "Test",
+            Body = "Test Body",
+            RecipientCount = 1,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedDateTime = DateTime.UtcNow,
+            Recipients = new List<CommunicationRecipientDto>()
+        };
+        _communicationServiceMock
+            .Setup(x => x.CreateAsync(dto, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<CommunicationDto>.Success(communicationDto));
+        var result = await _controller.Create(dto);
+        var createdResult = result.Should().BeOfType<CreatedAtActionResult>().Subject;
+        createdResult.ActionName.Should().Be(nameof(CommunicationsController.GetByIdKey));
+        createdResult.Value.Should().Be(communicationDto);
+    }
+
+    [Fact]
+    public async Task Create_WithValidationError_ReturnsBadRequest()
+    {
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Test",
+            Body = "Test Body",
+            FromEmail = "test@example.com",
+            GroupIdKeys = new List<string> { "ABC123" }
+        };
+        var error = new Error("VALIDATION_ERROR", "Validation failed");
+        _communicationServiceMock
+            .Setup(x => x.CreateAsync(dto, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<CommunicationDto>.Failure(error));
+        var result = await _controller.Create(dto);
+        result.Should().BeOfType<BadRequestObjectResult>();
+    }
+
+    [Fact]
+    public async Task GetByIdKey_WithExistingId_ReturnsOkResult()
+    {
+        var idKey = "ABC123";
+        var communicationDto = new CommunicationDto
+        {
+            IdKey = idKey,
+            Guid = Guid.NewGuid(),
+            CommunicationType = "Email",
+            Status = "Draft",
+            Subject = "Test",
+            Body = "Test Body",
+            RecipientCount = 1,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedDateTime = DateTime.UtcNow,
+            Recipients = new List<CommunicationRecipientDto>()
+        };
+        _communicationServiceMock
+            .Setup(x => x.GetByIdKeyAsync(idKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(communicationDto);
+        var result = await _controller.GetByIdKey(idKey);
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.Value.Should().Be(communicationDto);
+    }
+
+    [Fact]
+    public async Task GetByIdKey_WithNonExistingId_ReturnsNotFound()
+    {
+        var idKey = "NONEXISTENT";
+        _communicationServiceMock
+            .Setup(x => x.GetByIdKeyAsync(idKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((CommunicationDto?)null);
+        var result = await _controller.GetByIdKey(idKey);
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task Search_WithValidParameters_ReturnsOkResult()
+    {
+        var pagedResult = new PagedResult<CommunicationSummaryDto>(
+            new List<CommunicationSummaryDto>(),
+            0,
+            1,
+            20);
+        _communicationServiceMock
+            .Setup(x => x.SearchAsync(1, 20, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pagedResult);
+        var result = await _controller.Search(page: 1, pageSize: 20);
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.Value.Should().Be(pagedResult);
+    }
+
+    [Fact]
+    public async Task Delete_WithExistingDraft_ReturnsNoContent()
+    {
+        var idKey = "ABC123";
+        _communicationServiceMock
+            .Setup(x => x.DeleteAsync(idKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Success());
+        var result = await _controller.Delete(idKey);
+        result.Should().BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task Delete_WithNonExisting_ReturnsNotFound()
+    {
+        var idKey = "NONEXISTENT";
+        var error = new Error("NOT_FOUND", "Communication not found");
+        _communicationServiceMock
+            .Setup(x => x.DeleteAsync(idKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result.Failure(error));
+        var result = await _controller.Delete(idKey);
+        result.Should().BeOfType<NotFoundObjectResult>();
+    }
+
+    [Fact]
+    public async Task Send_WithExistingDraft_ReturnsOkResult()
+    {
+        var idKey = "ABC123";
+        var communicationDto = new CommunicationDto
+        {
+            IdKey = idKey,
+            Guid = Guid.NewGuid(),
+            CommunicationType = "Email",
+            Status = "Pending",
+            Subject = "Test",
+            Body = "Test Body",
+            RecipientCount = 1,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedDateTime = DateTime.UtcNow,
+            Recipients = new List<CommunicationRecipientDto>()
+        };
+        _communicationServiceMock
+            .Setup(x => x.SendAsync(idKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Result<CommunicationDto>.Success(communicationDto));
+        var result = await _controller.Send(idKey);
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        okResult.Value.Should().Be(communicationDto);
+    }
+}

--- a/tests/Koinon.Application.Tests/Services/CommunicationServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/CommunicationServiceTests.cs
@@ -1,0 +1,803 @@
+using AutoMapper;
+using FluentAssertions;
+using Koinon.Application.Common;
+using Koinon.Application.DTOs;
+using Koinon.Application.Interfaces;
+using Koinon.Application.Services;
+using Koinon.Domain.Data;
+using Koinon.Domain.Entities;
+using Koinon.Domain.Enums;
+using Koinon.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Application.Tests.Services;
+
+/// <summary>
+/// Unit tests for CommunicationService.
+/// </summary>
+public class CommunicationServiceTests : IDisposable
+{
+    private readonly KoinonDbContext _context;
+    private readonly Mock<IMapper> _mapperMock;
+    private readonly Mock<IUserContext> _userContextMock;
+    private readonly Mock<ILogger<CommunicationService>> _loggerMock;
+
+    public CommunicationServiceTests()
+    {
+        // Setup in-memory database with full KoinonDbContext
+        var options = new DbContextOptionsBuilder<KoinonDbContext>()
+            .UseInMemoryDatabase(databaseName: $"KoinonTestDb_{Guid.NewGuid()}")
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _context = new KoinonDbContext(options);
+        _context.Database.EnsureCreated();
+
+        _mapperMock = new Mock<IMapper>();
+        _userContextMock = new Mock<IUserContext>();
+        _loggerMock = new Mock<ILogger<CommunicationService>>();
+    }
+
+    [Fact]
+    public async Task GetByIdKeyAsync_WithValidIdKey_ReturnsCommunication()
+    {
+        // Arrange
+        var personAlias = new PersonAlias { PersonId = 1 };
+        _context.PersonAliases.Add(personAlias);
+
+        var communication = new Communication
+        {
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Draft,
+            Subject = "Test Subject",
+            Body = "Test Body",
+            FromEmail = "test@example.com",
+            RecipientCount = 1,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedByPersonAliasId = personAlias.Id
+        };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        _userContextMock.Setup(x => x.CurrentPersonId).Returns(1);
+        _userContextMock.Setup(x => x.IsInRole("Staff")).Returns(false);
+        _userContextMock.Setup(x => x.IsInRole("Admin")).Returns(false);
+
+        var expectedDto = new CommunicationDto
+        {
+            IdKey = communication.IdKey,
+            Guid = communication.Guid,
+            CommunicationType = "Email",
+            Status = "Draft",
+            Subject = "Test Subject",
+            Body = "Test Body",
+            RecipientCount = 1,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedDateTime = communication.CreatedDateTime,
+            Recipients = new List<CommunicationRecipientDto>()
+        };
+
+        _mapperMock.Setup(x => x.Map<CommunicationDto>(It.IsAny<Communication>()))
+            .Returns(expectedDto);
+
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.GetByIdKeyAsync(communication.IdKey);
+
+        // Assert
+        result.Should().NotBeNull();
+        result!.IdKey.Should().Be(communication.IdKey);
+        result.Subject.Should().Be("Test Subject");
+    }
+
+    [Fact]
+    public async Task GetByIdKeyAsync_WithInvalidIdKey_ReturnsNull()
+    {
+        // Arrange
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.GetByIdKeyAsync("invalid-idkey");
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdKeyAsync_WithUnauthorizedUser_ReturnsNull()
+    {
+        // Arrange
+        var personAlias = new PersonAlias { PersonId = 1 };
+        _context.PersonAliases.Add(personAlias);
+
+        var communication = new Communication
+        {
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Draft,
+            Subject = "Test Subject",
+            Body = "Test Body",
+            RecipientCount = 0,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedByPersonAliasId = personAlias.Id
+        };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        // Different person trying to access
+        _userContextMock.Setup(x => x.CurrentPersonId).Returns(999);
+        _userContextMock.Setup(x => x.IsInRole("Staff")).Returns(false);
+        _userContextMock.Setup(x => x.IsInRole("Admin")).Returns(false);
+
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.GetByIdKeyAsync(communication.IdKey);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task GetByIdKeyAsync_WithStaffRole_ReturnsAnyonesCommunication()
+    {
+        // Arrange
+        var personAlias = new PersonAlias { PersonId = 1 };
+        _context.PersonAliases.Add(personAlias);
+
+        var communication = new Communication
+        {
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Draft,
+            Subject = "Test Subject",
+            Body = "Test Body",
+            RecipientCount = 0,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedByPersonAliasId = personAlias.Id
+        };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        _userContextMock.Setup(x => x.CurrentPersonId).Returns(999);
+        _userContextMock.Setup(x => x.IsInRole("Staff")).Returns(true);
+        _userContextMock.Setup(x => x.IsInRole("Admin")).Returns(false);
+
+        var expectedDto = new CommunicationDto
+        {
+            IdKey = communication.IdKey,
+            Guid = communication.Guid,
+            CommunicationType = "Email",
+            Status = "Draft",
+            Subject = "Test Subject",
+            Body = "Test Body",
+            RecipientCount = 0,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedDateTime = communication.CreatedDateTime,
+            Recipients = new List<CommunicationRecipientDto>()
+        };
+
+        _mapperMock.Setup(x => x.Map<CommunicationDto>(It.IsAny<Communication>()))
+            .Returns(expectedDto);
+
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.GetByIdKeyAsync(communication.IdKey);
+
+        // Assert
+        result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithValidData_CreatesSuccessfully()
+    {
+        // Arrange
+
+        var person = new Person
+        {
+            FirstName = "John",
+            LastName = "Doe",
+            Email = "john@example.com",
+            Gender = Gender.Male
+        };
+        _context.People.Add(person);
+
+        var personAlias = new PersonAlias { PersonId = person.Id };
+        _context.PersonAliases.Add(personAlias);
+
+        var groupType = new GroupType { Name = "Small Group" };
+        _context.GroupTypes.Add(groupType);
+
+        var groupRole = new GroupTypeRole
+        {
+            GroupTypeId = groupType.Id,
+            Name = "Leader",
+            IsLeader = true
+        };
+        _context.GroupTypeRoles.Add(groupRole);
+
+        var group = new Group
+        {
+            Name = "Test Group",
+            GroupTypeId = groupType.Id,
+            IsActive = true
+        };
+        _context.Groups.Add(group);
+
+        var groupMember = new GroupMember
+        {
+            GroupId = group.Id,
+            PersonId = person.Id,
+            GroupRoleId = groupRole.Id,
+            GroupMemberStatus = GroupMemberStatus.Active
+        };
+        _context.GroupMembers.Add(groupMember);
+        await _context.SaveChangesAsync();
+
+        _userContextMock.Setup(x => x.CurrentPersonId).Returns(person.Id);
+        _userContextMock.Setup(x => x.IsInRole("Staff")).Returns(false);
+        _userContextMock.Setup(x => x.IsInRole("Admin")).Returns(false);
+
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Test Subject",
+            Body = "Test Body",
+            FromEmail = "from@example.com",
+            FromName = "From Name",
+            GroupIdKeys = new List<string> { group.IdKey }
+        };
+
+        _mapperMock.Setup(x => x.Map<CommunicationDto>(It.IsAny<Communication>()))
+            .Returns((Communication c) => new CommunicationDto
+            {
+                IdKey = c.IdKey,
+                Guid = c.Guid,
+                CommunicationType = "Email",
+                Status = "Draft",
+                Subject = "Test Subject",
+                Body = "Test Body",
+                RecipientCount = 1,
+                DeliveredCount = 0,
+                FailedCount = 0,
+                OpenedCount = 0,
+                CreatedDateTime = c.CreatedDateTime,
+                Recipients = new List<CommunicationRecipientDto>()
+            });
+
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.CreateAsync(dto);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().NotBeNull();
+        result.Value!.RecipientCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithInvalidCommunicationType_ReturnsFailure()
+    {
+        // Arrange
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "InvalidType",
+            Subject = "Test",
+            Body = "Test Body",
+            GroupIdKeys = new List<string> { "ABC123" }
+        };
+
+        // Act
+        var result = await service.CreateAsync(dto);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("INVALID_TYPE");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithMoreThan50Groups_ReturnsFailure()
+    {
+        // Arrange
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        var groupIdKeys = Enumerable.Range(1, 51).Select(i => $"GROUP{i}").ToList();
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Test",
+            Body = "Test Body",
+            GroupIdKeys = groupIdKeys
+        };
+
+        // Act
+        var result = await service.CreateAsync(dto);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Message.Should().Contain("more than 50 groups");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithInvalidGroupIdKey_ReturnsFailure()
+    {
+        // Arrange
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Test",
+            Body = "Test Body",
+            GroupIdKeys = new List<string> { "invalid-idkey" }
+        };
+
+        // Act
+        var result = await service.CreateAsync(dto);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task CreateAsync_WithNoRecipients_ReturnsFailure()
+    {
+        // Arrange
+
+        var groupType = new GroupType { Name = "Small Group" };
+        _context.GroupTypes.Add(groupType);
+
+        var groupRole = new GroupTypeRole
+        {
+            GroupTypeId = groupType.Id,
+            Name = "Leader",
+            IsLeader = true
+        };
+        _context.GroupTypeRoles.Add(groupRole);
+
+        var group = new Group
+        {
+            Name = "Empty Group",
+            GroupTypeId = groupType.Id,
+            IsActive = true
+        };
+        _context.Groups.Add(group);
+        await _context.SaveChangesAsync();
+
+        _userContextMock.Setup(x => x.IsInRole("Staff")).Returns(true);
+
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Test",
+            Body = "Test Body",
+            FromEmail = "from@example.com",
+            GroupIdKeys = new List<string> { group.IdKey }
+        };
+
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.CreateAsync(dto);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("NO_RECIPIENTS");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithValidData_UpdatesSuccessfully()
+    {
+        // Arrange
+
+        var personAlias = new PersonAlias { PersonId = 1 };
+        _context.PersonAliases.Add(personAlias);
+
+        var communication = new Communication
+        {
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Draft,
+            Subject = "Original Subject",
+            Body = "Original Body",
+            FromEmail = "original@example.com",
+            RecipientCount = 0,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedByPersonAliasId = personAlias.Id
+        };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        _userContextMock.Setup(x => x.CurrentPersonId).Returns(1);
+        _userContextMock.Setup(x => x.IsInRole("Staff")).Returns(false);
+        _userContextMock.Setup(x => x.IsInRole("Admin")).Returns(false);
+
+        var updateDto = new UpdateCommunicationDto
+        {
+            Subject = "Updated Subject",
+            Body = "Updated Body"
+        };
+
+        var expectedDto = new CommunicationDto
+        {
+            IdKey = communication.IdKey,
+            Guid = communication.Guid,
+            CommunicationType = "Email",
+            Status = "Draft",
+            Subject = "Updated Subject",
+            Body = "Updated Body",
+            RecipientCount = 0,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedDateTime = communication.CreatedDateTime,
+            Recipients = new List<CommunicationRecipientDto>()
+        };
+
+        _mapperMock.Setup(x => x.Map<CommunicationDto>(It.IsAny<Communication>()))
+            .Returns(expectedDto);
+
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.UpdateAsync(communication.IdKey, updateDto);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Subject.Should().Be("Updated Subject");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithNonDraftStatus_ReturnsFailure()
+    {
+        // Arrange
+
+        var personAlias = new PersonAlias { PersonId = 1 };
+        _context.PersonAliases.Add(personAlias);
+
+        var communication = new Communication
+        {
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Sent,
+            Subject = "Sent Subject",
+            Body = "Sent Body",
+            RecipientCount = 0,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedByPersonAliasId = personAlias.Id
+        };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        _userContextMock.Setup(x => x.CurrentPersonId).Returns(1);
+        _userContextMock.Setup(x => x.IsInRole("Staff")).Returns(false);
+        _userContextMock.Setup(x => x.IsInRole("Admin")).Returns(false);
+
+        var updateDto = new UpdateCommunicationDto { Subject = "New Subject" };
+
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.UpdateAsync(communication.IdKey, updateDto);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Message.Should().Contain("Only draft communications can be updated");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WithDraftCommunication_DeletesSuccessfully()
+    {
+        // Arrange
+
+        var personAlias = new PersonAlias { PersonId = 1 };
+        _context.PersonAliases.Add(personAlias);
+
+        var communication = new Communication
+        {
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Draft,
+            Subject = "Test",
+            Body = "Test Body",
+            RecipientCount = 0,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedByPersonAliasId = personAlias.Id
+        };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        _userContextMock.Setup(x => x.CurrentPersonId).Returns(1);
+        _userContextMock.Setup(x => x.IsInRole("Staff")).Returns(false);
+        _userContextMock.Setup(x => x.IsInRole("Admin")).Returns(false);
+
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.DeleteAsync(communication.IdKey);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var deletedComm = await _context.Communications.FindAsync(communication.Id);
+        deletedComm.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WithNonDraftStatus_ReturnsFailure()
+    {
+        // Arrange
+
+        var personAlias = new PersonAlias { PersonId = 1 };
+        _context.PersonAliases.Add(personAlias);
+
+        var communication = new Communication
+        {
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Sent,
+            Subject = "Test",
+            Body = "Test Body",
+            RecipientCount = 0,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedByPersonAliasId = personAlias.Id
+        };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        _userContextMock.Setup(x => x.CurrentPersonId).Returns(1);
+        _userContextMock.Setup(x => x.IsInRole("Staff")).Returns(false);
+        _userContextMock.Setup(x => x.IsInRole("Admin")).Returns(false);
+
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.DeleteAsync(communication.IdKey);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Message.Should().Contain("Only draft communications can be deleted");
+    }
+
+    [Fact]
+    public async Task SendAsync_WithDraftCommunication_QueuesCommunication()
+    {
+        // Arrange
+
+        var personAlias = new PersonAlias { PersonId = 1 };
+        _context.PersonAliases.Add(personAlias);
+
+        var communication = new Communication
+        {
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Draft,
+            Subject = "Test",
+            Body = "Test Body",
+            RecipientCount = 1,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedByPersonAliasId = personAlias.Id
+        };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        _userContextMock.Setup(x => x.CurrentPersonId).Returns(1);
+        _userContextMock.Setup(x => x.IsInRole("Staff")).Returns(false);
+        _userContextMock.Setup(x => x.IsInRole("Admin")).Returns(false);
+
+        var expectedDto = new CommunicationDto
+        {
+            IdKey = communication.IdKey,
+            Guid = communication.Guid,
+            CommunicationType = "Email",
+            Status = "Pending",
+            Subject = "Test",
+            Body = "Test Body",
+            RecipientCount = 1,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedDateTime = communication.CreatedDateTime,
+            Recipients = new List<CommunicationRecipientDto>()
+        };
+
+        _mapperMock.Setup(x => x.Map<CommunicationDto>(It.IsAny<Communication>()))
+            .Returns(expectedDto);
+
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.SendAsync(communication.IdKey);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Status.Should().Be("Pending");
+
+        var updatedComm = await _context.Communications.FindAsync(communication.Id);
+        updatedComm!.Status.Should().Be(CommunicationStatus.Pending);
+    }
+
+    [Fact]
+    public async Task SendAsync_WithNoRecipients_ReturnsFailure()
+    {
+        // Arrange
+
+        var personAlias = new PersonAlias { PersonId = 1 };
+        _context.PersonAliases.Add(personAlias);
+
+        var communication = new Communication
+        {
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Draft,
+            Subject = "Test",
+            Body = "Test Body",
+            RecipientCount = 0,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedByPersonAliasId = personAlias.Id
+        };
+        _context.Communications.Add(communication);
+        await _context.SaveChangesAsync();
+
+        _userContextMock.Setup(x => x.CurrentPersonId).Returns(1);
+        _userContextMock.Setup(x => x.IsInRole("Staff")).Returns(false);
+        _userContextMock.Setup(x => x.IsInRole("Admin")).Returns(false);
+
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.SendAsync(communication.IdKey);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Message.Should().Contain("Cannot send communication with no recipients");
+    }
+
+    [Fact]
+    public async Task SearchAsync_WithStaffRole_ReturnsAllCommunications()
+    {
+        // Arrange
+
+        var comm1 = new Communication
+        {
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Draft,
+            Subject = "Test 1",
+            Body = "Body 1",
+            RecipientCount = 0,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0
+        };
+        var comm2 = new Communication
+        {
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Sent,
+            Subject = "Test 2",
+            Body = "Body 2",
+            RecipientCount = 0,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0
+        };
+        _context.Communications.AddRange(comm1, comm2);
+        await _context.SaveChangesAsync();
+
+        _userContextMock.Setup(x => x.IsInRole("Staff")).Returns(true);
+
+        _mapperMock.Setup(x => x.Map<CommunicationSummaryDto>(It.IsAny<Communication>()))
+            .Returns((Communication c) => new CommunicationSummaryDto
+            {
+                IdKey = c.IdKey,
+                CommunicationType = c.CommunicationType.ToString(),
+                Status = c.Status.ToString(),
+                Subject = c.Subject,
+                RecipientCount = c.RecipientCount,
+                DeliveredCount = c.DeliveredCount,
+                FailedCount = c.FailedCount,
+                CreatedDateTime = c.CreatedDateTime,
+                SentDateTime = c.SentDateTime
+            });
+
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.SearchAsync(page: 1, pageSize: 20);
+
+        // Assert
+        result.Items.Should().HaveCount(2);
+        result.TotalCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task SearchAsync_WithNonStaffRole_ReturnsOnlyOwnCommunications()
+    {
+        // Arrange
+
+        var personAlias1 = new PersonAlias { PersonId = 1 };
+        var personAlias2 = new PersonAlias { PersonId = 2 };
+        _context.PersonAliases.AddRange(personAlias1, personAlias2);
+
+        var comm1 = new Communication
+        {
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Draft,
+            Subject = "My Communication",
+            Body = "Body 1",
+            RecipientCount = 0,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedByPersonAliasId = personAlias1.Id
+        };
+        var comm2 = new Communication
+        {
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Sent,
+            Subject = "Other's Communication",
+            Body = "Body 2",
+            RecipientCount = 0,
+            DeliveredCount = 0,
+            FailedCount = 0,
+            OpenedCount = 0,
+            CreatedByPersonAliasId = personAlias2.Id
+        };
+        _context.Communications.AddRange(comm1, comm2);
+        await _context.SaveChangesAsync();
+
+        _userContextMock.Setup(x => x.CurrentPersonId).Returns(1);
+        _userContextMock.Setup(x => x.IsInRole("Staff")).Returns(false);
+        _userContextMock.Setup(x => x.IsInRole("Admin")).Returns(false);
+
+        _mapperMock.Setup(x => x.Map<CommunicationSummaryDto>(It.IsAny<Communication>()))
+            .Returns((Communication c) => new CommunicationSummaryDto
+            {
+                IdKey = c.IdKey,
+                CommunicationType = c.CommunicationType.ToString(),
+                Status = c.Status.ToString(),
+                Subject = c.Subject,
+                RecipientCount = c.RecipientCount,
+                DeliveredCount = c.DeliveredCount,
+                FailedCount = c.FailedCount,
+                CreatedDateTime = c.CreatedDateTime,
+                SentDateTime = c.SentDateTime
+            });
+
+        var service = new CommunicationService(_context, _mapperMock.Object, _userContextMock.Object, _loggerMock.Object);
+
+        // Act
+        var result = await service.SearchAsync(page: 1, pageSize: 20);
+
+        // Assert
+        result.Items.Should().HaveCount(1);
+        result.Items.First().Subject.Should().Be("My Communication");
+    }
+
+    public void Dispose()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+    }
+}

--- a/tests/Koinon.Application.Tests/Validators/CreateCommunicationDtoValidatorTests.cs
+++ b/tests/Koinon.Application.Tests/Validators/CreateCommunicationDtoValidatorTests.cs
@@ -1,0 +1,184 @@
+using FluentValidation.TestHelper;
+using Koinon.Application.DTOs;
+using Koinon.Application.Validators;
+using Xunit;
+
+namespace Koinon.Application.Tests.Validators;
+
+public class CreateCommunicationDtoValidatorTests
+{
+    private readonly CreateCommunicationDtoValidator _validator = new();
+
+    [Fact]
+    public void Should_Have_Error_When_GroupIdKeys_Is_Empty()
+    {
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Test",
+            Body = "Test Body",
+            FromEmail = "test@example.com",
+            GroupIdKeys = new List<string>()
+        };
+        var result = _validator.TestValidate(dto);
+        result.ShouldHaveValidationErrorFor(x => x.GroupIdKeys)
+            .WithErrorMessage("At least one group must be specified");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_GroupIdKeys_Exceeds_50()
+    {
+        var groupIdKeys = Enumerable.Range(1, 51).Select(i => $"GROUP{i}").ToList();
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Test",
+            Body = "Test Body",
+            FromEmail = "test@example.com",
+            GroupIdKeys = groupIdKeys
+        };
+        var result = _validator.TestValidate(dto);
+        result.ShouldHaveValidationErrorFor(x => x.GroupIdKeys)
+            .WithErrorMessage("Cannot specify more than 50 groups per communication");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_Subject_Exceeds_MaxLength()
+    {
+        var longSubject = new string('A', 501);
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = longSubject,
+            Body = "Test Body",
+            FromEmail = "test@example.com",
+            GroupIdKeys = new List<string> { "ABC123" }
+        };
+        var result = _validator.TestValidate(dto);
+        result.ShouldHaveValidationErrorFor(x => x.Subject)
+            .WithErrorMessage("Subject cannot exceed 500 characters");
+    }
+
+    [Theory]
+    [InlineData("Subject\nwith newline")]
+    [InlineData("Subject\rwith carriage return")]
+    [InlineData("Subject\0with null byte")]
+    public void Should_Have_Error_When_Subject_Contains_HeaderInjection(string subject)
+    {
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = subject,
+            Body = "Test Body",
+            FromEmail = "test@example.com",
+            GroupIdKeys = new List<string> { "ABC123" }
+        };
+        var result = _validator.TestValidate(dto);
+        result.ShouldHaveValidationErrorFor(x => x.Subject)
+            .WithErrorMessage("Subject contains invalid characters");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_FromEmail_Is_Invalid()
+    {
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Test",
+            Body = "Test Body",
+            FromEmail = "invalid-email",
+            GroupIdKeys = new List<string> { "ABC123" }
+        };
+        var result = _validator.TestValidate(dto);
+        result.ShouldHaveValidationErrorFor(x => x.FromEmail)
+            .WithErrorMessage("Invalid email address");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_FromEmail_Exceeds_MaxLength()
+    {
+        var longEmail = new string('a', 250) + "@test.com";
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Test",
+            Body = "Test Body",
+            FromEmail = longEmail,
+            GroupIdKeys = new List<string> { "ABC123" }
+        };
+        var result = _validator.TestValidate(dto);
+        result.ShouldHaveValidationErrorFor(x => x.FromEmail)
+            .WithErrorMessage("From email cannot exceed 254 characters");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_FromName_Exceeds_MaxLength()
+    {
+        var longName = new string('A', 201);
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Test",
+            Body = "Test Body",
+            FromEmail = "test@example.com",
+            FromName = longName,
+            GroupIdKeys = new List<string> { "ABC123" }
+        };
+        var result = _validator.TestValidate(dto);
+        result.ShouldHaveValidationErrorFor(x => x.FromName)
+            .WithErrorMessage("From name cannot exceed 200 characters");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_ReplyToEmail_Is_Invalid()
+    {
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Test",
+            Body = "Test Body",
+            FromEmail = "from@example.com",
+            ReplyToEmail = "invalid-email",
+            GroupIdKeys = new List<string> { "ABC123" }
+        };
+        var result = _validator.TestValidate(dto);
+        result.ShouldHaveValidationErrorFor(x => x.ReplyToEmail)
+            .WithErrorMessage("Invalid email address");
+    }
+
+    [Fact]
+    public void Should_Have_Error_When_ReplyToEmail_Exceeds_MaxLength()
+    {
+        var longEmail = new string('a', 250) + "@test.com";
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Test",
+            Body = "Test Body",
+            FromEmail = "from@example.com",
+            ReplyToEmail = longEmail,
+            GroupIdKeys = new List<string> { "ABC123" }
+        };
+        var result = _validator.TestValidate(dto);
+        result.ShouldHaveValidationErrorFor(x => x.ReplyToEmail)
+            .WithErrorMessage("Reply-to email cannot exceed 254 characters");
+    }
+
+    [Fact]
+    public void Should_Not_Have_Error_For_Valid_Email_Communication()
+    {
+        var dto = new CreateCommunicationDto
+        {
+            CommunicationType = "Email",
+            Subject = "Valid Email Subject",
+            Body = "Valid email body content",
+            FromEmail = "sender@example.com",
+            FromName = "Sender Name",
+            ReplyToEmail = "reply@example.com",
+            Note = "Some note",
+            GroupIdKeys = new List<string> { "ABC123", "DEF456" }
+        };
+        var result = _validator.TestValidate(dto);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/tests/Koinon.Infrastructure.Tests/Koinon.Infrastructure.Tests.csproj
+++ b/tests/Koinon.Infrastructure.Tests/Koinon.Infrastructure.Tests.csproj
@@ -24,6 +24,8 @@
     <PackageReference Include="Testcontainers.PostgreSql" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
   </ItemGroup>
 
 </Project>

--- a/tests/Koinon.Infrastructure.Tests/Services/SmtpEmailSenderTests.cs
+++ b/tests/Koinon.Infrastructure.Tests/Services/SmtpEmailSenderTests.cs
@@ -1,0 +1,165 @@
+using FluentAssertions;
+using Koinon.Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Infrastructure.Tests.Services;
+
+public class SmtpEmailSenderTests
+{
+    private readonly Mock<ILogger<SmtpEmailSender>> _loggerMock;
+    private readonly IConfiguration _configuration;
+
+    public SmtpEmailSenderTests()
+    {
+        _loggerMock = new Mock<ILogger<SmtpEmailSender>>();
+        var configData = new Dictionary<string, string?>
+        {
+            ["Smtp:Host"] = "localhost",
+            ["Smtp:Port"] = "587",
+            ["Smtp:Username"] = "testuser",
+            ["Smtp:Password"] = "testpass",
+            ["Smtp:UseSsl"] = "true"
+        };
+        _configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithValidParameters_AttemptsToSend()
+    {
+        var sender = new SmtpEmailSender(_configuration, _loggerMock.Object);
+        var result = await sender.SendEmailAsync(
+            toAddress: "recipient@example.com",
+            toName: "Test Recipient",
+            fromAddress: "sender@example.com",
+            fromName: "Test Sender",
+            subject: "Test Subject",
+            bodyHtml: "<p>Test Body</p>",
+            replyToAddress: null,
+            ct: CancellationToken.None);
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithInvalidSmtpPort_UsesDefault587()
+    {
+        var configData = new Dictionary<string, string?>
+        {
+            ["Smtp:Host"] = "localhost",
+            ["Smtp:Port"] = "invalid",
+            ["Smtp:Username"] = "testuser",
+            ["Smtp:Password"] = "testpass",
+            ["Smtp:UseSsl"] = "true"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+        var sender = new SmtpEmailSender(configuration, _loggerMock.Object);
+        var result = await sender.SendEmailAsync(
+            toAddress: "recipient@example.com",
+            toName: "Test Recipient",
+            fromAddress: "sender@example.com",
+            fromName: "Test Sender",
+            subject: "Test Subject",
+            bodyHtml: "<p>Test Body</p>");
+        result.Should().BeFalse();
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Invalid SMTP port configuration")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithInvalidUseSsl_UsesDefaultTrue()
+    {
+        var configData = new Dictionary<string, string?>
+        {
+            ["Smtp:Host"] = "localhost",
+            ["Smtp:Port"] = "587",
+            ["Smtp:Username"] = "testuser",
+            ["Smtp:Password"] = "testpass",
+            ["Smtp:UseSsl"] = "invalid-boolean"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+        var sender = new SmtpEmailSender(configuration, _loggerMock.Object);
+        var result = await sender.SendEmailAsync(
+            toAddress: "recipient@example.com",
+            toName: null,
+            fromAddress: "sender@example.com",
+            fromName: null,
+            subject: "Test Subject",
+            bodyHtml: "<p>Test Body</p>");
+        result.Should().BeFalse();
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Invalid SMTP UseSsl configuration")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithConnectionFailure_LogsErrorAndReturnsFalse()
+    {
+        var configData = new Dictionary<string, string?>
+        {
+            ["Smtp:Host"] = "invalid.smtp.server.that.does.not.exist",
+            ["Smtp:Port"] = "587",
+            ["Smtp:Username"] = "testuser",
+            ["Smtp:Password"] = "testpass",
+            ["Smtp:UseSsl"] = "true"
+        };
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(configData)
+            .Build();
+        var sender = new SmtpEmailSender(configuration, _loggerMock.Object);
+        var result = await sender.SendEmailAsync(
+            toAddress: "recipient@example.com",
+            toName: "Test Recipient",
+            fromAddress: "sender@example.com",
+            fromName: "Test Sender",
+            subject: "Test Subject",
+            bodyHtml: "<p>Test Body</p>");
+        result.Should().BeFalse();
+        _loggerMock.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.AtLeastOnce);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithCancellationToken_RespectsCancellation()
+    {
+        var sender = new SmtpEmailSender(_configuration, _loggerMock.Object);
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+        {
+            await sender.SendEmailAsync(
+                toAddress: "recipient@example.com",
+                toName: "Test Recipient",
+                fromAddress: "sender@example.com",
+                fromName: "Test Sender",
+                subject: "Test Subject",
+                bodyHtml: "<p>Test Body</p>",
+                replyToAddress: null,
+                ct: cts.Token);
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Add 40+ unit tests for Communication feature components
- Increase test count from 782 to 824 (42 new tests)
- Address technical debt from issue #113 implementation

## Test Coverage

### CommunicationServiceTests (17 tests)
- GetByIdKeyAsync with valid/invalid IdKeys and authorization scenarios
- CreateAsync with validation, group limits, and recipient resolution
- UpdateAsync/DeleteAsync with draft status enforcement
- SendAsync with recipient validation
- SearchAsync with staff/non-staff role filtering

### CreateCommunicationDtoValidatorTests (10 tests)
- MaxLength validations (Subject: 500, FromEmail: 254, FromName: 200, ReplyToEmail: 254)
- Email header injection protection (newline/null byte detection)
- Required field and email format validation

### SmtpEmailSenderTests (5 tests)
- SMTP configuration parsing and defaults
- Connection failure handling and logging
- Cancellation token support

### CommunicationsControllerTests (8 tests)
- CRUD endpoint responses and authorization
- Input validation and error handling

## Test plan
- [x] All 824 tests passing
- [x] Code-critic approved
- [x] No production code changes

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)