### PR TITLE
feat(import): build ImportProgress and ValidationPreview components

### DIFF
--- a/src/web/src/components/import/ImportProgress.tsx
+++ b/src/web/src/components/import/ImportProgress.tsx
@@ -1,0 +1,155 @@
+import { ImportStatus } from '@/types/import';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { cn } from '@/lib/utils';
+
+export interface ImportProgressProps {
+  progress: number;
+  processedRows: number;
+  totalRows: number;
+  successCount: number;
+  errorCount: number;
+  elapsedSeconds: number;
+  status: ImportStatus;
+  onCancel?: () => void;
+}
+
+export function ImportProgress({
+  progress,
+  processedRows,
+  totalRows,
+  successCount,
+  errorCount,
+  elapsedSeconds,
+  status,
+  onCancel,
+}: ImportProgressProps) {
+  const formatTime = (seconds: number): string => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return mins + ':' + secs.toString().padStart(2, '0');
+  };
+
+  const getStatusMessage = () => {
+    switch (status) {
+      case 'completed':
+        return (
+          <div className="flex items-center gap-2 text-green-600 text-lg font-semibold">
+            <span className="text-2xl">✓</span>
+            Import completed successfully
+          </div>
+        );
+      case 'failed':
+        return (
+          <div className="flex items-center gap-2 text-red-600 text-lg font-semibold">
+            <span className="text-2xl">✗</span>
+            Import failed
+          </div>
+        );
+      case 'cancelled':
+        return (
+          <div className="flex items-center gap-2 text-yellow-600 text-lg font-semibold">
+            <span className="text-2xl">⚠</span>
+            Import cancelled by user
+          </div>
+        );
+      case 'importing':
+        return (
+          <div className="text-lg font-semibold text-gray-900">Importing People...</div>
+        );
+    }
+  };
+
+  const isCompleted = status === 'completed' || status === 'failed' || status === 'cancelled';
+
+  return (
+    <Card className="p-6">
+      <div className="space-y-6" role="status" aria-live="polite" aria-atomic="true">
+        {/* Status Message */}
+        {getStatusMessage()}
+
+        {/* Progress Bar */}
+        <div className="space-y-2">
+          <div className="relative w-full h-8 bg-gray-200 rounded-lg overflow-hidden">
+            <div
+              className={cn(
+                'absolute top-0 left-0 h-full transition-all duration-300 ease-out',
+                status === 'completed'
+                  ? 'bg-green-600'
+                  : status === 'failed'
+                  ? 'bg-red-600'
+                  : status === 'cancelled'
+                  ? 'bg-yellow-600'
+                  : 'bg-blue-600'
+              )}
+              style={{ width: Math.min(100, Math.max(0, progress)) + '%' }}
+              role="progressbar"
+              aria-valuenow={progress}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label="Import progress"
+            />
+            <div className="absolute inset-0 flex items-center justify-center">
+              <span className="text-sm font-semibold text-gray-900 mix-blend-difference">
+                {Math.round(progress)}%
+              </span>
+            </div>
+          </div>
+        </div>
+
+        {/* Stats */}
+        <div className="space-y-2 text-sm">
+          <div className="flex items-center justify-between">
+            <span className="text-gray-700 font-medium">Processed:</span>
+            <span className="text-gray-900 font-semibold">
+              {processedRows} of {totalRows} rows
+            </span>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <span className="text-gray-700 font-medium">Results:</span>
+            <div className="flex items-center gap-4">
+              <span className="text-green-600 font-semibold">✓ Success: {successCount}</span>
+              <span className="text-red-600 font-semibold">✗ Errors: {errorCount}</span>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between">
+            <span className="text-gray-700 font-medium">Elapsed:</span>
+            <span className="text-gray-900 font-semibold">{formatTime(elapsedSeconds)}</span>
+          </div>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="flex justify-center pt-4 border-t border-gray-200">
+          {status === 'importing' && onCancel && (
+            <Button onClick={onCancel} variant="outline" size="md">
+              Cancel Import
+            </Button>
+          )}
+
+          {isCompleted && errorCount > 0 && (
+            <Button
+              onClick={() => {
+                const errorReport = 'Import Error Report\n\nTotal Errors: ' + errorCount + '\nSuccessful: ' + successCount + '\nTotal Processed: ' + processedRows + '\n\nPlease review the import logs for details.';
+                const blob = new Blob([errorReport], { type: 'text/plain' });
+                const url = URL.createObjectURL(blob);
+                const link = document.createElement('a');
+                link.href = url;
+                link.download = 'import-errors-' + new Date().toISOString().slice(0, 10) + '.txt';
+                document.body.appendChild(link);
+                link.click();
+                document.body.removeChild(link);
+                URL.revokeObjectURL(url);
+              }}
+              variant="outline"
+              size="md"
+            >
+              Download Error Report
+            </Button>
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/web/src/components/import/ValidationPreview.tsx
+++ b/src/web/src/components/import/ValidationPreview.tsx
@@ -1,0 +1,253 @@
+import { useState, useMemo } from 'react';
+import { ValidationError, ValidationSeverity } from '@/types/import';
+import { Card } from '@/components/ui/Card';
+import { Button } from '@/components/ui/Button';
+import { cn } from '@/lib/utils';
+
+export interface ValidationPreviewProps {
+  validationErrors: ValidationError[];
+  onFixErrors?: () => void;
+  onImportAnyway: () => void;
+  onCancel: () => void;
+}
+
+type SeverityFilter = 'all' | ValidationSeverity;
+
+export function ValidationPreview({
+  validationErrors,
+  onFixErrors,
+  onImportAnyway,
+  onCancel,
+}: ValidationPreviewProps) {
+  const [severityFilter, setSeverityFilter] = useState<SeverityFilter>('all');
+  const [sortBy, setSortBy] = useState<'row' | 'severity'>('row');
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+
+  const severityCounts = useMemo(() => {
+    return validationErrors.reduce(
+      (acc, error) => {
+        acc[error.severity]++;
+        return acc;
+      },
+      { error: 0, warning: 0, info: 0 } as Record<ValidationSeverity, number>
+    );
+  }, [validationErrors]);
+
+  const filteredAndSortedErrors = useMemo(() => {
+    const filtered =
+      severityFilter === 'all'
+        ? validationErrors
+        : validationErrors.filter((e) => e.severity === severityFilter);
+
+    const severityOrder: Record<ValidationSeverity, number> = {
+      error: 0,
+      warning: 1,
+      info: 2,
+    };
+
+    const sorted = [...filtered].sort((a, b) => {
+      let comparison = 0;
+      if (sortBy === 'row') {
+        comparison = a.rowNumber - b.rowNumber;
+      } else {
+        comparison = severityOrder[a.severity] - severityOrder[b.severity];
+      }
+      return sortOrder === 'asc' ? comparison : -comparison;
+    });
+
+    return sorted;
+  }, [validationErrors, severityFilter, sortBy, sortOrder]);
+
+  const toggleSort = (column: 'row' | 'severity') => {
+    if (sortBy === column) {
+      setSortOrder(sortOrder === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortBy(column);
+      setSortOrder('asc');
+    }
+  };
+
+  const getSeverityIcon = (severity: ValidationSeverity) => {
+    switch (severity) {
+      case 'error':
+        return (
+          <span className="text-red-600 font-bold" aria-label="Error">
+            ✗
+          </span>
+        );
+      case 'warning':
+        return (
+          <span className="text-yellow-600 font-bold" aria-label="Warning">
+            ⚠
+          </span>
+        );
+      case 'info':
+        return (
+          <span className="text-blue-600 font-bold" aria-label="Info">
+            ℹ
+          </span>
+        );
+    }
+  };
+
+  const getSeverityColor = (severity: ValidationSeverity) => {
+    switch (severity) {
+      case 'error':
+        return 'text-red-600';
+      case 'warning':
+        return 'text-yellow-600';
+      case 'info':
+        return 'text-blue-600';
+    }
+  };
+
+  if (validationErrors.length === 0) {
+    return (
+      <Card className="p-6">
+        <div className="text-center text-gray-500">
+          <div className="mb-4 text-green-600 text-5xl">✓</div>
+          <p className="text-lg font-medium">No validation issues found</p>
+          <p className="mt-2 text-sm">All rows are valid and ready to import</p>
+          <div className="mt-6 flex justify-center gap-4">
+            <Button onClick={onImportAnyway} variant="primary">
+              Continue Import
+            </Button>
+            <Button onClick={onCancel} variant="outline">
+              Cancel
+            </Button>
+          </div>
+        </div>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-6">
+      <div className="space-y-4">
+        {/* Header */}
+        <div>
+          <h2 className="text-xl font-semibold mb-2">Validation Results</h2>
+          <div className="flex items-center gap-4 text-sm">
+            <span className="text-green-600 font-medium">
+              ✓ {validationErrors.length - severityCounts.error - severityCounts.warning} valid
+            </span>
+            <span className={cn('font-medium', getSeverityColor('warning'))}>
+              ⚠ {severityCounts.warning} warnings
+            </span>
+            <span className={cn('font-medium', getSeverityColor('error'))}>
+              ✗ {severityCounts.error} errors
+            </span>
+          </div>
+        </div>
+
+        {/* Filter Controls */}
+        <div className="flex items-center gap-4">
+          <label htmlFor="severity-filter" className="text-sm font-medium">
+            Filter by severity:
+          </label>
+          <select
+            id="severity-filter"
+            value={severityFilter}
+            onChange={(e) => setSeverityFilter(e.target.value as SeverityFilter)}
+            className="px-3 py-2 border border-gray-300 rounded-md text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            aria-label="Filter validation results by severity"
+          >
+            <option value="all">All ({validationErrors.length})</option>
+            <option value="error">Errors ({severityCounts.error})</option>
+            <option value="warning">Warnings ({severityCounts.warning})</option>
+            <option value="info">Info ({severityCounts.info})</option>
+          </select>
+        </div>
+
+        {/* Table */}
+        <div className="overflow-x-auto border border-gray-200 rounded-lg">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                  onClick={() => toggleSort('row')}
+                >
+                  <div className="flex items-center gap-1">
+                    Row #
+                    {sortBy === 'row' && (
+                      <span className="text-blue-600">{sortOrder === 'asc' ? '↑' : '↓'}</span>
+                    )}
+                  </div>
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
+                  onClick={() => toggleSort('severity')}
+                >
+                  <div className="flex items-center gap-1">
+                    Severity
+                    {sortBy === 'severity' && (
+                      <span className="text-blue-600">{sortOrder === 'asc' ? '↑' : '↓'}</span>
+                    )}
+                  </div>
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider"
+                >
+                  Column
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider"
+                >
+                  Value
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-medium text-gray-700 uppercase tracking-wider"
+                >
+                  Issue
+                </th>
+              </tr>
+            </thead>
+            <tbody className="bg-white divide-y divide-gray-200">
+              {filteredAndSortedErrors.map((error, index) => (
+                <tr key={index} className="hover:bg-gray-50">
+                  <td className="px-4 py-3 whitespace-nowrap text-sm font-medium text-gray-900">
+                    {error.rowNumber}
+                  </td>
+                  <td className="px-4 py-3 whitespace-nowrap text-sm">
+                    {getSeverityIcon(error.severity)}
+                  </td>
+                  <td className="px-4 py-3 whitespace-nowrap text-sm text-gray-900">
+                    {error.columnName}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-700 max-w-xs truncate" title={error.value}>
+                    {error.value}
+                  </td>
+                  <td className="px-4 py-3 text-sm text-gray-700">{error.message}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Action Buttons */}
+        <div className="flex justify-end gap-4 pt-4 border-t border-gray-200">
+          {onFixErrors && severityCounts.error > 0 && (
+            <Button onClick={onFixErrors} variant="primary">
+              Fix Errors
+            </Button>
+          )}
+          <Button
+            onClick={onImportAnyway}
+            variant={severityCounts.error > 0 ? 'outline' : 'primary'}
+          >
+            Import Anyway
+          </Button>
+          <Button onClick={onCancel} variant="ghost">
+            Cancel
+          </Button>
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/src/web/src/types/import.ts
+++ b/src/web/src/types/import.ts
@@ -1,0 +1,25 @@
+/**
+ * CSV Import Type Definitions
+ * For validation and progress tracking during import operations
+ */
+
+export type ValidationSeverity = 'error' | 'warning' | 'info';
+
+export interface ValidationError {
+  rowNumber: number;
+  columnName: string;
+  value: string;
+  message: string;
+  severity: ValidationSeverity;
+}
+
+export type ImportStatus = 'importing' | 'completed' | 'failed' | 'cancelled';
+
+export interface ImportProgress {
+  processedRows: number;
+  totalRows: number;
+  successCount: number;
+  errorCount: number;
+  elapsedSeconds: number;
+  status: ImportStatus;
+}


### PR DESCRIPTION
## Summary
Implements #249 - ImportProgress and ValidationPreview components for CSV import validation and progress tracking

## Changes
- Created ValidationPreview component with sortable/filterable validation results table
- Created ImportProgress component with real-time progress tracking
- Added import type definitions (ValidationError, ImportStatus, ImportProgress)
- Implemented severity filtering (error, warning, info) with color coding
- Added elapsed time tracking and cancel import functionality
- Implemented download error report feature
- Full accessibility with ARIA attributes and live regions

## Components Added
- `src/web/src/types/import.ts` - Import type definitions (25 lines)
- `src/web/src/components/import/ValidationPreview.tsx` - Validation results table (253 lines)
- `src/web/src/components/import/ImportProgress.tsx` - Progress tracker (155 lines)

## Features
- **ValidationPreview**: Sortable table, severity filtering, summary counts, fix/import/cancel actions
- **ImportProgress**: Animated progress bar, real-time stats, elapsed timer, status-based UI, error report download

## Code Quality
- Code-critic: APPROVED (0 blocking issues, 3 minor quality suggestions noted for future tech debt)
- TypeScript strict mode enforced
- All accessibility requirements met
- Follows existing UI component patterns

## Test Plan
- [ ] Upload CSV file and trigger validation
- [ ] View validation errors/warnings with severity filtering
- [ ] Sort validation results by row or severity
- [ ] Start import and watch progress bar update
- [ ] Verify success/error counters update in real-time
- [ ] Test cancel import functionality
- [ ] Download error report after failed import
- [ ] Verify ARIA live regions announce progress updates

## Future Improvements (Tech Debt)
- Extract download logic to utility function
- Use stable keys for table rows instead of array index
- Avoid array mutation in useMemo sort operation

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)