### PR TITLE
feat(types): add missing analytics and dashboard types to central module

### DIFF
--- a/src/web/src/components/admin/analytics/AnalyticsSummaryCards.tsx
+++ b/src/web/src/components/admin/analytics/AnalyticsSummaryCards.tsx
@@ -3,10 +3,10 @@
  * Displays key attendance metrics in card format
  */
 
-import type { AttendanceAnalytics } from '@/services/api/analytics';
+import type { AttendanceAnalyticsDto } from '@/types';
 
 export interface AnalyticsSummaryCardsProps {
-  analytics: AttendanceAnalytics | undefined;
+  analytics: AttendanceAnalyticsDto | undefined;
   isLoading: boolean;
 }
 

--- a/src/web/src/components/admin/analytics/AttendanceByGroupTable.tsx
+++ b/src/web/src/components/admin/analytics/AttendanceByGroupTable.tsx
@@ -4,10 +4,10 @@
  */
 
 import { useState } from 'react';
-import type { AttendanceByGroup } from '@/services/api/analytics';
+import type { AttendanceByGroupDto } from '@/types';
 
 export interface AttendanceByGroupTableProps {
-  groups: AttendanceByGroup[] | undefined;
+  groups: AttendanceByGroupDto[] | undefined;
   isLoading: boolean;
 }
 

--- a/src/web/src/components/admin/analytics/AttendanceTrendChart.tsx
+++ b/src/web/src/components/admin/analytics/AttendanceTrendChart.tsx
@@ -13,10 +13,10 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
-import type { AttendanceTrend } from '@/services/api/analytics';
+import type { AttendanceTrendDto } from '@/types';
 
 export interface AttendanceTrendChartProps {
-  trends: AttendanceTrend[] | undefined;
+  trends: AttendanceTrendDto[] | undefined;
   isLoading: boolean;
 }
 

--- a/src/web/src/components/admin/dashboard/UpcomingSchedules.tsx
+++ b/src/web/src/components/admin/dashboard/UpcomingSchedules.tsx
@@ -4,10 +4,10 @@
  */
 
 import { Link } from 'react-router-dom';
-import type { UpcomingSchedule } from '@/services/api/dashboard';
+import type { UpcomingScheduleDto } from '@/types';
 
 export interface UpcomingSchedulesProps {
-  schedules: UpcomingSchedule[];
+  schedules: UpcomingScheduleDto[];
   isLoading: boolean;
 }
 
