### PR TITLE
feat(communications): add communication detail page

### DIFF
--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -41,6 +41,7 @@ import { PWAUpdatePrompt, InstallPrompt } from './components/pwa';
 import { GroupFinderPage } from './pages/public/GroupFinderPage';
 import { MyGroupsPage } from './pages/MyGroupsPage';
 import { CommunicationsPage } from './pages/communications/CommunicationsPage';
+import { CommunicationDetailPage } from './pages/communications/CommunicationDetailPage';
 import { MyProfilePage } from './pages/profile';
 import { RosterPage } from './pages/admin/RosterPage';
 import { BatchListPage, BatchDetailPage, BatchFormPage } from './pages/admin/giving';
@@ -235,6 +236,7 @@ function App() {
           <Route path="schedules/:idKey/edit" element={<ScheduleFormPage />} />
           <Route path="analytics" element={<AnalyticsPage />} />
           <Route path="communications" element={<CommunicationsPage />} />
+          <Route path="communications/:idKey" element={<CommunicationDetailPage />} />
           <Route path="roster" element={<RosterPage />} />
           <Route path="giving" element={<BatchListPage />} />
           <Route path="giving/new" element={<BatchFormPage />} />

--- a/src/web/src/components/communication/CommunicationStatisticsCard.example.tsx
+++ b/src/web/src/components/communication/CommunicationStatisticsCard.example.tsx
@@ -1,0 +1,67 @@
+/**
+ * Example usage of CommunicationStatisticsCard
+ * This file demonstrates how to use the component in a page
+ */
+
+import { CommunicationStatisticsCard } from './CommunicationStatisticsCard';
+
+export function CommunicationStatisticsExample() {
+  return (
+    <div className="max-w-md">
+      <CommunicationStatisticsCard
+        recipientCount={100}
+        deliveredCount={85}
+        failedCount={5}
+        openedCount={60}
+      />
+    </div>
+  );
+}
+
+/**
+ * Example with all messages delivered
+ */
+export function AllDeliveredExample() {
+  return (
+    <div className="max-w-md">
+      <CommunicationStatisticsCard
+        recipientCount={50}
+        deliveredCount={50}
+        failedCount={0}
+        openedCount={30}
+      />
+    </div>
+  );
+}
+
+/**
+ * Example with pending messages
+ */
+export function PendingMessagesExample() {
+  return (
+    <div className="max-w-md">
+      <CommunicationStatisticsCard
+        recipientCount={100}
+        deliveredCount={60}
+        failedCount={3}
+        openedCount={40}
+      />
+    </div>
+  );
+}
+
+/**
+ * Example with some failures
+ */
+export function WithFailuresExample() {
+  return (
+    <div className="max-w-md">
+      <CommunicationStatisticsCard
+        recipientCount={100}
+        deliveredCount={75}
+        failedCount={25}
+        openedCount={50}
+      />
+    </div>
+  );
+}

--- a/src/web/src/components/communication/CommunicationStatisticsCard.tsx
+++ b/src/web/src/components/communication/CommunicationStatisticsCard.tsx
@@ -1,0 +1,212 @@
+/**
+ * CommunicationStatisticsCard Component
+ * Displays delivery, open, and failure statistics for communication messages
+ * with visual indicators and percentage breakdowns
+ */
+
+export interface CommunicationStatisticsCardProps {
+  recipientCount: number;
+  deliveredCount: number;
+  failedCount: number;
+  openedCount: number;
+}
+
+export function CommunicationStatisticsCard({
+  recipientCount,
+  deliveredCount,
+  failedCount,
+  openedCount,
+}: CommunicationStatisticsCardProps) {
+  // Calculate pending count
+  const pendingCount = recipientCount - deliveredCount - failedCount;
+
+  // Calculate percentages
+  const deliveredPercent = recipientCount > 0 ? (deliveredCount / recipientCount) * 100 : 0;
+  const openedPercent = deliveredCount > 0 ? (openedCount / deliveredCount) * 100 : 0;
+  const failedPercent = recipientCount > 0 ? (failedCount / recipientCount) * 100 : 0;
+  const pendingPercent = recipientCount > 0 ? (pendingCount / recipientCount) * 100 : 0;
+
+  // Format percentage
+  const formatPercent = (value: number): string => {
+    return `${value.toFixed(1)}%`;
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      {/* Header */}
+      <h3 className="text-lg font-semibold text-gray-900 mb-6">Delivery Statistics</h3>
+
+      {/* Total Recipients */}
+      <div className="mb-6">
+        <div className="flex justify-between items-center mb-2">
+          <span className="text-sm font-medium text-gray-700">Total Recipients</span>
+          <span className="text-2xl font-bold text-gray-900">{recipientCount}</span>
+        </div>
+      </div>
+
+      {/* Divider */}
+      <div className="border-t border-gray-200 my-4" />
+
+      {/* Statistics */}
+      <div className="space-y-4">
+        {/* Delivered */}
+        <div>
+          <div className="flex justify-between items-center mb-2">
+            <span className="text-sm font-medium text-gray-700">Delivered</span>
+            <div className="text-right">
+              <span className="text-sm font-semibold text-green-600">{deliveredCount}</span>
+              <span className="text-xs text-gray-500 ml-2">({formatPercent(deliveredPercent)})</span>
+            </div>
+          </div>
+          <div className="w-full bg-gray-200 rounded-full h-2">
+            <div
+              className="bg-green-600 h-2 rounded-full transition-all duration-300"
+              style={{ width: `${deliveredPercent}%` }}
+              role="progressbar"
+              aria-valuenow={deliveredPercent}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={`${formatPercent(deliveredPercent)} delivered`}
+            />
+          </div>
+        </div>
+
+        {/* Opened (only shown if there are delivered messages) */}
+        {deliveredCount > 0 && (
+          <div>
+            <div className="flex justify-between items-center mb-2">
+              <span className="text-sm font-medium text-gray-700">Opened</span>
+              <div className="text-right">
+                <span className="text-sm font-semibold text-green-700">{openedCount}</span>
+                <span className="text-xs text-gray-500 ml-2">({formatPercent(openedPercent)})</span>
+              </div>
+            </div>
+            <div className="w-full bg-gray-200 rounded-full h-2">
+              <div
+                className="bg-green-700 h-2 rounded-full transition-all duration-300"
+                style={{ width: `${openedPercent}%` }}
+                role="progressbar"
+                aria-valuenow={openedPercent}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${formatPercent(openedPercent)} opened`}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Failed */}
+        {failedCount > 0 && (
+          <div>
+            <div className="flex justify-between items-center mb-2">
+              <span className="text-sm font-medium text-gray-700">Failed</span>
+              <div className="text-right">
+                <span className="text-sm font-semibold text-red-600">{failedCount}</span>
+                <span className="text-xs text-gray-500 ml-2">({formatPercent(failedPercent)})</span>
+              </div>
+            </div>
+            <div className="w-full bg-gray-200 rounded-full h-2">
+              <div
+                className="bg-red-600 h-2 rounded-full transition-all duration-300"
+                style={{ width: `${failedPercent}%` }}
+                role="progressbar"
+                aria-valuenow={failedPercent}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${formatPercent(failedPercent)} failed`}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Pending */}
+        {pendingCount > 0 && (
+          <div>
+            <div className="flex justify-between items-center mb-2">
+              <span className="text-sm font-medium text-gray-700">Pending</span>
+              <div className="text-right">
+                <span className="text-sm font-semibold text-gray-600">{pendingCount}</span>
+                <span className="text-xs text-gray-500 ml-2">({formatPercent(pendingPercent)})</span>
+              </div>
+            </div>
+            <div className="w-full bg-gray-200 rounded-full h-2">
+              <div
+                className="bg-gray-400 h-2 rounded-full transition-all duration-300"
+                style={{ width: `${pendingPercent}%` }}
+                role="progressbar"
+                aria-valuenow={pendingPercent}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                aria-label={`${formatPercent(pendingPercent)} pending`}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Summary Indicator */}
+      {recipientCount > 0 && (
+        <>
+          <div className="border-t border-gray-200 my-4" />
+          <div className="flex items-center gap-2">
+            {failedCount === 0 && deliveredCount === recipientCount ? (
+              <>
+                <svg
+                  className="w-5 h-5 text-green-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+                <span className="text-sm font-medium text-green-600">All messages delivered</span>
+              </>
+            ) : failedCount > 0 ? (
+              <>
+                <svg
+                  className="w-5 h-5 text-amber-600"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+                  />
+                </svg>
+                <span className="text-sm font-medium text-amber-600">Some messages failed</span>
+              </>
+            ) : pendingCount > 0 ? (
+              <>
+                <svg
+                  className="w-5 h-5 text-gray-500"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                <span className="text-sm font-medium text-gray-600">Delivery in progress</span>
+              </>
+            ) : null}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/web/src/components/communication/RecipientStatusBadge.tsx
+++ b/src/web/src/components/communication/RecipientStatusBadge.tsx
@@ -1,0 +1,27 @@
+/**
+ * RecipientStatusBadge
+ * Badge component for displaying individual recipient delivery status
+ */
+
+interface RecipientStatusBadgeProps {
+  status: string;
+}
+
+export function RecipientStatusBadge({ status }: RecipientStatusBadgeProps) {
+  const colors: Record<string, string> = {
+    Pending: 'bg-blue-100 text-blue-800',
+    Delivered: 'bg-green-100 text-green-800',
+    Failed: 'bg-red-100 text-red-800',
+    Opened: 'bg-purple-100 text-purple-800',
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+        colors[status] || 'bg-gray-100 text-gray-800'
+      }`}
+    >
+      {status}
+    </span>
+  );
+}

--- a/src/web/src/components/communication/RecipientTable.tsx
+++ b/src/web/src/components/communication/RecipientTable.tsx
@@ -1,0 +1,200 @@
+/**
+ * Recipient Table Component
+ * Displays communication recipients with delivery status and details
+ */
+
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { cn } from '@/lib/utils';
+import { formatDateTime } from '@/lib/utils';
+import { EmptyState } from '@/components/ui';
+import { RecipientStatusBadge } from './RecipientStatusBadge';
+import type { CommunicationRecipientDto } from '@/types/communication';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface RecipientTableProps {
+  recipients: CommunicationRecipientDto[];
+  communicationType: 'Email' | 'Sms';
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function RecipientTable({
+  recipients,
+  communicationType,
+}: RecipientTableProps) {
+  const [expandedRowId, setExpandedRowId] = useState<string | null>(null);
+
+  const handleRowClick = (idKey: string) => {
+    // Only toggle if the recipient has an error message
+    const recipient = recipients.find((r) => r.idKey === idKey);
+    if (recipient?.errorMessage) {
+      setExpandedRowId((current) => (current === idKey ? null : idKey));
+    }
+  };
+
+  const formatDateTimeOrEmpty = (dateTime?: string): string => {
+    if (!dateTime) {
+      return '-';
+    }
+    return formatDateTime(dateTime);
+  };
+
+  const getAddressLabel = (): string => {
+    return communicationType === 'Email' ? 'Email' : 'Phone';
+  };
+
+  // Empty state
+  if (recipients.length === 0) {
+    return (
+      <EmptyState
+        icon={
+          <svg
+            className="w-12 h-12 text-gray-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+            />
+          </svg>
+        }
+        title="No recipients"
+        description="Add recipients to this communication to get started"
+      />
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead className="bg-gray-50">
+          <tr>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Recipient
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              {getAddressLabel()}
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Status
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Delivered
+            </th>
+            <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+              Opened
+            </th>
+          </tr>
+        </thead>
+        <tbody className="bg-white divide-y divide-gray-200">
+          {recipients.map((recipient) => {
+            const isExpanded = expandedRowId === recipient.idKey;
+            const hasError = !!recipient.errorMessage;
+            const isClickable = hasError;
+
+            return (
+              <React.Fragment key={recipient.idKey}>
+                {/* Main Row */}
+                <tr
+                  onClick={() => handleRowClick(recipient.idKey)}
+                  className={cn(
+                    'transition-colors',
+                    isClickable && 'cursor-pointer',
+                    isExpanded ? 'bg-red-50' : isClickable ? 'hover:bg-gray-50' : ''
+                  )}
+                >
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <div className="flex items-center gap-2">
+                      {hasError && (
+                        <svg
+                          className={cn(
+                            'w-4 h-4 text-gray-400 transition-transform',
+                            isExpanded && 'rotate-90'
+                          )}
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M9 5l7 7-7 7"
+                          />
+                        </svg>
+                      )}
+                      <Link
+                        to={`/admin/people/${recipient.personIdKey}`}
+                        className="text-sm font-medium text-primary-600 hover:text-primary-700 transition-colors"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        {recipient.recipientName || 'Unknown'}
+                      </Link>
+                    </div>
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {recipient.address}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap">
+                    <RecipientStatusBadge status={recipient.status} />
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {formatDateTimeOrEmpty(recipient.deliveredDateTime)}
+                  </td>
+                  <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                    {formatDateTimeOrEmpty(recipient.openedDateTime)}
+                  </td>
+                </tr>
+
+                {/* Expanded Error Row */}
+                {isExpanded && hasError && (
+                  <tr className="bg-red-50">
+                    <td colSpan={5} className="px-6 py-4">
+                      <div className="ml-10">
+                        <div className="flex items-start gap-3">
+                          <svg
+                            className="w-5 h-5 text-red-600 mt-0.5 flex-shrink-0"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                            aria-hidden="true"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                            />
+                          </svg>
+                          <div className="flex-1">
+                            <h4 className="text-xs font-semibold text-red-900 uppercase tracking-wider mb-1">
+                              Delivery Error
+                            </h4>
+                            <p className="text-sm text-red-800">
+                              {recipient.errorMessage}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                  </tr>
+                )}
+              </React.Fragment>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/web/src/components/communication/index.ts
+++ b/src/web/src/components/communication/index.ts
@@ -7,3 +7,6 @@ export { MessageTypeToggle } from './MessageTypeToggle';
 export { SmsComposer } from './SmsComposer';
 export { EmailComposer } from './EmailComposer';
 export { CommunicationComposer } from './CommunicationComposer';
+export { CommunicationStatisticsCard } from './CommunicationStatisticsCard';
+export { RecipientStatusBadge } from './RecipientStatusBadge';
+export { RecipientTable } from './RecipientTable';

--- a/src/web/src/pages/communications/CommunicationDetailPage.tsx
+++ b/src/web/src/pages/communications/CommunicationDetailPage.tsx
@@ -1,0 +1,239 @@
+/**
+ * CommunicationDetailPage
+ * View details of a sent communication including recipients and statistics
+ */
+
+import { useParams, Link } from 'react-router-dom';
+import { useCommunication } from '@/hooks/useCommunications';
+import { CommunicationStatisticsCard, RecipientTable } from '@/components/communication';
+
+function CommunicationStatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    Draft: 'bg-gray-100 text-gray-800',
+    Pending: 'bg-blue-100 text-blue-800',
+    Sent: 'bg-green-100 text-green-800',
+    Failed: 'bg-red-100 text-red-800',
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+        colors[status] || 'bg-gray-100 text-gray-800'
+      }`}
+    >
+      {status}
+    </span>
+  );
+}
+
+function CommunicationTypeBadge({ type }: { type: string }) {
+  return (
+    <span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">
+      {type === 'Email' ? (
+        <>
+          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+            />
+          </svg>
+          Email
+        </>
+      ) : (
+        <>
+          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+            />
+          </svg>
+          SMS
+        </>
+      )}
+    </span>
+  );
+}
+
+export function CommunicationDetailPage() {
+  const { idKey } = useParams<{ idKey: string }>();
+  const { data: communication, isLoading, error } = useCommunication(idKey);
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="inline-block w-8 h-8 border-4 border-gray-200 border-t-primary-600 rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  // Error state
+  if (error || !communication) {
+    return (
+      <div className="text-center py-12">
+        <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-red-100 mb-4">
+          <svg
+            className="w-8 h-8 text-red-600"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        </div>
+        <h2 className="text-2xl font-bold text-gray-900 mb-2">Communication Not Found</h2>
+        <p className="text-gray-600 mb-4">
+          The communication you're looking for could not be loaded. It may have been deleted or you
+          may not have access.
+        </p>
+        <Link
+          to="/admin/communications"
+          className="inline-block px-4 py-2 text-primary-600 hover:text-primary-700 font-medium"
+        >
+          Back to Communications
+        </Link>
+      </div>
+    );
+  }
+
+  const sentDate = communication.sentDateTime
+    ? new Date(communication.sentDateTime)
+    : new Date(communication.createdDateTime);
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-start gap-4">
+        <Link
+          to="/admin/communications"
+          className="p-2 text-gray-400 hover:text-gray-600 rounded-lg hover:bg-gray-100 transition-colors"
+          aria-label="Back to communications"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
+        </Link>
+        <div className="flex-1">
+          <h1 className="text-3xl font-bold text-gray-900">
+            {communication.subject || 'SMS Communication'}
+          </h1>
+          <div className="flex items-center gap-3 mt-2">
+            <CommunicationTypeBadge type={communication.communicationType} />
+            <CommunicationStatusBadge status={communication.status} />
+            <span className="text-sm text-gray-600">
+              {sentDate.toLocaleDateString()} at {sentDate.toLocaleTimeString()}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Layout Grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Main Content */}
+        <div className="lg:col-span-2 space-y-6">
+          {/* Recipients Table */}
+          <div className="bg-white rounded-lg border border-gray-200 overflow-hidden">
+            <div className="px-6 py-4 border-b border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900">
+                Recipients ({communication.recipientCount})
+              </h2>
+            </div>
+            <RecipientTable 
+              recipients={communication.recipients} 
+              communicationType={communication.communicationType as 'Email' | 'Sms'}
+            />
+          </div>
+
+          {/* Message Body */}
+          {communication.body && (
+            <div className="bg-white rounded-lg border border-gray-200 p-6">
+              <h2 className="text-lg font-semibold text-gray-900 mb-4">Message</h2>
+              <div className="prose max-w-none">
+                <div
+                  className="text-sm text-gray-700 whitespace-pre-wrap"
+                  dangerouslySetInnerHTML={{ __html: communication.body }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Notes */}
+          {communication.note && (
+            <div className="bg-white rounded-lg border border-gray-200 p-6">
+              <h2 className="text-lg font-semibold text-gray-900 mb-2">Notes</h2>
+              <p className="text-sm text-gray-700 whitespace-pre-wrap">{communication.note}</p>
+            </div>
+          )}
+        </div>
+
+        {/* Sidebar */}
+        <div className="space-y-6">
+          {/* Statistics Card */}
+          <CommunicationStatisticsCard 
+            recipientCount={communication.recipientCount}
+            deliveredCount={communication.deliveredCount}
+            failedCount={communication.failedCount}
+            openedCount={communication.openedCount}
+          />
+
+          {/* Metadata */}
+          <div className="bg-white rounded-lg border border-gray-200 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">Metadata</h2>
+            <dl className="space-y-3 text-sm">
+              <div>
+                <dt className="text-gray-500">Created</dt>
+                <dd className="text-gray-900">
+                  {new Date(communication.createdDateTime).toLocaleDateString()}
+                </dd>
+              </div>
+
+              {communication.fromName && (
+                <div>
+                  <dt className="text-gray-500">From Name</dt>
+                  <dd className="text-gray-900">{communication.fromName}</dd>
+                </div>
+              )}
+
+              {communication.fromEmail && (
+                <div>
+                  <dt className="text-gray-500">From Email</dt>
+                  <dd className="text-gray-900">{communication.fromEmail}</dd>
+                </div>
+              )}
+
+              {communication.replyToEmail && (
+                <div>
+                  <dt className="text-gray-500">Reply To</dt>
+                  <dd className="text-gray-900">{communication.replyToEmail}</dd>
+                </div>
+              )}
+
+              {communication.modifiedDateTime && (
+                <div>
+                  <dt className="text-gray-500">Last Modified</dt>
+                  <dd className="text-gray-900">
+                    {new Date(communication.modifiedDateTime).toLocaleDateString()}
+                  </dd>
+                </div>
+              )}
+            </dl>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/pages/communications/CommunicationsPage.tsx
+++ b/src/web/src/pages/communications/CommunicationsPage.tsx
@@ -4,6 +4,7 @@
  */
 
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useCommunications } from '@/hooks/useCommunications';
 import { useGroups } from '@/hooks/useGroups';
 import { CommunicationComposer } from '@/components/communication/CommunicationComposer';
@@ -73,7 +74,10 @@ function CommunicationRow({ communication }: { communication: CommunicationSumma
   const sentDate = communication.sentDateTime ? new Date(communication.sentDateTime) : null;
 
   return (
-    <div className="bg-white border border-gray-200 rounded-lg p-4 hover:border-primary-300 transition-colors">
+    <Link
+      to={`/admin/communications/${communication.idKey}`}
+      className="block bg-white border border-gray-200 rounded-lg p-4 hover:border-primary-300 transition-colors cursor-pointer"
+    >
       <div className="flex items-start justify-between gap-4">
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-3 mb-2">
@@ -121,7 +125,7 @@ function CommunicationRow({ communication }: { communication: CommunicationSumma
           </div>
         </div>
       </div>
-    </div>
+    </Link>
   );
 }
 

--- a/src/web/src/pages/communications/index.ts
+++ b/src/web/src/pages/communications/index.ts
@@ -4,3 +4,4 @@
  */
 
 export { CommunicationsPage } from './CommunicationsPage';
+export { CommunicationDetailPage } from './CommunicationDetailPage';

--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-01-02T20:57:03.107725+00:00",
+  "generated_at": "2026-01-02T21:38:15.094752+00:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-01-02T20:57:03.288Z",
+  "generated_at": "2026-01-02T21:38:15.283Z",
   "types": {
     "AttendanceAnalyticsDto": {
       "name": "AttendanceAnalyticsDto",
@@ -4999,6 +4999,18 @@
       ],
       "apiCallsDirectly": false
     },
+    "CommunicationStatisticsExample": {
+      "name": "CommunicationStatisticsExample",
+      "path": "components/communication/CommunicationStatisticsCard.example.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "CommunicationStatisticsCard": {
+      "name": "CommunicationStatisticsCard",
+      "path": "components/communication/CommunicationStatisticsCard.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
     "EmailComposer": {
       "name": "EmailComposer",
       "path": "components/communication/EmailComposer.tsx",
@@ -5008,6 +5020,18 @@
     "MessageTypeToggle": {
       "name": "MessageTypeToggle",
       "path": "components/communication/MessageTypeToggle.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "RecipientStatusBadge": {
+      "name": "RecipientStatusBadge",
+      "path": "components/communication/RecipientStatusBadge.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "RecipientTable": {
+      "name": "RecipientTable",
+      "path": "components/communication/RecipientTable.tsx",
       "hooksUsed": [],
       "apiCallsDirectly": false
     },

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-01-02T20:57:03.444452+00:00",
+  "generated_at": "2026-01-02T21:38:15.453326+00:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -7035,6 +7035,18 @@
       ],
       "apiCallsDirectly": false
     },
+    "CommunicationStatisticsExample": {
+      "name": "CommunicationStatisticsExample",
+      "path": "components/communication/CommunicationStatisticsCard.example.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "CommunicationStatisticsCard": {
+      "name": "CommunicationStatisticsCard",
+      "path": "components/communication/CommunicationStatisticsCard.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
     "EmailComposer": {
       "name": "EmailComposer",
       "path": "components/communication/EmailComposer.tsx",
@@ -7044,6 +7056,18 @@
     "MessageTypeToggle": {
       "name": "MessageTypeToggle",
       "path": "components/communication/MessageTypeToggle.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "RecipientStatusBadge": {
+      "name": "RecipientStatusBadge",
+      "path": "components/communication/RecipientStatusBadge.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "RecipientTable": {
+      "name": "RecipientTable",
+      "path": "components/communication/RecipientTable.tsx",
       "hooksUsed": [],
       "apiCallsDirectly": false
     },
@@ -8529,7 +8553,7 @@
     "types": 231,
     "api_functions": 111,
     "hooks": 83,
-    "components": 93,
+    "components": 97,
     "total_edges": 229
   }
 }


### PR DESCRIPTION
## Summary
- Added CommunicationDetailPage for viewing individual communications with delivery statistics
- Created CommunicationStatisticsCard with progress bars showing delivered/opened/failed/pending rates
- Created RecipientTable with expandable rows to view error details for failed messages
- Added RecipientStatusBadge component for visual status indication

Closes #366

## Test plan
- [ ] Navigate to /admin/communications and click a communication row
- [ ] Verify detail page loads with statistics sidebar
- [ ] Verify recipient table shows all recipients with status badges
- [ ] Verify clicking on failed recipient expands to show error message
- [ ] Verify progress bars show correct percentages
- [ ] Verify back navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)