### PR TITLE
chore(types): audit and remove duplicate type definitions

### DIFF
--- a/src/web/src/services/api/communications.ts
+++ b/src/web/src/services/api/communications.ts
@@ -3,82 +3,26 @@
  */
 
 import { get, post } from './client';
-import type { PagedResult, IdKey } from './types';
+import type { PagedResult } from './types';
+import type {
+  CreateCommunicationDto,
+  CommunicationDto,
+  CommunicationRecipientDto,
+  CommunicationSummaryDto,
+  CommunicationsParams,
+} from '@/types/communication';
 
-// ============================================================================
-// Request Types
-// ============================================================================
+// Re-export types from central module for backward compatibility
+export type {
+  CreateCommunicationDto,
+  CommunicationDto,
+  CommunicationRecipientDto,
+  CommunicationSummaryDto,
+  CommunicationsParams,
+};
 
-export interface CreateCommunicationRequest {
-  communicationType: 'Email' | 'Sms';
-  subject?: string;
-  body: string;
-  fromEmail?: string;
-  fromName?: string;
-  replyToEmail?: string;
-  note?: string;
-  groupIdKeys: string[];
-}
-
-// ============================================================================
-// Response Types
-// ============================================================================
-
-export interface CommunicationRecipientDto {
-  idKey: IdKey;
-  personIdKey: IdKey;
-  address: string;
-  recipientName?: string;
-  status: string;
-  deliveredDateTime?: string;
-  openedDateTime?: string;
-  errorMessage?: string;
-  groupIdKey?: IdKey;
-}
-
-export interface CommunicationDto {
-  idKey: IdKey;
-  guid: string;
-  communicationType: string;
-  status: string;
-  subject?: string;
-  body: string;
-  fromEmail?: string;
-  fromName?: string;
-  replyToEmail?: string;
-  sentDateTime?: string;
-  recipientCount: number;
-  deliveredCount: number;
-  failedCount: number;
-  openedCount: number;
-  note?: string;
-  createdDateTime: string;
-  modifiedDateTime?: string;
-  recipients: CommunicationRecipientDto[];
-}
-
-export interface CommunicationSummaryDto {
-  idKey: IdKey;
-  guid: string;
-  communicationType: string;
-  status: string;
-  subject?: string;
-  sentDateTime?: string;
-  recipientCount: number;
-  deliveredCount: number;
-  failedCount: number;
-  createdDateTime: string;
-}
-
-// ============================================================================
-// Query Parameters
-// ============================================================================
-
-export interface CommunicationsParams {
-  page?: number;
-  pageSize?: number;
-  status?: string;
-}
+// Type alias for API compatibility
+export type CreateCommunicationRequest = CreateCommunicationDto;
 
 // ============================================================================
 // API Functions

--- a/src/web/src/services/api/files.ts
+++ b/src/web/src/services/api/files.ts
@@ -3,20 +3,13 @@
  */
 
 import { get, del, apiClient, getAccessToken } from './client';
-import type { FileMetadataDto } from '@/types/files';
+import type { FileMetadataDto, UploadFileOptions } from '@/types/files';
 
 const API_BASE_URL =
   import.meta.env.VITE_API_URL || 'http://localhost:5000/api/v1';
 
-/**
- * Upload options for file upload
- */
-export interface UploadFileOptions {
-  /** Optional description or alt text */
-  description?: string;
-  /** Optional file type category IdKey (from DefinedValue) */
-  binaryFileTypeIdKey?: string;
-}
+// Re-export for backward compatibility
+export type { UploadFileOptions };
 
 /**
  * Uploads a file

--- a/src/web/src/services/api/giving.ts
+++ b/src/web/src/services/api/giving.ts
@@ -12,33 +12,12 @@ import type {
   ContributionDto,
   AddContributionRequest,
   UpdateContributionRequest,
+  BatchFilterParams,
+  BatchListResponse,
 } from '@/types/giving';
 
-/**
- * Filter parameters for batch search
- */
-export interface BatchFilterParams {
-  /** Filter by status (Open, Closed, Posted) */
-  status?: string;
-  /** Filter by campus IdKey */
-  campusIdKey?: string;
-  /** Filter by start date (inclusive) */
-  startDate?: string;
-  /** Filter by end date (inclusive) */
-  endDate?: string;
-  /** Page number (1-based) */
-  page?: number;
-  /** Items per page */
-  pageSize?: number;
-}
-
-/**
- * Response envelope for paginated batch results
- */
-export interface BatchListResponse {
-  data: ContributionBatchDto[];
-  meta: PaginationMeta;
-}
+// Re-export for backward compatibility
+export type { BatchFilterParams, BatchListResponse };
 
 // ============================================================================
 // Funds

