### PR TITLE
feat(tooling): add CLI arguments to generate-frontend.js for testability

### DIFF
--- a/tools/graph/README.md
+++ b/tools/graph/README.md
@@ -66,6 +66,119 @@ npm run graph:update
 4. Reorganizing component structure
 5. Major structural refactoring
 
+## CLI Arguments
+
+Both `generate-frontend.js` and `merge-graph.py` support custom path arguments for advanced usage (especially useful for testing with fixture directories).
+
+### generate-frontend.js
+
+Parses TypeScript/React source files from a custom directory and outputs to a custom location.
+
+**Arguments:**
+- `--src-dir <path>` - Source directory containing `src/web/src` structure (default: `src/web/src`)
+- `--output-dir <path>` - Output directory for generated `frontend-graph.json` (default: `tools/graph`)
+
+**Examples:**
+
+Default behavior (no arguments):
+```bash
+node tools/graph/generate-frontend.js
+# Reads from: src/web/src/
+# Writes to: tools/graph/frontend-graph.json
+```
+
+Custom source directory for testing:
+```bash
+node tools/graph/generate-frontend.js --src-dir tests/fixtures/web
+# Reads from: tests/fixtures/web/
+# Writes to: tools/graph/frontend-graph.json
+```
+
+Custom output directory:
+```bash
+node tools/graph/generate-frontend.js --output-dir tests/output
+# Reads from: src/web/src/
+# Writes to: tests/output/frontend-graph.json
+```
+
+Both arguments together:
+```bash
+node tools/graph/generate-frontend.js --src-dir tests/fixtures/web --output-dir tests/output
+# Reads from: tests/fixtures/web/
+# Writes to: tests/output/frontend-graph.json
+```
+
+### merge-graph.py
+
+Combines backend and frontend graphs, detecting cross-layer inconsistencies.
+
+**Arguments:**
+- `--backend <path>` or `-b <path>` - Backend graph input file (default: `tools/graph/backend-graph.json`)
+- `--frontend <path>` or `-f <path>` - Frontend graph input file (default: `tools/graph/frontend-graph.json`)
+- `--output <path>` or `-o <path>` - Output file path (default: `tools/graph/graph-baseline.json`)
+
+**Examples:**
+
+Default behavior (no arguments):
+```bash
+python3 tools/graph/merge-graph.py
+# Reads: tools/graph/backend-graph.json + tools/graph/frontend-graph.json
+# Writes: tools/graph/graph-baseline.json
+```
+
+Custom backend and frontend for testing:
+```bash
+python3 tools/graph/merge-graph.py \
+  --backend tests/fixtures/backend-graph.json \
+  --frontend tests/fixtures/frontend-graph.json
+# Reads: tests/fixtures/backend-graph.json + tests/fixtures/frontend-graph.json
+# Writes: tools/graph/graph-baseline.json
+```
+
+Custom output path:
+```bash
+python3 tools/graph/merge-graph.py --output tests/output/merged-graph.json
+# Reads: tools/graph/backend-graph.json + tools/graph/frontend-graph.json
+# Writes: tests/output/merged-graph.json
+```
+
+All arguments together (full test isolation):
+```bash
+python3 tools/graph/merge-graph.py \
+  --backend tests/fixtures/backend-graph.json \
+  --frontend tests/fixtures/frontend-graph.json \
+  --output tests/output/graph-baseline.json
+# Reads: tests/fixtures/backend-graph.json + tests/fixtures/frontend-graph.json
+# Writes: tests/output/graph-baseline.json
+```
+
+### Test Isolation Pattern
+
+These arguments enable test isolation with fixture directories:
+
+```bash
+# Setup fixture directories
+mkdir -p tests/fixtures tests/output
+
+# Copy fixture files
+cp tools/graph/backend-graph.json tests/fixtures/
+
+# Run generator with fixtures
+node tools/graph/generate-frontend.js --src-dir tests/fixtures/web --output-dir tests/output
+python3 tools/graph/merge-graph.py \
+  --backend tests/fixtures/backend-graph.json \
+  --frontend tests/output/frontend-graph.json \
+  --output tests/output/graph-baseline.json
+
+# Cleanup
+rm -rf tests/output
+```
+
+This pattern ensures:
+- No modification of production files
+- Repeatable test runs
+- Safe experimentation with new graph structures
+
 ## Common Scenarios
 
 ### Scenario 1: Adding a New Entity Type

--- a/tools/graph/generate-frontend.js
+++ b/tools/graph/generate-frontend.js
@@ -13,15 +13,41 @@ const fs = require('fs');
 const path = require('path');
 
 // ============================================================================
+// Argument Parsing
+// ============================================================================
+
+/**
+ * Parse command-line arguments
+ * Returns { srcDir, outputDir } with defaults
+ */
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let srcDir = path.join(process.cwd(), 'src/web/src');
+  let outputDir = path.join(process.cwd(), 'tools/graph');
+
+  // Parse arguments
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--src-dir' && i + 1 < args.length) {
+      srcDir = path.resolve(args[i + 1]);
+      i++; // Skip next arg since we processed it
+    } else if (args[i] === '--output-dir' && i + 1 < args.length) {
+      outputDir = path.resolve(args[i + 1]);
+      i++; // Skip next arg since we processed it
+    }
+  }
+
+  return { srcDir, outputDir };
+}
+// ============================================================================
 // Configuration
 // ============================================================================
 
-const WEB_SRC_DIR = path.join(process.cwd(), 'src/web/src');
+const { srcDir: WEB_SRC_DIR, outputDir: OUTPUT_DIR_BASE } = parseArgs();
 const TYPES_FILE = path.join(WEB_SRC_DIR, 'services/api/types.ts');
 const SERVICES_API_DIR = path.join(WEB_SRC_DIR, 'services/api');
 const HOOKS_DIR = path.join(WEB_SRC_DIR, 'hooks');
 const COMPONENTS_DIR = path.join(WEB_SRC_DIR, 'components');
-const OUTPUT_DIR = path.join(process.cwd(), 'tools/graph');
+const OUTPUT_DIR = OUTPUT_DIR_BASE;
 const OUTPUT_FILE = path.join(OUTPUT_DIR, 'frontend-graph.json');
 
 // ============================================================================
@@ -435,6 +461,7 @@ async function main() {
   try {
     console.log('Frontend Graph Generator');
     console.log('========================\n');
+    console.log(`Source directory: ${WEB_SRC_DIR}\n`);
 
     // 1. Parse types
     console.log('Reading types.ts...');
@@ -505,6 +532,7 @@ if (require.main === module) {
 
 // Export functions for testing
 module.exports = {
+  parseArgs,
   parseTypes,
   parseProperties,
   parseApiFunctions,


### PR DESCRIPTION
## Summary
- Added parseArgs() function with --src-dir and --output-dir arguments
- Refactored path constants from hardcoded to computed values
- Updated integration test to use new CLI arguments with fixtures
- Enhanced README with comprehensive CLI argument documentation

## Test plan
- [x] All 78 Jest tests pass (7 new parseArgs tests)
- [x] Integration test now runs generate-frontend.js with fixtures
- [x] Pre-push validation passed
- [x] Backward compatibility maintained (defaults work)

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)