### PR TITLE
fix: enable Enter key submission test for login form

### DIFF
--- a/src/web/e2e/tests/auth/login.spec.ts
+++ b/src/web/e2e/tests/auth/login.spec.ts
@@ -53,8 +53,7 @@ test.describe('Login Flow', () => {
     await loginPage.expectLoggedIn();
   });
 
-  // Bug: #125 - Login form does not submit on Enter key press
-  test.fixme('should submit form on Enter key press', async ({ page }) => {
+  test('should submit form on Enter key press', async ({ page }) => {
     const loginPage = new LoginPage(page);
 
     await loginPage.usernameInput.fill('admin');


### PR DESCRIPTION
## Summary
- Enables previously disabled E2E test for Enter key login submission
- Test validates accessibility/UX requirement for keyboard form submission

## Changes
- Removed `test.fixme` marker from login Enter key test
- Test already contained proper implementation (fill username, fill password, press Enter, verify success)

## Test Plan
- [x] E2E test runs successfully
- [x] Test validates Enter key submits login form
- [x] No production code changes required (feature already works)

Fixes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)