### PR TITLE
fix: Improve phone number validation UX with normalization (#107)

### DIFF
--- a/src/Koinon.Application/Helpers/PhoneNumberHelper.cs
+++ b/src/Koinon.Application/Helpers/PhoneNumberHelper.cs
@@ -1,0 +1,103 @@
+using System.Text.RegularExpressions;
+
+namespace Koinon.Application.Helpers;
+
+/// <summary>
+/// Helper for phone number normalization and validation.
+/// Converts common US phone formats to E.164 format.
+/// </summary>
+public static class PhoneNumberHelper
+{
+    private static readonly Regex E164Regex = new(@"^\+[1-9]\d{1,14}$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Normalizes phone number to E.164 format.
+    /// Accepts formats like (555) 123-4567, 555-123-4567, 555.123.4567
+    /// </summary>
+    /// <param name="input">Raw phone number input</param>
+    /// <returns>Normalized E.164 format phone number, or null if input is invalid</returns>
+    public static string? Normalize(string? input)
+    {
+        if (string.IsNullOrWhiteSpace(input))
+        {
+            return null;
+        }
+
+        // Keep leading + if present
+        var hasPlus = input.TrimStart().StartsWith('+');
+
+        // Strip all non-digits
+        var digits = new string(input.Where(char.IsDigit).ToArray());
+
+        if (string.IsNullOrEmpty(digits))
+        {
+            return null;
+        }
+
+        // Reject numbers starting with 0 (invalid for E.164)
+        if (digits.StartsWith('0'))
+        {
+            return null;
+        }
+
+        // E.164 allows 1-15 digits total
+        // If less than 7 digits (minimum for most countries), reject
+        if (digits.Length < 7)
+        {
+            return null;
+        }
+
+        // If more than 15 digits, reject
+        if (digits.Length > 15)
+        {
+            return null;
+        }
+
+        // If exactly 10 digits and no country code, assume US (+1)
+        if (digits.Length == 10 && !hasPlus)
+        {
+            return $"+1{digits}";
+        }
+
+        // If 11 digits starting with 1, add +
+        if (digits.Length == 11 && digits.StartsWith('1') && !hasPlus)
+        {
+            return $"+{digits}";
+        }
+
+        // Otherwise, add + prefix
+        return $"+{digits}";
+    }
+
+    /// <summary>
+    /// Validates that a phone number is in E.164 format.
+    /// </summary>
+    /// <param name="phone">Phone number to validate</param>
+    /// <returns>True if valid E.164 format, false otherwise</returns>
+    public static bool IsValidE164(string? phone)
+    {
+        if (string.IsNullOrWhiteSpace(phone))
+        {
+            return false;
+        }
+
+        return E164Regex.IsMatch(phone);
+    }
+
+    /// <summary>
+    /// Normalizes and validates a phone number.
+    /// Returns the normalized E.164 format if valid, null otherwise.
+    /// </summary>
+    /// <param name="input">Raw phone number input</param>
+    /// <returns>Normalized E.164 format if valid, null otherwise</returns>
+    public static string? NormalizeAndValidate(string? input)
+    {
+        var normalized = Normalize(input);
+        if (normalized == null || !IsValidE164(normalized))
+        {
+            return null;
+        }
+
+        return normalized;
+    }
+}

--- a/src/Koinon.Application/Services/AuthorizedPickupService.cs
+++ b/src/Koinon.Application/Services/AuthorizedPickupService.cs
@@ -2,6 +2,7 @@ using System.Security.Cryptography;
 using System.Text;
 using Koinon.Application.DTOs;
 using Koinon.Application.DTOs.Requests;
+using Koinon.Application.Helpers;
 using Koinon.Application.Interfaces;
 using Koinon.Domain.Data;
 using Koinon.Domain.Entities;
@@ -107,12 +108,17 @@ public class AuthorizedPickupService(
             throw new ArgumentException($"Child with IdKey {childIdKey} not found", nameof(childIdKey));
         }
 
+        // Normalize phone number to E.164 format if provided
+        var normalizedPhone = string.IsNullOrWhiteSpace(request.PhoneNumber)
+            ? null
+            : PhoneNumberHelper.Normalize(request.PhoneNumber);
+
         var pickup = new AuthorizedPickup
         {
             ChildPersonId = childId,
             AuthorizedPersonId = authorizedPersonId,
             Name = request.Name,
-            PhoneNumber = request.PhoneNumber,
+            PhoneNumber = normalizedPhone,
             Relationship = request.Relationship,
             AuthorizationLevel = request.AuthorizationLevel,
             PhotoUrl = request.PhotoUrl,

--- a/src/Koinon.Application/Services/MyProfileService.cs
+++ b/src/Koinon.Application/Services/MyProfileService.cs
@@ -2,6 +2,7 @@ using FluentValidation;
 using Koinon.Application.Common;
 using Koinon.Application.DTOs;
 using Koinon.Application.DTOs.Requests;
+using Koinon.Application.Helpers;
 using Koinon.Application.Interfaces;
 using Koinon.Domain.Data;
 using Koinon.Domain.Entities;
@@ -577,6 +578,9 @@ public class MyProfileService(
         // Update or add phone numbers
         foreach (var phoneRequest in phoneNumberRequests)
         {
+            // Normalize phone number to E.164 format
+            var normalizedNumber = PhoneNumberHelper.Normalize(phoneRequest.Number) ?? phoneRequest.Number;
+
             PhoneNumber? phoneNumber;
 
             if (!string.IsNullOrWhiteSpace(phoneRequest.IdKey)
@@ -594,7 +598,7 @@ public class MyProfileService(
                 // Create new
                 phoneNumber = new PhoneNumber
                 {
-                    Number = phoneRequest.Number,
+                    Number = normalizedNumber,
                     PersonId = person.Id,
                     Guid = Guid.NewGuid(),
                     CreatedDateTime = DateTime.UtcNow
@@ -602,7 +606,7 @@ public class MyProfileService(
                 person.PhoneNumbers.Add(phoneNumber);
             }
 
-            phoneNumber.Number = phoneRequest.Number;
+            phoneNumber.Number = normalizedNumber;
             phoneNumber.Extension = phoneRequest.Extension;
             phoneNumber.IsMessagingEnabled = phoneRequest.IsMessagingEnabled;
             phoneNumber.IsUnlisted = phoneRequest.IsUnlisted;

--- a/src/Koinon.Application/Validators/CreateAuthorizedPickupRequestValidator.cs
+++ b/src/Koinon.Application/Validators/CreateAuthorizedPickupRequestValidator.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Koinon.Application.DTOs.Requests;
+using Koinon.Application.Helpers;
 using Koinon.Domain.Enums;
 
 namespace Koinon.Application.Validators;
@@ -22,9 +23,9 @@ public class CreateAuthorizedPickupRequestValidator : AbstractValidator<CreateAu
             .MaximumLength(200).WithMessage("Name cannot exceed 200 characters")
             .When(x => !string.IsNullOrWhiteSpace(x.Name));
 
-        // If PhoneNumber provided, validate E.164 format
+        // If PhoneNumber provided, normalize and validate E.164 format
         RuleFor(x => x.PhoneNumber)
-            .Matches(@"^\+?[1-9]\d{1,14}$")
+            .Must(phone => PhoneNumberHelper.NormalizeAndValidate(phone) != null)
             .WithMessage("Phone number must be in valid E.164 format (e.g., +12345678901)")
             .When(x => !string.IsNullOrWhiteSpace(x.PhoneNumber));
 

--- a/src/Koinon.Application/Validators/UpdateMyProfileRequestValidator.cs
+++ b/src/Koinon.Application/Validators/UpdateMyProfileRequestValidator.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using Koinon.Application.DTOs.Requests;
+using Koinon.Application.Helpers;
 
 namespace Koinon.Application.Validators;
 
@@ -54,8 +55,8 @@ public class UpdatePhoneNumberRequestValidator : AbstractValidator<UpdatePhoneNu
         RuleFor(x => x.Number)
             .NotEmpty()
             .WithMessage("Phone number is required")
-            .Matches(@"^\d{10,15}$")
-            .WithMessage("Phone number must be 10-15 digits");
+            .Must(phone => PhoneNumberHelper.NormalizeAndValidate(phone) != null)
+            .WithMessage("Phone number must be in valid E.164 format (e.g., +12345678901 or formats like (555) 123-4567)");
 
         When(x => !string.IsNullOrWhiteSpace(x.Extension), () =>
         {

--- a/tests/Koinon.Application.Tests/Helpers/PhoneNumberHelperTests.cs
+++ b/tests/Koinon.Application.Tests/Helpers/PhoneNumberHelperTests.cs
@@ -1,0 +1,242 @@
+using Koinon.Application.Helpers;
+using Xunit;
+
+namespace Koinon.Application.Tests.Helpers;
+
+/// <summary>
+/// Tests for PhoneNumberHelper.
+/// </summary>
+public class PhoneNumberHelperTests
+{
+    #region Normalize Tests
+
+    [Theory]
+    [InlineData("(555) 123-4567", "+15551234567")]
+    [InlineData("555-123-4567", "+15551234567")]
+    [InlineData("555.123.4567", "+15551234567")]
+    [InlineData("555 123 4567", "+15551234567")]
+    [InlineData("5551234567", "+15551234567")]
+    public void Normalize_ShouldConvert_CommonUSFormats_ToE164(string input, string expected)
+    {
+        // Act
+        var result = PhoneNumberHelper.Normalize(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void Normalize_ShouldAddPlusToUS11DigitNumber_StartingWith1()
+    {
+        // Arrange
+        var input = "15551234567";
+
+        // Act
+        var result = PhoneNumberHelper.Normalize(input);
+
+        // Assert
+        Assert.Equal("+15551234567", result);
+    }
+
+    [Fact]
+    public void Normalize_ShouldPreserve_AlreadyE164FormattedNumber()
+    {
+        // Arrange
+        var input = "+15551234567";
+
+        // Act
+        var result = PhoneNumberHelper.Normalize(input);
+
+        // Assert
+        Assert.Equal("+15551234567", result);
+    }
+
+    [Fact]
+    public void Normalize_ShouldHandleInternationalNumber_WithPlus()
+    {
+        // Arrange
+        var input = "+442071234567";
+
+        // Act
+        var result = PhoneNumberHelper.Normalize(input);
+
+        // Assert
+        Assert.Equal("+442071234567", result);
+    }
+
+    [Fact]
+    public void Normalize_ShouldHandleInternationalNumber_WithoutPlus()
+    {
+        // Arrange
+        var input = "442071234567";
+
+        // Act
+        var result = PhoneNumberHelper.Normalize(input);
+
+        // Assert
+        Assert.Equal("+442071234567", result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Normalize_ShouldReturnNull_ForEmptyOrWhitespace(string? input)
+    {
+        // Act
+        var result = PhoneNumberHelper.Normalize(input);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Normalize_ShouldReturnNull_ForInputWithNoDigits()
+    {
+        // Arrange
+        var input = "abc-def-ghij";
+
+        // Act
+        var result = PhoneNumberHelper.Normalize(input);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void Normalize_ShouldStripAllNonDigits_ExceptLeadingPlus()
+    {
+        // Arrange
+        var input = "+1 (555) 123-4567 ext. 890";
+
+        // Act
+        var result = PhoneNumberHelper.Normalize(input);
+
+        // Assert
+        Assert.Equal("+15551234567890", result);
+    }
+
+    #endregion
+
+    #region IsValidE164 Tests
+
+    [Theory]
+    [InlineData("+15551234567")]
+    [InlineData("+442071234567")]
+    [InlineData("+12345678901")]
+    [InlineData("+61412345678")]
+    public void IsValidE164_ShouldReturnTrue_ForValidE164Numbers(string phone)
+    {
+        // Act
+        var result = PhoneNumberHelper.IsValidE164(phone);
+
+        // Assert
+        Assert.True(result);
+    }
+
+    [Theory]
+    [InlineData("5551234567")]          // Missing +
+    [InlineData("0123456789")]          // Starts with 0
+    [InlineData("+0123456789")]         // Starts with +0
+    [InlineData("+1234567890123456")]   // Too long (16 digits)
+    [InlineData("+1")]                  // Too short
+    [InlineData("abc")]                 // Not digits
+    [InlineData("(555) 123-4567")]      // Not normalized
+    public void IsValidE164_ShouldReturnFalse_ForInvalidE164Numbers(string phone)
+    {
+        // Act
+        var result = PhoneNumberHelper.IsValidE164(phone);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsValidE164_ShouldReturnFalse_ForEmptyOrWhitespace(string? phone)
+    {
+        // Act
+        var result = PhoneNumberHelper.IsValidE164(phone);
+
+        // Assert
+        Assert.False(result);
+    }
+
+    #endregion
+
+    #region NormalizeAndValidate Tests
+
+    [Theory]
+    [InlineData("(555) 123-4567", "+15551234567")]
+    [InlineData("555-123-4567", "+15551234567")]
+    [InlineData("555.123.4567", "+15551234567")]
+    [InlineData("+15551234567", "+15551234567")]
+    [InlineData("15551234567", "+15551234567")]
+    public void NormalizeAndValidate_ShouldReturnNormalizedE164_ForValidInputs(string input, string expected)
+    {
+        // Act
+        var result = PhoneNumberHelper.NormalizeAndValidate(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("abc")]
+    [InlineData("123")]                         // Too short
+    [InlineData("01234567890")]                 // Starts with 0
+    public void NormalizeAndValidate_ShouldReturnNull_ForInvalidInputs(string? input)
+    {
+        // Act
+        var result = PhoneNumberHelper.NormalizeAndValidate(input);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void NormalizeAndValidate_ShouldRejectNumber_ThatStartsWith0()
+    {
+        // Arrange
+        var input = "0551234567";
+
+        // Act
+        var result = PhoneNumberHelper.NormalizeAndValidate(input);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void NormalizeAndValidate_ShouldRejectNumber_ThatIsTooLong()
+    {
+        // Arrange - E.164 allows max 15 digits (including country code)
+        var input = "12345678901234567"; // 17 digits
+
+        // Act
+        var result = PhoneNumberHelper.NormalizeAndValidate(input);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Theory]
+    [InlineData("+44 20 7123 4567", "+442071234567")]
+    [InlineData("+61 412 345 678", "+61412345678")]
+    [InlineData("+33 1 23 45 67 89", "+33123456789")]
+    public void NormalizeAndValidate_ShouldHandleInternationalFormats(string input, string expected)
+    {
+        // Act
+        var result = PhoneNumberHelper.NormalizeAndValidate(input);
+
+        // Assert
+        Assert.Equal(expected, result);
+    }
+
+    #endregion
+}

--- a/tests/Koinon.Application.Tests/Validators/CreateAuthorizedPickupRequestValidatorTests.cs
+++ b/tests/Koinon.Application.Tests/Validators/CreateAuthorizedPickupRequestValidatorTests.cs
@@ -131,6 +131,9 @@ public class CreateAuthorizedPickupRequestValidatorTests
     [InlineData("+12345678901")]
     [InlineData("+442071234567")]
     [InlineData("12345678901")]
+    [InlineData("(555) 123-4567")]
+    [InlineData("555-123-4567")]
+    [InlineData("555.123.4567")]
     public void Should_Not_Have_Error_For_Valid_PhoneNumber_Format(string phoneNumber)
     {
         // Arrange
@@ -157,6 +160,7 @@ public class CreateAuthorizedPickupRequestValidatorTests
     [InlineData("+0123456789")]
     [InlineData("+1234567890123456")]
     [InlineData("not-a-phone")]
+    [InlineData("123")]
     public void Should_Have_Error_For_Invalid_PhoneNumber_Format(string phoneNumber)
     {
         // Arrange


### PR DESCRIPTION
## Summary
- Add `PhoneNumberHelper` utility that normalizes common phone formats to E.164
- Accepts formats: `(555) 123-4567`, `555-123-4567`, `555.123.4567`, `555 123 4567`
- Automatically adds `+1` for 10-digit US numbers
- Update validators and services to use normalization

## Test plan
- [x] All 872 existing tests pass
- [x] 44 new tests for PhoneNumberHelper covering all formats
- [x] Validator tests updated for common phone formats
- [x] Code-critic approved

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)