--- a/src/web/src/services/api/publicGroups.ts
+++ b/src/web/src/services/api/publicGroups.ts
@@ -5,32 +5,10 @@
 
 import { get } from './client';
 import type { PagedResult } from './types';
+import type { PublicGroupDto, PublicGroupSearchParams } from '@/types/group';
 
-export interface PublicGroupDto {
-  idKey: string;
-  name: string;
-  publicDescription?: string;
-  groupTypeName?: string;
-  campusIdKey?: string;
-  campusName?: string;
-  memberCount: number;
-  capacity?: number;
-  hasOpenings: boolean;
-  meetingDay?: string;
-  meetingTime?: string;
-  meetingScheduleSummary?: string;
-}
-
-export interface PublicGroupSearchParams {
-  searchTerm?: string;
-  groupTypeIdKey?: string;
-  campusIdKey?: string;
-  dayOfWeek?: number;
-  timeOfDay?: 0 | 1 | 2;
-  hasOpenings?: boolean;
-  pageNumber?: number;
-  pageSize?: number;
-}
+// Re-export types for backward compatibility
+export type { PublicGroupDto, PublicGroupSearchParams };
 
 /**
  * Search for public groups with filters

--- a/src/web/src/types/communication.ts
+++ b/src/web/src/types/communication.ts
@@ -141,3 +141,16 @@ export interface UpdateCommunicationDto {
   replyToEmail?: string;
   note?: string;
 }
+
+// ============================================================================
+// Query Parameters
+// ============================================================================
+
+/**
+ * Query parameters for listing communications
+ */
+export interface CommunicationsParams {
+  page?: number;
+  pageSize?: number;
+  status?: string;
+}

--- a/src/web/src/types/files.ts
+++ b/src/web/src/types/files.ts
@@ -57,3 +57,14 @@ export interface UploadFileRequest {
   /** Optional file type category IdKey (from DefinedValue) */
   binaryFileTypeIdKey?: string;
 }
+
+/**
+ * Upload options for file upload
+ * Simplified options interface for frontend upload function
+ */
+export interface UploadFileOptions {
+  /** Optional description or alt text */
+  description?: string;
+  /** Optional file type category IdKey (from DefinedValue) */
+  binaryFileTypeIdKey?: string;
+}

--- a/src/web/src/types/giving.ts
+++ b/src/web/src/types/giving.ts
@@ -161,3 +161,38 @@ export interface PersonLookupDto {
   fullName: string;
   email?: string;
 }
+
+// ============================================================================
+// Batch Filter and Response Types
+// ============================================================================
+
+/**
+ * Filter parameters for batch search
+ */
+export interface BatchFilterParams {
+  /** Filter by status (Open, Closed, Posted) */
+  status?: string;
+  /** Filter by campus IdKey */
+  campusIdKey?: string;
+  /** Filter by start date (inclusive) */
+  startDate?: string;
+  /** Filter by end date (inclusive) */
+  endDate?: string;
+  /** Page number (1-based) */
+  page?: number;
+  /** Items per page */
+  pageSize?: number;
+}
+
+/**
+ * Response envelope for paginated batch results
+ */
+export interface BatchListResponse {
+  data: ContributionBatchDto[];
+  meta: {
+    page: number;
+    pageSize: number;
+    totalCount: number;
+    totalPages: number;
+  };
+}

--- a/src/web/src/types/group.ts
+++ b/src/web/src/types/group.ts
@@ -200,3 +200,41 @@ export interface GroupMemberDetailDto {
   inactiveDateTime?: DateTime;
   note?: string;
 }
+
+// ============================================================================
+// Public Group Types
+// ============================================================================
+
+/**
+ * Public group DTO for public-facing group finder.
+ * Contains only information safe to display to unauthenticated users.
+ */
+export interface PublicGroupDto {
+  idKey: string;
+  name: string;
+  publicDescription?: string;
+  groupTypeName?: string;
+  campusIdKey?: string;
+  campusName?: string;
+  memberCount: number;
+  capacity?: number;
+  hasOpenings: boolean;
+  meetingDay?: string;
+  meetingTime?: string;
+  meetingScheduleSummary?: string;
+}
+
+/**
+ * Search parameters for public group finder.
+ * All parameters are optional filters.
+ */
+export interface PublicGroupSearchParams {
+  searchTerm?: string;
+  groupTypeIdKey?: string;
+  campusIdKey?: string;
+  dayOfWeek?: number;
+  timeOfDay?: 0 | 1 | 2;
+  hasOpenings?: boolean;
+  pageNumber?: number;
+  pageSize?: number;
+}