@@ -71,7 +71,7 @@ export function UpcomingSchedules({ schedules, isLoading }: UpcomingSchedulesPro
 }
 
 interface ScheduleItemProps {
-  schedule: UpcomingSchedule;
+  schedule: UpcomingScheduleDto;
 }
 
 function ScheduleItem({ schedule }: ScheduleItemProps) {

--- a/src/web/src/services/api/analytics.ts
+++ b/src/web/src/services/api/analytics.ts
@@ -3,54 +3,26 @@
  */
 
 import { get } from './client';
+import type {
+  AttendanceAnalyticsDto,
+  AttendanceAnalyticsParams,
+  AttendanceByGroupDto,
+  AttendanceTrendDto,
+  FirstTimeVisitorDto,
+} from '@/types';
 
-export interface AttendanceAnalytics {
-  totalAttendance: number;
-  uniqueAttendees: number;
-  firstTimeVisitors: number;
-  returningVisitors: number;
-  averageAttendance: number;
-  startDate: string;
-  endDate: string;
-}
-
-export interface AttendanceTrend {
-  date: string;
-  count: number;
-  firstTime: number;
-  returning: number;
-}
-
-export interface AttendanceByGroup {
-  groupIdKey: string;
-  groupName: string;
-  groupTypeName: string;
-  totalAttendance: number;
-  uniqueAttendees: number;
-}
-
-export interface FirstTimeVisitorDto {
-  personIdKey: string;
-  personName: string;
-  email?: string;
-  phoneNumber?: string;
-  checkInDateTime: string;
-  groupName: string;
-  groupTypeName: string;
-  campusName?: string;
-  hasFollowUp: boolean;
-}
-
-export interface AttendanceAnalyticsParams {
-  startDate: string;
-  endDate: string;
-  campusIdKey?: string;
-  groupTypeIdKey?: string;
-}
+// Re-export types for backwards compatibility
+export type {
+  AttendanceAnalyticsDto,
+  AttendanceAnalyticsParams,
+  AttendanceByGroupDto,
+  AttendanceTrendDto,
+  FirstTimeVisitorDto,
+};
 
 export async function getAttendanceAnalytics(
   params: AttendanceAnalyticsParams
-): Promise<AttendanceAnalytics> {
+): Promise<AttendanceAnalyticsDto> {
   const queryParams = new URLSearchParams({
     startDate: params.startDate,
     endDate: params.endDate,
@@ -64,7 +36,7 @@ export async function getAttendanceAnalytics(
     queryParams.append('groupTypeIdKey', params.groupTypeIdKey);
   }
 
-  const response = await get<{ data: AttendanceAnalytics }>(
+  const response = await get<{ data: AttendanceAnalyticsDto }>(
     `/analytics/attendance?${queryParams.toString()}`
   );
   if (!response.data) {
@@ -75,7 +47,7 @@ export async function getAttendanceAnalytics(
 
 export async function getAttendanceTrends(
   params: AttendanceAnalyticsParams
-): Promise<AttendanceTrend[]> {
+): Promise<AttendanceTrendDto[]> {
   const queryParams = new URLSearchParams({
     startDate: params.startDate,
     endDate: params.endDate,
@@ -89,7 +61,7 @@ export async function getAttendanceTrends(
     queryParams.append('groupTypeIdKey', params.groupTypeIdKey);
   }
 
-  const response = await get<{ data: AttendanceTrend[] }>(
+  const response = await get<{ data: AttendanceTrendDto[] }>(
     `/analytics/attendance/trends?${queryParams.toString()}`
   );
   if (!response.data) {
@@ -100,7 +72,7 @@ export async function getAttendanceTrends(
 
 export async function getAttendanceByGroup(
   params: AttendanceAnalyticsParams
-): Promise<AttendanceByGroup[]> {
+): Promise<AttendanceByGroupDto[]> {
   const queryParams = new URLSearchParams({
     startDate: params.startDate,
     endDate: params.endDate,
@@ -114,7 +86,7 @@ export async function getAttendanceByGroup(
     queryParams.append('groupTypeIdKey', params.groupTypeIdKey);
   }
 
-  const response = await get<{ data: AttendanceByGroup[] }>(
+  const response = await get<{ data: AttendanceByGroupDto[] }>(
     `/analytics/attendance/by-group?${queryParams.toString()}`
   );
   if (!response.data) {

--- a/src/web/src/services/api/dashboard.ts
+++ b/src/web/src/services/api/dashboard.ts
@@ -3,25 +3,12 @@
  */
 
 import { get } from './client';
+import type { DashboardStatsDto, UpcomingScheduleDto } from '@/types';
 
-export interface DashboardStats {
-  totalPeople: number;
-  totalFamilies: number;
-  activeGroups: number;
-  todayCheckIns: number;
-  lastWeekCheckIns: number;
-  activeSchedules: number;
-  upcomingSchedules: UpcomingSchedule[];
-}
+// Re-export types for backwards compatibility
+export type { DashboardStatsDto, UpcomingScheduleDto };
 
-export interface UpcomingSchedule {
-  idKey: string;
-  name: string;
-  nextOccurrence: string;
-  minutesUntilCheckIn: number;
-}
-
-export async function getDashboardStats(): Promise<DashboardStats> {
-  const response = await get<{ data: DashboardStats }>('/dashboard/stats');
+export async function getDashboardStats(): Promise<DashboardStatsDto> {
+  const response = await get<{ data: DashboardStatsDto }>('/dashboard/stats');
   return response.data;
 }

--- a/src/web/src/types/analytics.ts
+++ b/src/web/src/types/analytics.ts
@@ -1,0 +1,69 @@
+/**
+ * Analytics domain types
+ *
+ * Types for attendance analytics and visitor tracking.
+ * Aligned with C# DTOs in src/Koinon.Application/DTOs/
+ *
+ * Note: TypeScript uses camelCase for properties while C# uses PascalCase.
+ * JSON serialization handles the casing transformation automatically.
+ * Date fields use ISO 8601 string format for C# DateOnly/DateTime types.
+ */
+
+/**
+ * Aggregated attendance statistics for a date range
+ */
+export interface AttendanceAnalyticsDto {
+  totalAttendance: number;
+  uniqueAttendees: number;
+  firstTimeVisitors: number;
+  returningVisitors: number;
+  averageAttendance: number;
+  startDate: string;
+  endDate: string;
+}
+
+/**
+ * Daily attendance trend data point
+ */
+export interface AttendanceTrendDto {
+  date: string;
+  count: number;
+  firstTime: number;
+  returning: number;
+}
+
+/**
+ * Attendance breakdown by group
+ */
+export interface AttendanceByGroupDto {
+  groupIdKey: string;
+  groupName: string;
+  groupTypeName: string;
+  totalAttendance: number;
+  uniqueAttendees: number;
+}
+
+/**
+ * First-time visitor record with contact information
+ */
+export interface FirstTimeVisitorDto {
+  personIdKey: string;
+  personName: string;
+  email?: string;
+  phoneNumber?: string;
+  checkInDateTime: string;
+  groupName: string;
+  groupTypeName: string;
+  campusName?: string;
+  hasFollowUp: boolean;
+}
+
+/**
+ * Parameters for querying attendance analytics
+ */
+export interface AttendanceAnalyticsParams {
+  startDate: string;
+  endDate: string;
+  campusIdKey?: string;
+  groupTypeIdKey?: string;
+}

--- a/src/web/src/types/checkin-extended.ts
+++ b/src/web/src/types/checkin-extended.ts
@@ -1,47 +1,18 @@
 /**
  * Extended TypeScript types for Koinon RMS Check-in API
- * Provides types for attendance analytics, roster management, and extended check-in operations
+ * Provides types for roster management and extended check-in operations
+ *
+ * Note: Attendance analytics types are now in './analytics.ts'
  */
 
 import type { IdKey, DateTime, DateOnly, Guid, CapacityStatus } from '@/services/api/types';
 
-// ============================================================================
-// Attendance Analytics Types
-// ============================================================================
-
-/**
- * Aggregate attendance statistics for a date range
- */
-export interface AttendanceAnalyticsDto {
-  totalAttendance: number;
-  uniqueAttendees: number;
-  firstTimeVisitors: number;
-  returningVisitors: number;
-  averageAttendance: number;
-  startDate: DateOnly;
-  endDate: DateOnly;
-}
-
-/**
- * Daily attendance trend data point
- */
-export interface AttendanceTrendDto {
-  date: DateOnly;
-  count: number;
-  firstTime: number;
-  returning: number;
-}
-
-/**
- * Attendance statistics grouped by group
- */
-export interface AttendanceByGroupDto {
-  groupIdKey: IdKey;
-  groupName: string;
-  groupTypeName: string;
-  totalAttendance: number;
-  uniqueAttendees: number;
-}
+// Re-export analytics types for backwards compatibility
+export type {
+  AttendanceAnalyticsDto,
+  AttendanceTrendDto,
+  AttendanceByGroupDto,
+} from './analytics';
 
 // ============================================================================
 // Attendance Taker / Roster Types

--- a/src/web/src/types/dashboard.ts
+++ b/src/web/src/types/dashboard.ts
@@ -1,0 +1,33 @@
+/**
+ * Dashboard domain types
+ *
+ * Types for dashboard statistics and overview data.
+ * Aligned with C# DTOs in src/Koinon.Application/DTOs/
+ *
+ * Note: TypeScript uses camelCase for properties while C# uses PascalCase.
+ * JSON serialization handles the casing transformation automatically.
+ * Date fields use ISO 8601 string format for C# DateOnly/DateTime types.
+ */
+
+/**
+ * Upcoming schedule summary for dashboard display
+ */
+export interface UpcomingScheduleDto {
+  idKey: string;
+  name: string;
+  nextOccurrence: string;
+  minutesUntilCheckIn: number;
+}
+
+/**
+ * Dashboard statistics overview
+ */
+export interface DashboardStatsDto {
+  totalPeople: number;
+  totalFamilies: number;
+  activeGroups: number;
+  todayCheckIns: number;
+  lastWeekCheckIns: number;
+  activeSchedules: number;
+  upcomingSchedules: UpcomingScheduleDto[];
+}

--- a/src/web/src/types/index.ts
+++ b/src/web/src/types/index.ts
@@ -10,9 +10,11 @@
  */
 
 // Domain types
+export * from './analytics';
 export * from './authorized-pickup';
 export * from './checkin-extended';
 export * from './communication';
+export * from './dashboard';
 export * from './files';
 export * from './followup';
 export * from './giving';

--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-01-02T13:53:56.322311+00:00",
+  "generated_at": "2026-01-02T14:22:57.748419+00:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -1,7 +1,71 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-01-02T13:53:56.492Z",
+  "generated_at": "2026-01-02T14:22:57.921Z",
   "types": {
+    "AttendanceAnalyticsDto": {
+      "name": "AttendanceAnalyticsDto",
+      "kind": "interface",
+      "properties": {
+        "totalAttendance": "number",
+        "uniqueAttendees": "number",
+        "firstTimeVisitors": "number",
+        "returningVisitors": "number",
+        "averageAttendance": "number",
+        "startDate": "string",
+        "endDate": "string"
+      },
+      "path": "types/analytics.ts"
+    },
+    "AttendanceTrendDto": {
+      "name": "AttendanceTrendDto",
+      "kind": "interface",
+      "properties": {
+        "date": "string",
+        "count": "number",
+        "firstTime": "number",
+        "returning": "number"
+      },
+      "path": "types/analytics.ts"
+    },
+    "AttendanceByGroupDto": {
+      "name": "AttendanceByGroupDto",
+      "kind": "interface",
+      "properties": {
+        "groupIdKey": "string",
+        "groupName": "string",
+        "groupTypeName": "string",
+        "totalAttendance": "number",
+        "uniqueAttendees": "number"
+      },
+      "path": "types/analytics.ts"
+    },
+    "FirstTimeVisitorDto": {
+      "name": "FirstTimeVisitorDto",
+      "kind": "interface",
+      "properties": {
+        "personIdKey": "string",
+        "personName": "string",
+        "email": "string",
+        "phoneNumber": "string",
+        "checkInDateTime": "string",
+        "groupName": "string",
+        "groupTypeName": "string",
+        "campusName": "string",
+        "hasFollowUp": "boolean"
+      },
+      "path": "types/analytics.ts"
+    },
+    "AttendanceAnalyticsParams": {
+      "name": "AttendanceAnalyticsParams",
+      "kind": "interface",
+      "properties": {
+        "startDate": "string",
+        "endDate": "string",
+        "campusIdKey": "string",
+        "groupTypeIdKey": "string"
+      },
+      "path": "types/analytics.ts"
+    },
     "AuthorizedPickupDto": {
       "name": "AuthorizedPickupDto",
       "kind": "interface",
@@ -111,43 +175,6 @@
       "kind": "enum",
       "properties": {},
       "path": "types/authorized-pickup.ts"
-    },
-    "AttendanceAnalyticsDto": {
-      "name": "AttendanceAnalyticsDto",
-      "kind": "interface",
-      "properties": {
-        "totalAttendance": "number",
-        "uniqueAttendees": "number",
-        "firstTimeVisitors": "number",
-        "returningVisitors": "number",
-        "averageAttendance": "number",
-        "startDate": "DateOnly",
-        "endDate": "DateOnly"
-      },
-      "path": "types/checkin-extended.ts"
-    },
-    "AttendanceTrendDto": {
-      "name": "AttendanceTrendDto",
-      "kind": "interface",
-      "properties": {
-        "date": "DateOnly",
-        "count": "number",
-        "firstTime": "number",
-        "returning": "number"
-      },
-      "path": "types/checkin-extended.ts"
-    },
-    "AttendanceByGroupDto": {
-      "name": "AttendanceByGroupDto",
-      "kind": "interface",
-      "properties": {
-        "groupIdKey": "IdKey",
-        "groupName": "string",
-        "groupTypeName": "string",
-        "totalAttendance": "number",
-        "uniqueAttendees": "number"
-      },
-      "path": "types/checkin-extended.ts"
     },
     "MarkAttendanceResultDto": {
       "name": "MarkAttendanceResultDto",
@@ -553,6 +580,31 @@
       "kind": "enum",
       "properties": {},
       "path": "types/communication.ts"
+    },
+    "UpcomingScheduleDto": {
+      "name": "UpcomingScheduleDto",
+      "kind": "interface",
+      "properties": {
+        "idKey": "string",
+        "name": "string",
+        "nextOccurrence": "string",
+        "minutesUntilCheckIn": "number"
+      },
+      "path": "types/dashboard.ts"
+    },
+    "DashboardStatsDto": {
+      "name": "DashboardStatsDto",
+      "kind": "interface",
+      "properties": {
+        "totalPeople": "number",
+        "totalFamilies": "number",
+        "activeGroups": "number",
+        "todayCheckIns": "number",
+        "lastWeekCheckIns": "number",
+        "activeSchedules": "number",
+        "upcomingSchedules": "UpcomingScheduleDto[]"
+      },
+      "path": "types/dashboard.ts"
     },
     "FileMetadataDto": {
       "name": "FileMetadataDto",
@@ -2515,23 +2567,23 @@
     "getAttendanceAnalytics": {
       "name": "getAttendanceAnalytics",
       "path": "services/api/analytics.ts",
-      "endpoint": "/analytics/a",
+      "endpoint": "/analy",
       "method": "GET",
-      "responseType": "AttendanceAnalytics"
+      "responseType": "AttendanceAnalyticsDto"
     },
     "getAttendanceTrends": {
       "name": "getAttendanceTrends",
       "path": "services/api/analytics.ts",
-      "endpoint": "/analytics/attendan",
+      "endpoint": "/analytics/at",
       "method": "GET",
-      "responseType": "AttendanceTrend[]"
+      "responseType": "AttendanceTrendDto[]"
     },
     "getAttendanceByGroup": {
       "name": "getAttendanceByGroup",
       "path": "services/api/analytics.ts",
-      "endpoint": "/analytics/att",
+      "endpoint": "/analyti",
       "method": "GET",
-      "responseType": "AttendanceByGroup[]"
+      "responseType": "AttendanceByGroupDto[]"
     },
     "getTodaysFirstTimeVisitors": {
       "name": "getTodaysFirstTimeVisitors",
@@ -2713,7 +2765,7 @@
       "path": "services/api/dashboard.ts",
       "endpoint": "/dashboard/stats",
       "method": "GET",
-      "responseType": "DashboardStats"
+      "responseType": "DashboardStatsDto"
     },
     "getFamilyByIdKey": {
       "name": "getFamilyByIdKey",

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-01-02T13:53:56.637844+00:00",
+  "generated_at": "2026-01-02T14:22:58.069830+00:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -5766,23 +5766,23 @@
     "getAttendanceAnalytics": {
       "name": "getAttendanceAnalytics",
       "path": "services/api/analytics.ts",
-      "endpoint": "/analytics/a",
+      "endpoint": "/analy",
       "method": "GET",
-      "responseType": "AttendanceAnalytics"
+      "responseType": "AttendanceAnalyticsDto"
     },
     "getAttendanceTrends": {
       "name": "getAttendanceTrends",
       "path": "services/api/analytics.ts",
-      "endpoint": "/analytics/attendan",
+      "endpoint": "/analytics/at",
       "method": "GET",
-      "responseType": "AttendanceTrend[]"
+      "responseType": "AttendanceTrendDto[]"
     },
     "getAttendanceByGroup": {
       "name": "getAttendanceByGroup",
       "path": "services/api/analytics.ts",
-      "endpoint": "/analytics/att",
+      "endpoint": "/analyti",
       "method": "GET",
-      "responseType": "AttendanceByGroup[]"
+      "responseType": "AttendanceByGroupDto[]"
     },
     "getTodaysFirstTimeVisitors": {
       "name": "getTodaysFirstTimeVisitors",
@@ -5964,7 +5964,7 @@
       "path": "services/api/dashboard.ts",
       "endpoint": "/dashboard/stats",
       "method": "GET",
-      "responseType": "DashboardStats"
+      "responseType": "DashboardStatsDto"
     },
     "getFamilyByIdKey": {
       "name": "getFamilyByIdKey",
@@ -8268,8 +8268,11 @@
     "dto:CommunicationRecipientDto": "type:CommunicationRecipientDto",
     "dto:CreateCommunicationDto": "type:CreateCommunicationDto",
     "dto:UpdateCommunicationDto": "type:UpdateCommunicationDto",
+    "dto:DashboardStatsDto": "type:DashboardStatsDto",
+    "dto:UpcomingScheduleDto": "type:UpcomingScheduleDto",
     "dto:FamilyMemberDto": "type:FamilyMemberDto",
     "dto:GroupTypeRoleDto": "type:GroupTypeRoleDto",
+    "dto:FirstTimeVisitorDto": "type:FirstTimeVisitorDto",
     "dto:FollowUpDto": "type:FollowUpDto",
     "dto:GroupSummaryDto": "type:GroupSummaryDto",
     "dto:GroupMemberDetailDto": "type:GroupMemberDetailDto",
@@ -8311,7 +8314,7 @@
     "dtos": 77,
     "services": 69,
     "controllers": 22,
-    "types": 203,
+    "types": 207,
     "api_functions": 111,
     "hooks": 71,
     "components": 87,


### PR DESCRIPTION
## Summary
- Created centralized analytics and dashboard type modules in `src/web/src/types/`
- Added Dto suffix to all types to match C# naming conventions
- Updated API services and components to import from `@/types`
- Removed duplicate type definitions from `checkin-extended.ts`

## Changes
- **New files:**
  - `src/web/src/types/analytics.ts` - Analytics domain types (5 interfaces)
  - `src/web/src/types/dashboard.ts` - Dashboard domain types (2 interfaces)
- **Modified:**
  - API services now import from `@/types` and re-export for backwards compatibility
  - Components updated to use Dto-suffixed type names
  - `checkin-extended.ts` now re-exports from analytics.ts

## Test plan
- [x] TypeScript compilation passes
- [x] Frontend tests pass (179 tests)
- [x] Backend tests pass (913 tests)
- [x] Graph validation passes

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)