### PR TITLE
feat(giving): implement BatchDonationEntryService for manual contribution entry (#256)

### DIFF
--- a/docs/issue-256-spec.md
+++ b/docs/issue-256-spec.md
@@ -1,0 +1,329 @@
+# BatchDonationEntryService Implementation
+
+## Task
+Implement BatchDonationEntryService for manual contribution entry with batch reconciliation for issue #256.
+
+## Files to Create
+
+### 1. Request DTOs (src/Koinon.Application/DTOs/Requests/)
+
+**CreateBatchRequest.cs**
+```csharp
+namespace Koinon.Application.DTOs.Requests;
+
+public record CreateBatchRequest
+{
+    public required string Name { get; init; }
+    public required DateTime BatchDate { get; init; }
+    public decimal? ControlAmount { get; init; }
+    public int? ControlItemCount { get; init; }
+    public string? CampusIdKey { get; init; }
+    public string? Note { get; init; }
+}
+```
+
+**AddContributionRequest.cs**
+```csharp
+namespace Koinon.Application.DTOs.Requests;
+
+public record AddContributionRequest
+{
+    public string? PersonIdKey { get; init; }
+    public required DateTime TransactionDateTime { get; init; }
+    public string? TransactionCode { get; init; }
+    public required string TransactionTypeValueIdKey { get; init; }
+    public required List<ContributionDetailRequest> Details { get; init; }
+    public string? Summary { get; init; }
+}
+```
+
+**ContributionDetailRequest.cs**
+```csharp
+namespace Koinon.Application.DTOs.Requests;
+
+public record ContributionDetailRequest
+{
+    public required string FundIdKey { get; init; }
+    public required decimal Amount { get; init; }
+    public string? Summary { get; init; }
+}
+```
+
+**UpdateContributionRequest.cs**
+```csharp
+namespace Koinon.Application.DTOs.Requests;
+
+public record UpdateContributionRequest
+{
+    public string? PersonIdKey { get; init; }
+    public required DateTime TransactionDateTime { get; init; }
+    public string? TransactionCode { get; init; }
+    public required string TransactionTypeValueIdKey { get; init; }
+    public required List<ContributionDetailRequest> Details { get; init; }
+    public string? Summary { get; init; }
+}
+```
+
+### 2. Response DTOs (create directory src/Koinon.Application/DTOs/Giving/)
+
+**ContributionBatchDto.cs**
+```csharp
+namespace Koinon.Application.DTOs.Giving;
+
+public record ContributionBatchDto
+{
+    public required string IdKey { get; init; }
+    public required string Name { get; init; }
+    public required DateTime BatchDate { get; init; }
+    public required string Status { get; init; }
+    public decimal? ControlAmount { get; init; }
+    public string? CampusIdKey { get; init; }
+    public string? Note { get; init; }
+    public required DateTime CreatedDateTime { get; init; }
+    public DateTime? ModifiedDateTime { get; init; }
+}
+```
+
+**ContributionDto.cs**
+```csharp
+namespace Koinon.Application.DTOs.Giving;
+
+public record ContributionDto
+{
+    public required string IdKey { get; init; }
+    public string? PersonIdKey { get; init; }
+    public string? PersonName { get; init; }
+    public string? BatchIdKey { get; init; }
+    public required DateTime TransactionDateTime { get; init; }
+    public string? TransactionCode { get; init; }
+    public required string TransactionTypeValueIdKey { get; init; }
+    public required string SourceTypeValueIdKey { get; init; }
+    public string? Summary { get; init; }
+    public string? CampusIdKey { get; init; }
+    public required List<ContributionDetailDto> Details { get; init; }
+    public required decimal TotalAmount { get; init; }
+}
+```
+
+**ContributionDetailDto.cs**
+```csharp
+namespace Koinon.Application.DTOs.Giving;
+
+public record ContributionDetailDto
+{
+    public required string IdKey { get; init; }
+    public required string FundIdKey { get; init; }
+    public required string FundName { get; init; }
+    public required decimal Amount { get; init; }
+    public string? Summary { get; init; }
+}
+```
+
+**BatchSummaryDto.cs**
+```csharp
+namespace Koinon.Application.DTOs.Giving;
+
+public record BatchSummaryDto
+{
+    public required string IdKey { get; init; }
+    public required string Name { get; init; }
+    public required string Status { get; init; }
+    public decimal? ControlAmount { get; init; }
+    public required decimal ActualAmount { get; init; }
+    public required int ContributionCount { get; init; }
+    public required decimal Variance { get; init; }
+    public required bool IsBalanced { get; init; }
+}
+```
+
+**PersonLookupDto.cs**
+```csharp
+namespace Koinon.Application.DTOs.Giving;
+
+public record PersonLookupDto
+{
+    public required string IdKey { get; init; }
+    public required string FullName { get; init; }
+    public string? Email { get; init; }
+}
+```
+
+**FundDto.cs**
+```csharp
+namespace Koinon.Application.DTOs.Giving;
+
+public record FundDto
+{
+    public required string IdKey { get; init; }
+    public required string Name { get; init; }
+    public string? PublicName { get; init; }
+    public required bool IsActive { get; init; }
+    public required bool IsPublic { get; init; }
+}
+```
+
+### 3. Interface (src/Koinon.Application/Interfaces/IBatchDonationEntryService.cs)
+
+```csharp
+using Koinon.Application.Common;
+using Koinon.Application.DTOs.Giving;
+using Koinon.Application.DTOs.Requests;
+
+namespace Koinon.Application.Interfaces;
+
+public interface IBatchDonationEntryService
+{
+    Task<Result<ContributionBatchDto>> CreateBatchAsync(CreateBatchRequest request, CancellationToken ct);
+    Task<Result<ContributionBatchDto>> GetBatchAsync(string batchIdKey, CancellationToken ct);
+    Task<Result<BatchSummaryDto>> GetBatchSummaryAsync(string batchIdKey, CancellationToken ct);
+    Task<Result> OpenBatchAsync(string batchIdKey, CancellationToken ct);
+    Task<Result> CloseBatchAsync(string batchIdKey, CancellationToken ct);
+    Task<Result<ContributionDto>> AddContributionAsync(string batchIdKey, AddContributionRequest request, CancellationToken ct);
+    Task<Result<ContributionDto>> UpdateContributionAsync(string contributionIdKey, UpdateContributionRequest request, CancellationToken ct);
+    Task<Result> DeleteContributionAsync(string contributionIdKey, CancellationToken ct);
+    Task<IReadOnlyList<PersonLookupDto>> SearchContributorsAsync(string searchTerm, CancellationToken ct);
+    Task<IReadOnlyList<FundDto>> GetActiveFundsAsync(CancellationToken ct);
+}
+```
+
+### 4. Service Implementation (src/Koinon.Application/Services/BatchDonationEntryService.cs)
+
+Use primary constructor pattern with these dependencies:
+- IApplicationDbContext context
+- IMapper mapper
+- IUserContext userContext
+- ILogger<BatchDonationEntryService> logger
+
+Business Rules:
+1. **Batch Status**: Open → Closed → Posted (no reopen, no edits after Closed)
+2. **CreateBatchAsync**: Creates batch in Open status
+3. **OpenBatchAsync**: No-op if already Open, error if Closed/Posted
+4. **CloseBatchAsync**: Can only close Open batches
+5. **AddContributionAsync**: Only allowed for Open batches
+6. **UpdateContributionAsync/DeleteContributionAsync**: Only allowed if parent batch is Open
+7. **Anonymous**: PersonIdKey = null → set PersonAliasId = null in Contribution
+8. **Identified**: PersonIdKey provided → look up primary PersonAlias.Id
+9. **SourceTypeValueId**: Query DefinedValue where DefinedType.Name = "Transaction Source" AND Value = "Manual Entry"
+10. **Audit**: Log all Create/Update/Delete to FinancialAuditLog
+
+Implementation:
+- Use IdKeyHelper.Decode(idKey) to get int ID
+- Use entity.IdKey to get IdKey string
+- Use Result<T>.Success() and Result<T>.Failure(Error)
+- Use Error.NotFound("Entity", idKey), Error.Validation("message"), Error.Conflict("message")
+- Include related entities with .Include() for navigation properties
+- Calculate TotalAmount = ContributionDetails.Sum(d => d.Amount)
+- For BatchSummaryDto: Variance = (ControlAmount ?? 0) - ActualAmount, IsBalanced = Variance == 0
+- SearchContributorsAsync: EF.Functions.ILike for case-insensitive search on FirstName, LastName, Email
+- GetActiveFundsAsync: Where IsActive = true, OrderBy Order then Name
+
+### 5. Validators (src/Koinon.Application/Validators/Giving/)
+
+Create directory and add:
+
+**CreateBatchRequestValidator.cs**
+```csharp
+using FluentValidation;
+using Koinon.Application.DTOs.Requests;
+
+namespace Koinon.Application.Validators.Giving;
+
+public class CreateBatchRequestValidator : AbstractValidator<CreateBatchRequest>
+{
+    public CreateBatchRequestValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.BatchDate).NotEmpty();
+        RuleFor(x => x.ControlAmount).GreaterThan(0).When(x => x.ControlAmount.HasValue);
+        RuleFor(x => x.ControlItemCount).GreaterThan(0).When(x => x.ControlItemCount.HasValue);
+    }
+}
+```
+
+**AddContributionRequestValidator.cs**
+```csharp
+using FluentValidation;
+using Koinon.Application.DTOs.Requests;
+
+namespace Koinon.Application.Validators.Giving;
+
+public class AddContributionRequestValidator : AbstractValidator<AddContributionRequest>
+{
+    public AddContributionRequestValidator()
+    {
+        RuleFor(x => x.TransactionDateTime).NotEmpty();
+        RuleFor(x => x.TransactionTypeValueIdKey).NotEmpty();
+        RuleFor(x => x.Details).NotEmpty().WithMessage("At least one contribution detail is required");
+        RuleForEach(x => x.Details).SetValidator(new ContributionDetailRequestValidator());
+    }
+}
+
+public class ContributionDetailRequestValidator : AbstractValidator<ContributionDetailRequest>
+{
+    public ContributionDetailRequestValidator()
+    {
+        RuleFor(x => x.FundIdKey).NotEmpty();
+        RuleFor(x => x.Amount).GreaterThan(0);
+    }
+}
+```
+
+**UpdateContributionRequestValidator.cs** (same as Add)
+
+### 6. AutoMapper Mappings
+
+Add to existing MappingProfile.cs in src/Koinon.Application/:
+
+```csharp
+// Giving DTOs
+CreateMap<ContributionBatch, ContributionBatchDto>()
+    .ForMember(d => d.Status, opt => opt.MapFrom(s => s.Status.ToString()));
+
+CreateMap<Contribution, ContributionDto>()
+    .ForMember(d => d.TotalAmount, opt => opt.MapFrom(s => s.ContributionDetails.Sum(cd => cd.Amount)))
+    .ForMember(d => d.PersonName, opt => opt.MapFrom(s => s.PersonAlias != null ? s.PersonAlias.Person.FullName : null));
+
+CreateMap<ContributionDetail, ContributionDetailDto>()
+    .ForMember(d => d.FundName, opt => opt.MapFrom(s => s.Fund!.Name));
+
+CreateMap<Fund, FundDto>();
+
+CreateMap<Person, PersonLookupDto>();
+```
+
+### 7. Register Service
+
+Add to DependencyInjection.cs in src/Koinon.Application/:
+
+```csharp
+services.AddScoped<IBatchDonationEntryService, BatchDonationEntryService>();
+```
+
+Add validators:
+```csharp
+services.AddScoped<IValidator<CreateBatchRequest>, CreateBatchRequestValidator>();
+services.AddScoped<IValidator<AddContributionRequest>, AddContributionRequestValidator>();
+services.AddScoped<IValidator<UpdateContributionRequest>, UpdateContributionRequestValidator>();
+```
+
+## Audit Logging Example
+
+```csharp
+private async Task LogAuditAsync(FinancialAuditAction action, string entityType, string entityIdKey, object? details = null)
+{
+    var auditLog = new FinancialAuditLog
+    {
+        PersonId = _userContext.PersonId,
+        ActionType = action,
+        EntityType = entityType,
+        EntityIdKey = entityIdKey,
+        IpAddress = _userContext.IpAddress,
+        UserAgent = _userContext.UserAgent,
+        Details = details != null ? JsonSerializer.Serialize(details) : null,
+        Timestamp = DateTime.UtcNow
+    };
+    context.FinancialAuditLogs.Add(auditLog);
+}
+```
+
+Call after each Create/Update/Delete operation before SaveChangesAsync().

--- a/src/Koinon.Application/DTOs/Giving/BatchSummaryDto.cs
+++ b/src/Koinon.Application/DTOs/Giving/BatchSummaryDto.cs
@@ -1,0 +1,57 @@
+namespace Koinon.Application.DTOs.Giving;
+
+/// <summary>
+/// DTO representing a batch summary with reconciliation status.
+/// </summary>
+public record BatchSummaryDto
+{
+    /// <summary>
+    /// URL-safe IdKey for the batch.
+    /// </summary>
+    public required string IdKey { get; init; }
+
+    /// <summary>
+    /// Name of the batch.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Current status of the batch (Open, Closed, Posted).
+    /// </summary>
+    public required string Status { get; init; }
+
+    /// <summary>
+    /// Expected total amount for reconciliation purposes.
+    /// </summary>
+    public decimal? ControlAmount { get; init; }
+
+    /// <summary>
+    /// Expected number of items for reconciliation purposes.
+    /// </summary>
+    public int? ControlItemCount { get; init; }
+
+    /// <summary>
+    /// Actual total amount from contributions.
+    /// </summary>
+    public required decimal ActualAmount { get; init; }
+
+    /// <summary>
+    /// Number of contributions in the batch.
+    /// </summary>
+    public required int ContributionCount { get; init; }
+
+    /// <summary>
+    /// Difference between control item count and actual contribution count.
+    /// </summary>
+    public int? ItemCountVariance { get; init; }
+
+    /// <summary>
+    /// Difference between control amount and actual amount.
+    /// </summary>
+    public required decimal Variance { get; init; }
+
+    /// <summary>
+    /// Whether the batch is balanced (variance is zero).
+    /// </summary>
+    public required bool IsBalanced { get; init; }
+}

--- a/src/Koinon.Application/DTOs/Giving/ContributionBatchDto.cs
+++ b/src/Koinon.Application/DTOs/Giving/ContributionBatchDto.cs
@@ -1,0 +1,57 @@
+namespace Koinon.Application.DTOs.Giving;
+
+/// <summary>
+/// DTO representing a contribution batch.
+/// </summary>
+public record ContributionBatchDto
+{
+    /// <summary>
+    /// URL-safe IdKey for the batch.
+    /// </summary>
+    public required string IdKey { get; init; }
+
+    /// <summary>
+    /// Name of the batch.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Date when the batch was created or intended for posting.
+    /// </summary>
+    public required DateTime BatchDate { get; init; }
+
+    /// <summary>
+    /// Current status of the batch (Open, Closed, Posted).
+    /// </summary>
+    public required string Status { get; init; }
+
+    /// <summary>
+    /// Expected total amount for reconciliation purposes.
+    /// </summary>
+    public decimal? ControlAmount { get; init; }
+
+    /// <summary>
+    /// Expected number of items for reconciliation purposes.
+    /// </summary>
+    public int? ControlItemCount { get; init; }
+
+    /// <summary>
+    /// Associated campus IdKey.
+    /// </summary>
+    public string? CampusIdKey { get; init; }
+
+    /// <summary>
+    /// Optional notes about the batch.
+    /// </summary>
+    public string? Note { get; init; }
+
+    /// <summary>
+    /// When the batch was created.
+    /// </summary>
+    public required DateTime CreatedDateTime { get; init; }
+
+    /// <summary>
+    /// When the batch was last modified.
+    /// </summary>
+    public DateTime? ModifiedDateTime { get; init; }
+}

--- a/src/Koinon.Application/DTOs/Giving/ContributionDetailDto.cs
+++ b/src/Koinon.Application/DTOs/Giving/ContributionDetailDto.cs
@@ -1,0 +1,32 @@
+namespace Koinon.Application.DTOs.Giving;
+
+/// <summary>
+/// DTO representing a line item allocation of a contribution to a specific fund.
+/// </summary>
+public record ContributionDetailDto
+{
+    /// <summary>
+    /// URL-safe IdKey for the contribution detail.
+    /// </summary>
+    public required string IdKey { get; init; }
+
+    /// <summary>
+    /// Fund IdKey for this allocation.
+    /// </summary>
+    public required string FundIdKey { get; init; }
+
+    /// <summary>
+    /// Fund name for display.
+    /// </summary>
+    public required string FundName { get; init; }
+
+    /// <summary>
+    /// Amount allocated to this fund.
+    /// </summary>
+    public required decimal Amount { get; init; }
+
+    /// <summary>
+    /// Optional notes for this line item.
+    /// </summary>
+    public string? Summary { get; init; }
+}

--- a/src/Koinon.Application/DTOs/Giving/ContributionDto.cs
+++ b/src/Koinon.Application/DTOs/Giving/ContributionDto.cs
@@ -1,0 +1,67 @@
+namespace Koinon.Application.DTOs.Giving;
+
+/// <summary>
+/// DTO representing a financial contribution/donation.
+/// </summary>
+public record ContributionDto
+{
+    /// <summary>
+    /// URL-safe IdKey for the contribution.
+    /// </summary>
+    public required string IdKey { get; init; }
+
+    /// <summary>
+    /// Donor's person IdKey (null for anonymous contributions).
+    /// </summary>
+    public string? PersonIdKey { get; init; }
+
+    /// <summary>
+    /// Donor's full name (null for anonymous contributions).
+    /// </summary>
+    public string? PersonName { get; init; }
+
+    /// <summary>
+    /// Associated batch IdKey.
+    /// </summary>
+    public string? BatchIdKey { get; init; }
+
+    /// <summary>
+    /// Date and time when the contribution occurred.
+    /// </summary>
+    public required DateTime TransactionDateTime { get; init; }
+
+    /// <summary>
+    /// Transaction reference (check number, confirmation code, etc.).
+    /// </summary>
+    public string? TransactionCode { get; init; }
+
+    /// <summary>
+    /// Transaction type IdKey (Cash, Check, Card, ACH).
+    /// </summary>
+    public required string TransactionTypeValueIdKey { get; init; }
+
+    /// <summary>
+    /// Source type IdKey (Website, Kiosk, Manual Entry).
+    /// </summary>
+    public required string SourceTypeValueIdKey { get; init; }
+
+    /// <summary>
+    /// Optional notes about the contribution.
+    /// </summary>
+    public string? Summary { get; init; }
+
+    /// <summary>
+    /// Associated campus IdKey.
+    /// </summary>
+    public string? CampusIdKey { get; init; }
+
+    /// <summary>
+    /// Line items splitting the contribution across funds.
+    /// </summary>
+    public required List<ContributionDetailDto> Details { get; init; }
+
+    /// <summary>
+    /// Total amount of the contribution (sum of all details).
+    /// </summary>
+    public required decimal TotalAmount { get; init; }
+}

--- a/src/Koinon.Application/DTOs/Giving/FundDto.cs
+++ b/src/Koinon.Application/DTOs/Giving/FundDto.cs
@@ -1,0 +1,32 @@
+namespace Koinon.Application.DTOs.Giving;
+
+/// <summary>
+/// DTO representing a fund for categorizing contributions.
+/// </summary>
+public record FundDto
+{
+    /// <summary>
+    /// URL-safe IdKey for the fund.
+    /// </summary>
+    public required string IdKey { get; init; }
+
+    /// <summary>
+    /// Internal name for the fund.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Public display name for givers (uses Name if null).
+    /// </summary>
+    public string? PublicName { get; init; }
+
+    /// <summary>
+    /// Whether the fund is available for contributions.
+    /// </summary>
+    public required bool IsActive { get; init; }
+
+    /// <summary>
+    /// Whether the fund is visible to online givers.
+    /// </summary>
+    public required bool IsPublic { get; init; }
+}

--- a/src/Koinon.Application/DTOs/Giving/PersonLookupDto.cs
+++ b/src/Koinon.Application/DTOs/Giving/PersonLookupDto.cs
@@ -1,0 +1,22 @@
+namespace Koinon.Application.DTOs.Giving;
+
+/// <summary>
+/// DTO for person lookup results in contribution entry.
+/// </summary>
+public record PersonLookupDto
+{
+    /// <summary>
+    /// URL-safe IdKey for the person.
+    /// </summary>
+    public required string IdKey { get; init; }
+
+    /// <summary>
+    /// Full name of the person.
+    /// </summary>
+    public required string FullName { get; init; }
+
+    /// <summary>
+    /// Email address (for display/verification).
+    /// </summary>
+    public string? Email { get; init; }
+}

--- a/src/Koinon.Application/DTOs/Requests/BatchDonationRequests.cs
+++ b/src/Koinon.Application/DTOs/Requests/BatchDonationRequests.cs
@@ -1,0 +1,130 @@
+namespace Koinon.Application.DTOs.Requests;
+
+/// <summary>
+/// Request to create a new contribution batch.
+/// </summary>
+public record CreateBatchRequest
+{
+    /// <summary>
+    /// Name of the batch.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Date when the batch was created or intended for posting.
+    /// </summary>
+    public required DateTime BatchDate { get; init; }
+
+    /// <summary>
+    /// Expected total amount for reconciliation purposes.
+    /// </summary>
+    public decimal? ControlAmount { get; init; }
+
+    /// <summary>
+    /// Expected number of items for reconciliation purposes.
+    /// </summary>
+    public int? ControlItemCount { get; init; }
+
+    /// <summary>
+    /// Associated campus IdKey.
+    /// </summary>
+    public string? CampusIdKey { get; init; }
+
+    /// <summary>
+    /// Optional notes about the batch.
+    /// </summary>
+    public string? Note { get; init; }
+}
+
+/// <summary>
+/// Request to add a contribution to a batch.
+/// </summary>
+public record AddContributionRequest
+{
+    /// <summary>
+    /// Donor's person IdKey (null for anonymous contributions).
+    /// </summary>
+    public string? PersonIdKey { get; init; }
+
+    /// <summary>
+    /// Date and time when the contribution occurred.
+    /// </summary>
+    public required DateTime TransactionDateTime { get; init; }
+
+    /// <summary>
+    /// Transaction reference (check number, confirmation code, etc.).
+    /// </summary>
+    public string? TransactionCode { get; init; }
+
+    /// <summary>
+    /// Transaction type IdKey (Cash, Check, Card, ACH).
+    /// </summary>
+    public required string TransactionTypeValueIdKey { get; init; }
+
+    /// <summary>
+    /// Line items splitting the contribution across funds.
+    /// </summary>
+    public required List<ContributionDetailRequest> Details { get; init; }
+
+    /// <summary>
+    /// Optional notes about the contribution.
+    /// </summary>
+    public string? Summary { get; init; }
+}
+
+/// <summary>
+/// Request for a contribution detail line item.
+/// </summary>
+public record ContributionDetailRequest
+{
+    /// <summary>
+    /// Fund IdKey for this allocation.
+    /// </summary>
+    public required string FundIdKey { get; init; }
+
+    /// <summary>
+    /// Amount allocated to this fund.
+    /// </summary>
+    public required decimal Amount { get; init; }
+
+    /// <summary>
+    /// Optional notes for this line item.
+    /// </summary>
+    public string? Summary { get; init; }
+}
+
+/// <summary>
+/// Request to update an existing contribution.
+/// </summary>
+public record UpdateContributionRequest
+{
+    /// <summary>
+    /// Donor's person IdKey (null for anonymous contributions).
+    /// </summary>
+    public string? PersonIdKey { get; init; }
+
+    /// <summary>
+    /// Date and time when the contribution occurred.
+    /// </summary>
+    public required DateTime TransactionDateTime { get; init; }
+
+    /// <summary>
+    /// Transaction reference (check number, confirmation code, etc.).
+    /// </summary>
+    public string? TransactionCode { get; init; }
+
+    /// <summary>
+    /// Transaction type IdKey (Cash, Check, Card, ACH).
+    /// </summary>
+    public required string TransactionTypeValueIdKey { get; init; }
+
+    /// <summary>
+    /// Line items splitting the contribution across funds.
+    /// </summary>
+    public required List<ContributionDetailRequest> Details { get; init; }
+
+    /// <summary>
+    /// Optional notes about the contribution.
+    /// </summary>
+    public string? Summary { get; init; }
+}

--- a/src/Koinon.Application/Interfaces/IApplicationDbContext.cs
+++ b/src/Koinon.Application/Interfaces/IApplicationDbContext.cs
@@ -45,6 +45,13 @@ public interface IApplicationDbContext
     DbSet<ImportTemplate> ImportTemplates { get; }
     DbSet<ImportJob> ImportJobs { get; }
 
+    // Giving/Financial
+    DbSet<Fund> Funds { get; }
+    DbSet<ContributionBatch> ContributionBatches { get; }
+    DbSet<Contribution> Contributions { get; }
+    DbSet<ContributionDetail> ContributionDetails { get; }
+    DbSet<FinancialAuditLog> FinancialAuditLogs { get; }
+
     DatabaseFacade Database { get; }
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
     EntityEntry<TEntity> Entry<TEntity>(TEntity entity) where TEntity : class;

--- a/src/Koinon.Application/Interfaces/IBatchDonationEntryService.cs
+++ b/src/Koinon.Application/Interfaces/IBatchDonationEntryService.cs
@@ -1,0 +1,92 @@
+using Koinon.Application.Common;
+using Koinon.Application.DTOs.Giving;
+using Koinon.Application.DTOs.Requests;
+
+namespace Koinon.Application.Interfaces;
+
+/// <summary>
+/// Service for manual contribution entry with batch reconciliation.
+/// </summary>
+public interface IBatchDonationEntryService
+{
+    /// <summary>
+    /// Creates a new contribution batch.
+    /// </summary>
+    /// <param name="request">The batch creation request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The created batch.</returns>
+    Task<Result<ContributionBatchDto>> CreateBatchAsync(CreateBatchRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a batch by its IdKey.
+    /// </summary>
+    /// <param name="batchIdKey">The batch IdKey.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The batch if found.</returns>
+    Task<Result<ContributionBatchDto>> GetBatchAsync(string batchIdKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a batch summary with reconciliation status.
+    /// </summary>
+    /// <param name="batchIdKey">The batch IdKey.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The batch summary with variance calculation.</returns>
+    Task<Result<BatchSummaryDto>> GetBatchSummaryAsync(string batchIdKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Opens a batch for editing (no-op if already open, error if closed/posted).
+    /// </summary>
+    /// <param name="batchIdKey">The batch IdKey.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result indicating success or failure.</returns>
+    Task<Result> OpenBatchAsync(string batchIdKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Closes a batch (can only close open batches).
+    /// </summary>
+    /// <param name="batchIdKey">The batch IdKey.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result indicating success or failure.</returns>
+    Task<Result> CloseBatchAsync(string batchIdKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Adds a contribution to a batch (only allowed for open batches).
+    /// </summary>
+    /// <param name="batchIdKey">The batch IdKey.</param>
+    /// <param name="request">The contribution request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The created contribution.</returns>
+    Task<Result<ContributionDto>> AddContributionAsync(string batchIdKey, AddContributionRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates an existing contribution (only allowed if parent batch is open).
+    /// </summary>
+    /// <param name="contributionIdKey">The contribution IdKey.</param>
+    /// <param name="request">The update request.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The updated contribution.</returns>
+    Task<Result<ContributionDto>> UpdateContributionAsync(string contributionIdKey, UpdateContributionRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes a contribution (only allowed if parent batch is open).
+    /// </summary>
+    /// <param name="contributionIdKey">The contribution IdKey.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Result indicating success or failure.</returns>
+    Task<Result> DeleteContributionAsync(string contributionIdKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Searches for contributors by name or email.
+    /// </summary>
+    /// <param name="searchTerm">The search term.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>Matching people for lookup.</returns>
+    Task<IReadOnlyList<PersonLookupDto>> SearchContributorsAsync(string searchTerm, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets all active funds for contribution entry.
+    /// </summary>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>List of active funds.</returns>
+    Task<IReadOnlyList<FundDto>> GetActiveFundsAsync(CancellationToken ct = default);
+}

--- a/src/Koinon.Application/Services/BatchDonationEntryService.cs
+++ b/src/Koinon.Application/Services/BatchDonationEntryService.cs
@@ -1,0 +1,747 @@
+using System.Text.Json;
+using FluentValidation;
+using Koinon.Application.Common;
+using Koinon.Application.DTOs.Giving;
+using Koinon.Application.DTOs.Requests;
+using Koinon.Application.Interfaces;
+using Koinon.Domain.Data;
+using Koinon.Domain.Entities;
+using Koinon.Domain.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Koinon.Application.Services;
+
+/// <summary>
+/// Service for manual contribution entry with batch reconciliation.
+/// </summary>
+public class BatchDonationEntryService(
+    IApplicationDbContext context,
+    IUserContext userContext,
+    IValidator<CreateBatchRequest> createBatchValidator,
+    IValidator<AddContributionRequest> addContributionValidator,
+    IValidator<UpdateContributionRequest> updateContributionValidator,
+    ILogger<BatchDonationEntryService> logger) : IBatchDonationEntryService
+{
+    private const string ManualEntrySourceName = "Manual Entry";
+    private const string TransactionSourceTypeName = "Transaction Source";
+
+    public async Task<Result<ContributionBatchDto>> CreateBatchAsync(
+        CreateBatchRequest request,
+        CancellationToken ct = default)
+    {
+        // Validate
+        var validation = await createBatchValidator.ValidateAsync(request, ct);
+        if (!validation.IsValid)
+        {
+            return Result<ContributionBatchDto>.Failure(Error.FromFluentValidation(validation));
+        }
+
+        // Decode campus if provided
+        int? campusId = null;
+        if (!string.IsNullOrWhiteSpace(request.CampusIdKey))
+        {
+            if (!IdKeyHelper.TryDecode(request.CampusIdKey, out int decodedCampusId))
+            {
+                return Result<ContributionBatchDto>.Failure(
+                    Error.NotFound("Campus", request.CampusIdKey));
+            }
+
+            var campusExists = await context.Campuses.AnyAsync(c => c.Id == decodedCampusId, ct);
+            if (!campusExists)
+            {
+                return Result<ContributionBatchDto>.Failure(
+                    Error.NotFound("Campus", request.CampusIdKey));
+            }
+
+            campusId = decodedCampusId;
+        }
+
+        // Verify authentication before any database changes
+        EnsureAuthenticated();
+
+        // Create batch
+        var batch = new ContributionBatch
+        {
+            Name = request.Name,
+            BatchDate = request.BatchDate,
+            Status = BatchStatus.Open,
+            ControlAmount = request.ControlAmount,
+            ControlItemCount = request.ControlItemCount,
+            CampusId = campusId,
+            Note = request.Note,
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        await context.ContributionBatches.AddAsync(batch, ct);
+        await context.SaveChangesAsync(ct);
+
+        await LogAuditAsync(FinancialAuditAction.Create, "ContributionBatch", batch.IdKey, new { request.Name }, ct);
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation("Created contribution batch {BatchId}: {Name}", batch.Id, batch.Name);
+
+        return Result<ContributionBatchDto>.Success(MapToBatchDto(batch));
+    }
+
+    public async Task<Result<ContributionBatchDto>> GetBatchAsync(
+        string batchIdKey,
+        CancellationToken ct = default)
+    {
+        if (!IdKeyHelper.TryDecode(batchIdKey, out int batchId))
+        {
+            return Result<ContributionBatchDto>.Failure(Error.NotFound("ContributionBatch", batchIdKey));
+        }
+
+        var batch = await context.ContributionBatches
+            .AsNoTracking()
+            .Include(b => b.Campus)
+            .FirstOrDefaultAsync(b => b.Id == batchId, ct);
+
+        if (batch is null)
+        {
+            return Result<ContributionBatchDto>.Failure(Error.NotFound("ContributionBatch", batchIdKey));
+        }
+
+        return Result<ContributionBatchDto>.Success(MapToBatchDto(batch));
+    }
+
+    public async Task<Result<BatchSummaryDto>> GetBatchSummaryAsync(
+        string batchIdKey,
+        CancellationToken ct = default)
+    {
+        if (!IdKeyHelper.TryDecode(batchIdKey, out int batchId))
+        {
+            return Result<BatchSummaryDto>.Failure(Error.NotFound("ContributionBatch", batchIdKey));
+        }
+
+        var batch = await context.ContributionBatches
+            .AsNoTracking()
+            .Include(b => b.Contributions)
+                .ThenInclude(c => c.ContributionDetails)
+            .FirstOrDefaultAsync(b => b.Id == batchId, ct);
+
+        if (batch is null)
+        {
+            return Result<BatchSummaryDto>.Failure(Error.NotFound("ContributionBatch", batchIdKey));
+        }
+
+        var actualAmount = batch.Contributions
+            .SelectMany(c => c.ContributionDetails)
+            .Sum(cd => cd.Amount);
+
+        var contributionCount = batch.Contributions.Count;
+        var variance = (batch.ControlAmount ?? 0) - actualAmount;
+        var itemCountVariance = batch.ControlItemCount.HasValue
+            ? batch.ControlItemCount.Value - contributionCount
+            : (int?)null;
+
+        var summary = new BatchSummaryDto
+        {
+            IdKey = batch.IdKey,
+            Name = batch.Name,
+            Status = batch.Status.ToString(),
+            ControlAmount = batch.ControlAmount,
+            ControlItemCount = batch.ControlItemCount,
+            ActualAmount = actualAmount,
+            ContributionCount = contributionCount,
+            ItemCountVariance = itemCountVariance,
+            Variance = variance,
+            IsBalanced = variance == 0 && (itemCountVariance is null || itemCountVariance == 0)
+        };
+
+        return Result<BatchSummaryDto>.Success(summary);
+    }
+
+    public async Task<Result> OpenBatchAsync(string batchIdKey, CancellationToken ct = default)
+    {
+        if (!IdKeyHelper.TryDecode(batchIdKey, out int batchId))
+        {
+            return Result.Failure(Error.NotFound("ContributionBatch", batchIdKey));
+        }
+
+        var batch = await context.ContributionBatches.FindAsync(new object[] { batchId }, ct);
+        if (batch is null)
+        {
+            return Result.Failure(Error.NotFound("ContributionBatch", batchIdKey));
+        }
+
+        // No-op if already open
+        if (batch.Status == BatchStatus.Open)
+        {
+            return Result.Success();
+        }
+
+        // Cannot reopen closed or posted batches
+        if (batch.Status == BatchStatus.Closed || batch.Status == BatchStatus.Posted)
+        {
+            return Result.Failure(Error.UnprocessableEntity(
+                $"Cannot open a batch that is {batch.Status}. Closed and Posted batches cannot be reopened."));
+        }
+
+        // Verify authentication before any database changes
+        EnsureAuthenticated();
+
+        var previousStatus = batch.Status;
+        batch.Status = BatchStatus.Open;
+        batch.ModifiedDateTime = DateTime.UtcNow;
+
+        await LogAuditAsync(FinancialAuditAction.Update, "ContributionBatch", batch.IdKey,
+            new { Action = "Open", PreviousStatus = previousStatus.ToString(), NewStatus = "Open" }, ct);
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation("Opened contribution batch {BatchId}: {Name}", batch.Id, batch.Name);
+
+        return Result.Success();
+    }
+
+    public async Task<Result> CloseBatchAsync(string batchIdKey, CancellationToken ct = default)
+    {
+        if (!IdKeyHelper.TryDecode(batchIdKey, out int batchId))
+        {
+            return Result.Failure(Error.NotFound("ContributionBatch", batchIdKey));
+        }
+
+        var batch = await context.ContributionBatches.FindAsync(new object[] { batchId }, ct);
+        if (batch is null)
+        {
+            return Result.Failure(Error.NotFound("ContributionBatch", batchIdKey));
+        }
+
+        // Can only close open batches
+        if (batch.Status != BatchStatus.Open)
+        {
+            return Result.Failure(Error.UnprocessableEntity(
+                $"Can only close Open batches. Current status: {batch.Status}"));
+        }
+
+        // Verify authentication before any database changes
+        EnsureAuthenticated();
+
+        batch.Status = BatchStatus.Closed;
+        batch.ModifiedDateTime = DateTime.UtcNow;
+
+        await LogAuditAsync(FinancialAuditAction.Update, "ContributionBatch", batch.IdKey,
+            new { Action = "Close", PreviousStatus = "Open", NewStatus = "Closed" }, ct);
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation("Closed contribution batch {BatchId}: {Name}", batch.Id, batch.Name);
+
+        return Result.Success();
+    }
+
+    public async Task<Result<ContributionDto>> AddContributionAsync(
+        string batchIdKey,
+        AddContributionRequest request,
+        CancellationToken ct = default)
+    {
+        // Validate
+        var validation = await addContributionValidator.ValidateAsync(request, ct);
+        if (!validation.IsValid)
+        {
+            return Result<ContributionDto>.Failure(Error.FromFluentValidation(validation));
+        }
+
+        // Get batch
+        if (!IdKeyHelper.TryDecode(batchIdKey, out int batchId))
+        {
+            return Result<ContributionDto>.Failure(Error.NotFound("ContributionBatch", batchIdKey));
+        }
+
+        var batch = await context.ContributionBatches
+            .FirstOrDefaultAsync(b => b.Id == batchId, ct);
+
+        if (batch is null)
+        {
+            return Result<ContributionDto>.Failure(Error.NotFound("ContributionBatch", batchIdKey));
+        }
+
+        // Only allow adding to open batches
+        if (batch.Status != BatchStatus.Open)
+        {
+            return Result<ContributionDto>.Failure(Error.UnprocessableEntity(
+                $"Can only add contributions to Open batches. Current status: {batch.Status}"));
+        }
+
+        // Verify authentication before any database changes
+        EnsureAuthenticated();
+
+        // Resolve person if provided
+        int? personAliasId = null;
+        if (!string.IsNullOrWhiteSpace(request.PersonIdKey))
+        {
+            if (!IdKeyHelper.TryDecode(request.PersonIdKey, out int personId))
+            {
+                return Result<ContributionDto>.Failure(Error.NotFound("Person", request.PersonIdKey));
+            }
+
+            // Get primary PersonAlias for this person
+            var personAlias = await context.PersonAliases
+                .FirstOrDefaultAsync(pa => pa.PersonId == personId, ct);
+
+            if (personAlias is null)
+            {
+                return Result<ContributionDto>.Failure(Error.NotFound("Person", request.PersonIdKey));
+            }
+
+            personAliasId = personAlias.Id;
+        }
+
+        // Resolve transaction type
+        if (!IdKeyHelper.TryDecode(request.TransactionTypeValueIdKey, out int transactionTypeValueId))
+        {
+            return Result<ContributionDto>.Failure(
+                Error.NotFound("TransactionType", request.TransactionTypeValueIdKey));
+        }
+
+        var transactionTypeExists = await context.DefinedValues.AnyAsync(dv => dv.Id == transactionTypeValueId, ct);
+        if (!transactionTypeExists)
+        {
+            return Result<ContributionDto>.Failure(
+                Error.NotFound("TransactionType", request.TransactionTypeValueIdKey));
+        }
+
+        // Get "Manual Entry" source type
+        var sourceTypeValue = await context.DefinedValues
+            .Include(dv => dv.DefinedType)
+            .FirstOrDefaultAsync(dv =>
+                dv.DefinedType != null &&
+                dv.DefinedType.Name == TransactionSourceTypeName &&
+                dv.Value == ManualEntrySourceName, ct);
+
+        if (sourceTypeValue is null)
+        {
+            return Result<ContributionDto>.Failure(Error.UnprocessableEntity(
+                $"'{ManualEntrySourceName}' source type not found. Please ensure the '{TransactionSourceTypeName}' defined type has a '{ManualEntrySourceName}' value."));
+        }
+
+        // Validate and resolve funds - batch load to avoid N+1
+        var fundIdKeys = request.Details.Select(d => d.FundIdKey).ToList();
+        var fundIdList = new List<int>();
+        foreach (var fundIdKey in fundIdKeys)
+        {
+            if (!IdKeyHelper.TryDecode(fundIdKey, out int fundId))
+            {
+                return Result<ContributionDto>.Failure(Error.NotFound("Fund", fundIdKey));
+            }
+            fundIdList.Add(fundId);
+        }
+
+        var funds = await context.Funds
+            .Where(f => fundIdList.Contains(f.Id))
+            .ToDictionaryAsync(f => f.Id, ct);
+
+        var contributionDetails = new List<ContributionDetail>();
+        foreach (var detail in request.Details)
+        {
+            var fundId = IdKeyHelper.Decode(detail.FundIdKey);
+
+            if (!funds.TryGetValue(fundId, out var fund))
+            {
+                return Result<ContributionDto>.Failure(Error.NotFound("Fund", detail.FundIdKey));
+            }
+
+            if (!fund.IsActive)
+            {
+                return Result<ContributionDto>.Failure(Error.UnprocessableEntity(
+                    $"Fund '{fund.Name}' is not active and cannot receive contributions."));
+            }
+
+            contributionDetails.Add(new ContributionDetail
+            {
+                ContributionId = 0, // Will be set after contribution is saved
+                FundId = fundId,
+                Amount = detail.Amount,
+                Summary = detail.Summary,
+                CreatedDateTime = DateTime.UtcNow
+            });
+        }
+
+        // Create contribution
+        var contribution = new Contribution
+        {
+            PersonAliasId = personAliasId,
+            BatchId = batchId,
+            TransactionDateTime = request.TransactionDateTime,
+            TransactionCode = request.TransactionCode,
+            TransactionTypeValueId = transactionTypeValueId,
+            SourceTypeValueId = sourceTypeValue.Id,
+            Summary = request.Summary,
+            CampusId = batch.CampusId,
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        await context.Contributions.AddAsync(contribution, ct);
+        await context.SaveChangesAsync(ct);
+
+        // Add details with contribution ID
+        foreach (var detail in contributionDetails)
+        {
+            detail.ContributionId = contribution.Id;
+        }
+
+        await context.ContributionDetails.AddRangeAsync(contributionDetails, ct);
+        await LogAuditAsync(FinancialAuditAction.Create, "Contribution", contribution.IdKey,
+            new { BatchIdKey = batchIdKey, TotalAmount = contributionDetails.Sum(d => d.Amount) }, ct);
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation("Added contribution {ContributionId} to batch {BatchId}",
+            contribution.Id, batchId);
+
+        // Fetch with includes for DTO mapping
+        var createdContribution = await context.Contributions
+            .AsNoTracking()
+            .Include(c => c.PersonAlias)
+                .ThenInclude(pa => pa != null ? pa.Person : null)
+            .Include(c => c.ContributionDetails)
+                .ThenInclude(cd => cd.Fund)
+            .FirstOrDefaultAsync(c => c.Id == contribution.Id, ct);
+
+        if (createdContribution is null)
+        {
+            logger.LogError("Contribution {ContributionId} not found after creation", contribution.Id);
+            return Result<ContributionDto>.Failure(Error.UnprocessableEntity("Contribution created but could not be retrieved"));
+        }
+
+        return Result<ContributionDto>.Success(MapToContributionDto(createdContribution));
+    }
+
+    public async Task<Result<ContributionDto>> UpdateContributionAsync(
+        string contributionIdKey,
+        UpdateContributionRequest request,
+        CancellationToken ct = default)
+    {
+        // Validate
+        var validation = await updateContributionValidator.ValidateAsync(request, ct);
+        if (!validation.IsValid)
+        {
+            return Result<ContributionDto>.Failure(Error.FromFluentValidation(validation));
+        }
+
+        // Get contribution with batch
+        if (!IdKeyHelper.TryDecode(contributionIdKey, out int contributionId))
+        {
+            return Result<ContributionDto>.Failure(Error.NotFound("Contribution", contributionIdKey));
+        }
+
+        var contribution = await context.Contributions
+            .Include(c => c.Batch)
+            .Include(c => c.ContributionDetails)
+            .FirstOrDefaultAsync(c => c.Id == contributionId, ct);
+
+        if (contribution is null)
+        {
+            return Result<ContributionDto>.Failure(Error.NotFound("Contribution", contributionIdKey));
+        }
+
+        // Only allow updating if parent batch is open
+        if (contribution.Batch?.Status != BatchStatus.Open)
+        {
+            return Result<ContributionDto>.Failure(Error.UnprocessableEntity(
+                $"Can only update contributions in Open batches. Batch status: {contribution.Batch?.Status}"));
+        }
+
+        // Verify authentication before any database changes
+        EnsureAuthenticated();
+
+        // Resolve person if provided
+        int? personAliasId = null;
+        if (!string.IsNullOrWhiteSpace(request.PersonIdKey))
+        {
+            if (!IdKeyHelper.TryDecode(request.PersonIdKey, out int personId))
+            {
+                return Result<ContributionDto>.Failure(Error.NotFound("Person", request.PersonIdKey));
+            }
+
+            var personAlias = await context.PersonAliases
+                .FirstOrDefaultAsync(pa => pa.PersonId == personId, ct);
+
+            if (personAlias is null)
+            {
+                return Result<ContributionDto>.Failure(Error.NotFound("Person", request.PersonIdKey));
+            }
+
+            personAliasId = personAlias.Id;
+        }
+
+        // Resolve transaction type
+        if (!IdKeyHelper.TryDecode(request.TransactionTypeValueIdKey, out int transactionTypeValueId))
+        {
+            return Result<ContributionDto>.Failure(
+                Error.NotFound("TransactionType", request.TransactionTypeValueIdKey));
+        }
+
+        var transactionTypeExists = await context.DefinedValues.AnyAsync(dv => dv.Id == transactionTypeValueId, ct);
+        if (!transactionTypeExists)
+        {
+            return Result<ContributionDto>.Failure(
+                Error.NotFound("TransactionType", request.TransactionTypeValueIdKey));
+        }
+
+        // Validate and resolve funds - batch load to avoid N+1
+        var updateFundIdKeys = request.Details.Select(d => d.FundIdKey).ToList();
+        var updateFundIdList = new List<int>();
+        foreach (var fundIdKey in updateFundIdKeys)
+        {
+            if (!IdKeyHelper.TryDecode(fundIdKey, out int fundId))
+            {
+                return Result<ContributionDto>.Failure(Error.NotFound("Fund", fundIdKey));
+            }
+            updateFundIdList.Add(fundId);
+        }
+
+        var updateFunds = await context.Funds
+            .Where(f => updateFundIdList.Contains(f.Id))
+            .ToDictionaryAsync(f => f.Id, ct);
+
+        var newDetails = new List<ContributionDetail>();
+        foreach (var detail in request.Details)
+        {
+            var fundId = IdKeyHelper.Decode(detail.FundIdKey);
+
+            if (!updateFunds.TryGetValue(fundId, out var fund))
+            {
+                return Result<ContributionDto>.Failure(Error.NotFound("Fund", detail.FundIdKey));
+            }
+
+            if (!fund.IsActive)
+            {
+                return Result<ContributionDto>.Failure(Error.UnprocessableEntity(
+                    $"Fund '{fund.Name}' is not active and cannot receive contributions."));
+            }
+
+            newDetails.Add(new ContributionDetail
+            {
+                ContributionId = contribution.Id,
+                FundId = fundId,
+                Amount = detail.Amount,
+                Summary = detail.Summary,
+                CreatedDateTime = DateTime.UtcNow
+            });
+        }
+
+        // Track old values for audit
+        var oldAmount = contribution.ContributionDetails.Sum(d => d.Amount);
+
+        // Remove old details
+        context.ContributionDetails.RemoveRange(contribution.ContributionDetails);
+
+        // Update contribution
+        contribution.PersonAliasId = personAliasId;
+        contribution.TransactionDateTime = request.TransactionDateTime;
+        contribution.TransactionCode = request.TransactionCode;
+        contribution.TransactionTypeValueId = transactionTypeValueId;
+        contribution.Summary = request.Summary;
+        contribution.ModifiedDateTime = DateTime.UtcNow;
+
+        // Add new details
+        await context.ContributionDetails.AddRangeAsync(newDetails, ct);
+
+        var newAmount = newDetails.Sum(d => d.Amount);
+        await LogAuditAsync(FinancialAuditAction.Update, "Contribution", contribution.IdKey,
+            new { OldAmount = oldAmount, NewAmount = newAmount }, ct);
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation("Updated contribution {ContributionId}", contribution.Id);
+
+        // Fetch with includes for DTO mapping
+        var updatedContribution = await context.Contributions
+            .AsNoTracking()
+            .Include(c => c.PersonAlias)
+                .ThenInclude(pa => pa != null ? pa.Person : null)
+            .Include(c => c.ContributionDetails)
+                .ThenInclude(cd => cd.Fund)
+            .FirstOrDefaultAsync(c => c.Id == contribution.Id, ct);
+
+        if (updatedContribution is null)
+        {
+            logger.LogError("Contribution {ContributionId} not found after update", contribution.Id);
+            return Result<ContributionDto>.Failure(Error.UnprocessableEntity("Contribution updated but could not be retrieved"));
+        }
+
+        return Result<ContributionDto>.Success(MapToContributionDto(updatedContribution));
+    }
+
+    public async Task<Result> DeleteContributionAsync(string contributionIdKey, CancellationToken ct = default)
+    {
+        if (!IdKeyHelper.TryDecode(contributionIdKey, out int contributionId))
+        {
+            return Result.Failure(Error.NotFound("Contribution", contributionIdKey));
+        }
+
+        var contribution = await context.Contributions
+            .Include(c => c.Batch)
+            .Include(c => c.ContributionDetails)
+            .FirstOrDefaultAsync(c => c.Id == contributionId, ct);
+
+        if (contribution is null)
+        {
+            return Result.Failure(Error.NotFound("Contribution", contributionIdKey));
+        }
+
+        // Only allow deleting if parent batch is open
+        if (contribution.Batch?.Status != BatchStatus.Open)
+        {
+            return Result.Failure(Error.UnprocessableEntity(
+                $"Can only delete contributions from Open batches. Batch status: {contribution.Batch?.Status}"));
+        }
+
+        // Verify authentication before any database changes
+        EnsureAuthenticated();
+
+        var amount = contribution.ContributionDetails.Sum(d => d.Amount);
+
+        // Remove details first, then contribution
+        context.ContributionDetails.RemoveRange(contribution.ContributionDetails);
+        context.Contributions.Remove(contribution);
+
+        await LogAuditAsync(FinancialAuditAction.Delete, "Contribution", contributionIdKey,
+            new { Amount = amount, BatchId = contribution.BatchId }, ct);
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation("Deleted contribution {ContributionId}", contributionId);
+
+        return Result.Success();
+    }
+
+    public async Task<IReadOnlyList<PersonLookupDto>> SearchContributorsAsync(
+        string searchTerm,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(searchTerm) || searchTerm.Length < 2)
+        {
+            return Array.Empty<PersonLookupDto>();
+        }
+
+        var searchLower = searchTerm.ToLower();
+
+        var people = await context.People
+            .AsNoTracking()
+            .Where(p =>
+                p.FirstName.ToLower().Contains(searchLower) ||
+                p.LastName.ToLower().Contains(searchLower) ||
+                (p.Email != null && p.Email.ToLower().Contains(searchLower)))
+            .OrderBy(p => p.LastName)
+            .ThenBy(p => p.FirstName)
+            .Take(20)
+            .ToListAsync(ct);
+
+        return people.Select(p => new PersonLookupDto
+        {
+            IdKey = p.IdKey,
+            FullName = p.FullName,
+            Email = p.Email
+        }).ToList();
+    }
+
+    public async Task<IReadOnlyList<FundDto>> GetActiveFundsAsync(CancellationToken ct = default)
+    {
+        var funds = await context.Funds
+            .AsNoTracking()
+            .Where(f => f.IsActive)
+            .OrderBy(f => f.Order)
+            .ThenBy(f => f.Name)
+            .Select(f => new FundDto
+            {
+                IdKey = f.IdKey,
+                Name = f.Name,
+                PublicName = f.PublicName,
+                IsActive = f.IsActive,
+                IsPublic = f.IsPublic
+            })
+            .ToListAsync(ct);
+
+        return funds;
+    }
+
+    private ContributionBatchDto MapToBatchDto(ContributionBatch batch)
+    {
+        return new ContributionBatchDto
+        {
+            IdKey = batch.IdKey,
+            Name = batch.Name,
+            BatchDate = batch.BatchDate,
+            Status = batch.Status.ToString(),
+            ControlAmount = batch.ControlAmount,
+            ControlItemCount = batch.ControlItemCount,
+            CampusIdKey = batch.Campus?.IdKey,
+            Note = batch.Note,
+            CreatedDateTime = batch.CreatedDateTime,
+            ModifiedDateTime = batch.ModifiedDateTime
+        };
+    }
+
+    private ContributionDto MapToContributionDto(Contribution contribution)
+    {
+        return new ContributionDto
+        {
+            IdKey = contribution.IdKey,
+            PersonIdKey = contribution.PersonAlias?.Person?.IdKey,
+            PersonName = contribution.PersonAlias?.Person?.FullName,
+            BatchIdKey = contribution.Batch?.IdKey,
+            TransactionDateTime = contribution.TransactionDateTime,
+            TransactionCode = contribution.TransactionCode,
+            TransactionTypeValueIdKey = IdKeyHelper.Encode(contribution.TransactionTypeValueId),
+            SourceTypeValueIdKey = IdKeyHelper.Encode(contribution.SourceTypeValueId),
+            Summary = contribution.Summary,
+            CampusIdKey = contribution.Campus?.IdKey,
+            Details = contribution.ContributionDetails
+                .Where(cd => cd.Fund != null)
+                .Select(cd => new ContributionDetailDto
+                {
+                    IdKey = cd.IdKey,
+                    FundIdKey = cd.Fund!.IdKey,
+                    FundName = cd.Fund.Name,
+                    Amount = cd.Amount,
+                    Summary = cd.Summary
+                }).ToList(),
+            TotalAmount = contribution.ContributionDetails.Sum(cd => cd.Amount)
+        };
+    }
+
+    /// <summary>
+    /// Ensures user is authenticated before any financial operation.
+    /// Must be called at the START of any mutation method, BEFORE any database changes.
+    /// </summary>
+    private void EnsureAuthenticated()
+    {
+        if (!userContext.IsAuthenticated || !userContext.CurrentPersonId.HasValue)
+        {
+            logger.LogWarning("Unauthenticated user attempted financial operation");
+            throw new UnauthorizedAccessException(
+                "Financial operations require authentication. Please log in to continue.");
+        }
+    }
+
+    private async Task LogAuditAsync(
+        FinancialAuditAction action,
+        string entityType,
+        string entityIdKey,
+        object? details = null,
+        CancellationToken ct = default)
+    {
+        // This should never happen if EnsureAuthenticated was called first
+        if (!userContext.CurrentPersonId.HasValue)
+        {
+            logger.LogError(
+                "Financial audit failed - no authenticated user for {Action} on {EntityType}/{EntityIdKey}",
+                action, entityType, entityIdKey);
+            throw new UnauthorizedAccessException(
+                $"Financial operations require authentication. Cannot perform {action} on {entityType}/{entityIdKey} without authenticated user.");
+        }
+
+        var auditLog = new FinancialAuditLog
+        {
+            PersonId = userContext.CurrentPersonId.Value,
+            ActionType = action,
+            EntityType = entityType,
+            EntityIdKey = entityIdKey,
+            IpAddress = null, // TODO(#260): Inject IHttpContextAccessor for forensic data
+            UserAgent = null, // TODO(#260): Inject IHttpContextAccessor for forensic data
+            Details = details != null ? JsonSerializer.Serialize(details) : null,
+            Timestamp = DateTime.UtcNow
+        };
+
+        await context.FinancialAuditLogs.AddAsync(auditLog, ct);
+    }
+}

--- a/src/Koinon.Application/Validators/Giving/AddContributionRequestValidator.cs
+++ b/src/Koinon.Application/Validators/Giving/AddContributionRequestValidator.cs
@@ -1,0 +1,79 @@
+using FluentValidation;
+using Koinon.Application.DTOs.Requests;
+using Koinon.Domain.Data;
+
+namespace Koinon.Application.Validators.Giving;
+
+/// <summary>
+/// Validator for AddContributionRequest.
+/// </summary>
+public class AddContributionRequestValidator : AbstractValidator<AddContributionRequest>
+{
+    public AddContributionRequestValidator()
+    {
+        RuleFor(x => x.TransactionDateTime)
+            .NotEmpty().WithMessage("Transaction date/time is required");
+
+        RuleFor(x => x.TransactionTypeValueIdKey)
+            .NotEmpty().WithMessage("Transaction type is required")
+            .Must(BeValidIdKey).WithMessage("Transaction type must be a valid IdKey format");
+
+        RuleFor(x => x.Details)
+            .NotEmpty().WithMessage("At least one contribution detail is required");
+
+        RuleForEach(x => x.Details)
+            .SetValidator(new ContributionDetailRequestValidator());
+
+        RuleFor(x => x.PersonIdKey)
+            .Must(BeValidIdKey).WithMessage("Person ID must be a valid IdKey format")
+            .When(x => !string.IsNullOrWhiteSpace(x.PersonIdKey));
+
+        RuleFor(x => x.TransactionCode)
+            .MaximumLength(50).WithMessage("Transaction code cannot exceed 50 characters")
+            .When(x => !string.IsNullOrEmpty(x.TransactionCode));
+
+        RuleFor(x => x.Summary)
+            .MaximumLength(500).WithMessage("Summary cannot exceed 500 characters")
+            .When(x => !string.IsNullOrEmpty(x.Summary));
+    }
+
+    private static bool BeValidIdKey(string? idKey)
+    {
+        if (string.IsNullOrWhiteSpace(idKey))
+        {
+            return false;
+        }
+
+        return IdKeyHelper.TryDecode(idKey, out _);
+    }
+}
+
+/// <summary>
+/// Validator for ContributionDetailRequest.
+/// </summary>
+public class ContributionDetailRequestValidator : AbstractValidator<ContributionDetailRequest>
+{
+    public ContributionDetailRequestValidator()
+    {
+        RuleFor(x => x.FundIdKey)
+            .NotEmpty().WithMessage("Fund is required")
+            .Must(BeValidIdKey).WithMessage("Fund ID must be a valid IdKey format");
+
+        RuleFor(x => x.Amount)
+            .GreaterThan(0).WithMessage("Amount must be greater than 0");
+
+        RuleFor(x => x.Summary)
+            .MaximumLength(500).WithMessage("Summary cannot exceed 500 characters")
+            .When(x => !string.IsNullOrEmpty(x.Summary));
+    }
+
+    private static bool BeValidIdKey(string? idKey)
+    {
+        if (string.IsNullOrWhiteSpace(idKey))
+        {
+            return false;
+        }
+
+        return IdKeyHelper.TryDecode(idKey, out _);
+    }
+}

--- a/src/Koinon.Application/Validators/Giving/CreateBatchRequestValidator.cs
+++ b/src/Koinon.Application/Validators/Giving/CreateBatchRequestValidator.cs
@@ -1,0 +1,47 @@
+using FluentValidation;
+using Koinon.Application.DTOs.Requests;
+using Koinon.Domain.Data;
+
+namespace Koinon.Application.Validators.Giving;
+
+/// <summary>
+/// Validator for CreateBatchRequest.
+/// </summary>
+public class CreateBatchRequestValidator : AbstractValidator<CreateBatchRequest>
+{
+    public CreateBatchRequestValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty().WithMessage("Batch name is required")
+            .MaximumLength(100).WithMessage("Batch name cannot exceed 100 characters");
+
+        RuleFor(x => x.BatchDate)
+            .NotEmpty().WithMessage("Batch date is required");
+
+        RuleFor(x => x.ControlAmount)
+            .GreaterThan(0).WithMessage("Control amount must be greater than 0")
+            .When(x => x.ControlAmount.HasValue);
+
+        RuleFor(x => x.ControlItemCount)
+            .GreaterThan(0).WithMessage("Control item count must be greater than 0")
+            .When(x => x.ControlItemCount.HasValue);
+
+        RuleFor(x => x.CampusIdKey)
+            .Must(BeValidIdKey).WithMessage("Campus ID must be a valid IdKey format")
+            .When(x => !string.IsNullOrWhiteSpace(x.CampusIdKey));
+
+        RuleFor(x => x.Note)
+            .MaximumLength(500).WithMessage("Note cannot exceed 500 characters")
+            .When(x => !string.IsNullOrEmpty(x.Note));
+    }
+
+    private static bool BeValidIdKey(string? idKey)
+    {
+        if (string.IsNullOrWhiteSpace(idKey))
+        {
+            return false;
+        }
+
+        return IdKeyHelper.TryDecode(idKey, out _);
+    }
+}

--- a/src/Koinon.Application/Validators/Giving/UpdateContributionRequestValidator.cs
+++ b/src/Koinon.Application/Validators/Giving/UpdateContributionRequestValidator.cs
@@ -1,0 +1,49 @@
+using FluentValidation;
+using Koinon.Application.DTOs.Requests;
+using Koinon.Domain.Data;
+
+namespace Koinon.Application.Validators.Giving;
+
+/// <summary>
+/// Validator for UpdateContributionRequest.
+/// </summary>
+public class UpdateContributionRequestValidator : AbstractValidator<UpdateContributionRequest>
+{
+    public UpdateContributionRequestValidator()
+    {
+        RuleFor(x => x.TransactionDateTime)
+            .NotEmpty().WithMessage("Transaction date/time is required");
+
+        RuleFor(x => x.TransactionTypeValueIdKey)
+            .NotEmpty().WithMessage("Transaction type is required")
+            .Must(BeValidIdKey).WithMessage("Transaction type must be a valid IdKey format");
+
+        RuleFor(x => x.Details)
+            .NotEmpty().WithMessage("At least one contribution detail is required");
+
+        RuleForEach(x => x.Details)
+            .SetValidator(new ContributionDetailRequestValidator());
+
+        RuleFor(x => x.PersonIdKey)
+            .Must(BeValidIdKey).WithMessage("Person ID must be a valid IdKey format")
+            .When(x => !string.IsNullOrWhiteSpace(x.PersonIdKey));
+
+        RuleFor(x => x.TransactionCode)
+            .MaximumLength(50).WithMessage("Transaction code cannot exceed 50 characters")
+            .When(x => !string.IsNullOrEmpty(x.TransactionCode));
+
+        RuleFor(x => x.Summary)
+            .MaximumLength(500).WithMessage("Summary cannot exceed 500 characters")
+            .When(x => !string.IsNullOrEmpty(x.Summary));
+    }
+
+    private static bool BeValidIdKey(string? idKey)
+    {
+        if (string.IsNullOrWhiteSpace(idKey))
+        {
+            return false;
+        }
+
+        return IdKeyHelper.TryDecode(idKey, out _);
+    }
+}

--- a/src/Koinon.Domain/Entities/ContributionBatch.cs
+++ b/src/Koinon.Domain/Entities/ContributionBatch.cs
@@ -30,6 +30,12 @@ public class ContributionBatch : Entity
     public decimal? ControlAmount { get; set; }
 
     /// <summary>
+    /// Expected number of items for reconciliation purposes.
+    /// Nullable - not all batches have a predetermined control count.
+    /// </summary>
+    public int? ControlItemCount { get; set; }
+
+    /// <summary>
     /// Optional campus association for the batch.
     /// </summary>
     public int? CampusId { get; set; }

--- a/src/Koinon.Infrastructure/Configurations/ContributionBatchConfiguration.cs
+++ b/src/Koinon.Infrastructure/Configurations/ContributionBatchConfiguration.cs
@@ -46,6 +46,9 @@ public class ContributionBatchConfiguration : IEntityTypeConfiguration<Contribut
             .HasColumnName("control_amount")
             .HasPrecision(18, 2);
 
+        builder.Property(cb => cb.ControlItemCount)
+            .HasColumnName("control_item_count");
+
         builder.Property(cb => cb.CampusId)
             .HasColumnName("campus_id");
 

--- a/tests/Koinon.Application.Tests/Services/AuthServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/AuthServiceTests.cs
@@ -450,6 +450,13 @@ public class AuthServiceTests
         public DbSet<ImportTemplate> ImportTemplates { get; set; } = null!;
         public DbSet<ImportJob> ImportJobs { get; set; } = null!;
 
+        // Giving/Financial
+        public DbSet<Fund> Funds { get; set; } = null!;
+        public DbSet<ContributionBatch> ContributionBatches { get; set; } = null!;
+        public DbSet<Contribution> Contributions { get; set; } = null!;
+        public DbSet<ContributionDetail> ContributionDetails { get; set; } = null!;
+        public DbSet<FinancialAuditLog> FinancialAuditLogs { get; set; } = null!;
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);

--- a/tests/Koinon.Application.Tests/Services/AuthorizedPickupServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/AuthorizedPickupServiceTests.cs
@@ -985,6 +985,11 @@ public class AuthorizedPickupServiceTests : IDisposable
         public DbSet<BinaryFile> BinaryFiles { get; set; } = null!;
         public DbSet<ImportTemplate> ImportTemplates { get; set; } = null!;
         public DbSet<ImportJob> ImportJobs { get; set; } = null!;
+        public DbSet<Fund> Funds { get; set; } = null!;
+        public DbSet<ContributionBatch> ContributionBatches { get; set; } = null!;
+        public DbSet<Contribution> Contributions { get; set; } = null!;
+        public DbSet<ContributionDetail> ContributionDetails { get; set; } = null!;
+        public DbSet<FinancialAuditLog> FinancialAuditLogs { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/tests/Koinon.Application.Tests/Services/DeviceValidationServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/DeviceValidationServiceTests.cs
@@ -279,6 +279,11 @@ public class DeviceValidationServiceTests : IDisposable
         public DbSet<BinaryFile> BinaryFiles { get; set; } = null!;
         public DbSet<ImportTemplate> ImportTemplates { get; set; } = null!;
         public DbSet<ImportJob> ImportJobs { get; set; } = null!;
+        public DbSet<Fund> Funds { get; set; } = null!;
+        public DbSet<ContributionBatch> ContributionBatches { get; set; } = null!;
+        public DbSet<Contribution> Contributions { get; set; } = null!;
+        public DbSet<ContributionDetail> ContributionDetails { get; set; } = null!;
+        public DbSet<FinancialAuditLog> FinancialAuditLogs { get; set; } = null!;
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {


### PR DESCRIPTION
## Summary

Implements BatchDonationEntryService for manual contribution entry with batch reconciliation:

- **Batch Management**: Create, open, close batch lifecycle with status transitions
- **Contribution CRUD**: Add, update, delete contributions with multi-fund allocation
- **Reconciliation**: Control amounts and item counts with variance calculations
- **Financial Audit**: All mutations logged to FinancialAuditLog for compliance
- **Security**: EnsureAuthenticated() called before any database mutations
- **Validation**: FluentValidation for all request types

## Key Features

- `ControlAmount` and `ControlItemCount` for batch reconciliation
- `BatchSummaryDto` with variance calculations and `IsBalanced` flag
- `EnsureAuthenticated()` prevents unauthenticated financial operations
- `Result<T>` pattern for all operations
- IdKey pattern throughout (no integer ID exposure)

## Files Changed (19)

### Application Layer
- `Services/BatchDonationEntryService.cs` - Main service (747 lines)
- `Interfaces/IBatchDonationEntryService.cs` - Service interface
- `DTOs/Giving/*.cs` - 7 DTO files for giving operations
- `DTOs/Requests/BatchDonationRequests.cs` - Request records
- `Validators/Giving/*.cs` - 3 FluentValidation validators
- `Interfaces/IApplicationDbContext.cs` - Added 5 new DbSets

### Domain Layer
- `Entities/ContributionBatch.cs` - Added ControlItemCount property

### Infrastructure Layer
- `Configurations/ContributionBatchConfiguration.cs` - Added control_item_count column

### Tests
- Updated mock DbContext setup files

## Test Plan

- [ ] Build passes: `dotnet build`
- [ ] All tests pass: `dotnet test`
- [ ] Service methods properly validate authentication
- [ ] Batch reconciliation calculates variances correctly
- [ ] Audit logs capture all financial operations

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)