--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-01-02T20:38:19.642112+00:00",
+  "generated_at": "2026-01-02T20:57:03.107725+00:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-01-02T20:38:19.829Z",
+  "generated_at": "2026-01-02T20:57:03.288Z",
   "types": {
     "AttendanceAnalyticsDto": {
       "name": "AttendanceAnalyticsDto",
@@ -618,6 +618,16 @@
       },
       "path": "types/communication.ts"
     },
+    "CommunicationsParams": {
+      "name": "CommunicationsParams",
+      "kind": "interface",
+      "properties": {
+        "page": "number",
+        "pageSize": "number",
+        "status": "string"
+      },
+      "path": "types/communication.ts"
+    },
     "CommunicationType": {
       "name": "CommunicationType",
       "kind": "enum",
@@ -729,6 +739,15 @@
         "fileName": "string",
         "contentType": "string",
         "length": "number",
+        "description": "string",
+        "binaryFileTypeIdKey": "string"
+      },
+      "path": "types/files.ts"
+    },
+    "UploadFileOptions": {
+      "name": "UploadFileOptions",
+      "kind": "interface",
+      "properties": {
         "description": "string",
         "binaryFileTypeIdKey": "string"
       },
@@ -911,6 +930,31 @@
       },
       "path": "types/giving.ts"
     },
+    "BatchFilterParams": {
+      "name": "BatchFilterParams",
+      "kind": "interface",
+      "properties": {
+        "status": "string",
+        "campusIdKey": "string",
+        "startDate": "string",
+        "endDate": "string",
+        "page": "number",
+        "pageSize": "number"
+      },
+      "path": "types/giving.ts"
+    },
+    "BatchListResponse": {
+      "name": "BatchListResponse",
+      "kind": "interface",
+      "properties": {
+        "data": "ContributionBatchDto[]",
+        "meta": "{\n    page: number",
+        "pageSize": "number",
+        "totalCount": "number",
+        "totalPages": "number"
+      },
+      "path": "types/giving.ts"
+    },
     "BatchStatus": {
       "name": "BatchStatus",
       "kind": "enum",
@@ -1055,6 +1099,40 @@
         "note": "string"
       },
       "path": "services/api/types.ts"
+    },
+    "PublicGroupDto": {
+      "name": "PublicGroupDto",
+      "kind": "interface",
+      "properties": {
+        "idKey": "string",
+        "name": "string",
+        "publicDescription": "string",
+        "groupTypeName": "string",
+        "campusIdKey": "string",
+        "campusName": "string",
+        "memberCount": "number",
+        "capacity": "number",
+        "hasOpenings": "boolean",
+        "meetingDay": "string",
+        "meetingTime": "string",
+        "meetingScheduleSummary": "string"
+      },
+      "path": "types/group.ts"
+    },
+    "PublicGroupSearchParams": {
+      "name": "PublicGroupSearchParams",
+      "kind": "interface",
+      "properties": {
+        "searchTerm": "string",
+        "groupTypeIdKey": "string",
+        "campusIdKey": "string",
+        "dayOfWeek": "number",
+        "timeOfDay": "0 | 1 | 2",
+        "hasOpenings": "boolean",
+        "pageNumber": "number",
+        "pageSize": "number"
+      },
+      "path": "types/group.ts"
     },
     "ValidationError": {
       "name": "ValidationError",

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-01-02T20:38:19.991602+00:00",
+  "generated_at": "2026-01-02T20:57:03.444452+00:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -8511,6 +8511,7 @@
     "dto:CampusSummaryDto": "type:CampusSummaryDto",
     "dto:PickupLogDto": "type:PickupLogDto",
     "dto:PickupVerificationResultDto": "type:PickupVerificationResultDto",
+    "dto:PublicGroupDto": "type:PublicGroupDto",
     "dto:RoomCapacityDto": "type:RoomCapacityDto",
     "dto:UpdateCapacitySettingsDto": "type:UpdateCapacitySettingsDto",
     "dto:CapacityOverrideRequestDto": "type:CapacityOverrideRequestDto",
@@ -8525,7 +8526,7 @@
     "dtos": 77,
     "services": 69,
     "controllers": 22,
-    "types": 225,
+    "types": 231,
     "api_functions": 111,
     "hooks": 83,
     "components": 93,


### PR DESCRIPTION
## Summary
Audit and consolidate inline type definitions from API services to central types module.

## Changes
- Move CommunicationsParams to types/communication.ts
- Move PublicGroupDto, PublicGroupSearchParams to types/group.ts
- Move BatchFilterParams, BatchListResponse to types/giving.ts
- Move UploadFileOptions to types/files.ts
- Update API services to import from @/types
- Re-export types for backward compatibility

## Benefits
- Single source of truth for type definitions
- Improved maintainability
- Consistent import patterns

## Test plan
- [x] TypeScript compilation passes
- [x] All existing tests pass
- [x] No breaking changes - backward compatible re-exports

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)