### PR TITLE
feat(dashboard): add giving and communications summary widgets

### DIFF
--- a/src/Koinon.Application/DTOs/DashboardStatsDto.cs
+++ b/src/Koinon.Application/DTOs/DashboardStatsDto.cs
@@ -1,3 +1,5 @@
+using Koinon.Application.DTOs.Giving;
+
 namespace Koinon.Application.DTOs;
 
 /// <summary>
@@ -40,6 +42,16 @@ public record DashboardStatsDto
     /// List of upcoming schedules with their next occurrence times.
     /// </summary>
     public required List<UpcomingScheduleDto> UpcomingSchedules { get; init; }
+
+    /// <summary>
+    /// Giving statistics summary.
+    /// </summary>
+    public required GivingStatsDto GivingStats { get; init; }
+
+    /// <summary>
+    /// Communications statistics summary.
+    /// </summary>
+    public required CommunicationsStatsDto CommunicationsStats { get; init; }
 }
 
 /// <summary>
@@ -68,3 +80,78 @@ public record UpcomingScheduleDto
     /// </summary>
     public required int MinutesUntilCheckIn { get; init; }
 }
+
+/// <summary>
+/// Data transfer object for giving statistics.
+/// </summary>
+public record GivingStatsDto
+{
+    /// <summary>
+    /// Total contributions received this month.
+    /// </summary>
+    public required decimal MonthToDateTotal { get; init; }
+
+    /// <summary>
+    /// Total contributions received this year.
+    /// </summary>
+    public required decimal YearToDateTotal { get; init; }
+
+    /// <summary>
+    /// List of recent open/pending batches (last 5).
+    /// </summary>
+    public required List<DashboardBatchDto> RecentBatches { get; init; }
+}
+
+/// <summary>
+/// Data transfer object for batch information on the dashboard.
+/// </summary>
+public record DashboardBatchDto
+{
+    /// <summary>
+    /// URL-safe identifier for the batch.
+    /// </summary>
+    public required string IdKey { get; init; }
+
+    /// <summary>
+    /// Name of the batch.
+    /// </summary>
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Date of the batch.
+    /// </summary>
+    public required DateTime BatchDate { get; init; }
+
+    /// <summary>
+    /// Status of the batch (e.g., Open, Pending, Closed).
+    /// </summary>
+    public required string Status { get; init; }
+
+    /// <summary>
+    /// Total amount in the batch.
+    /// </summary>
+    public required decimal Total { get; init; }
+}
+
+/// <summary>
+/// Data transfer object for communications statistics.
+/// </summary>
+public record CommunicationsStatsDto
+{
+    /// <summary>
+    /// Count of communications with Pending status.
+    /// </summary>
+    public required int PendingCount { get; init; }
+
+    /// <summary>
+    /// Count of communications sent in the last 7 days.
+    /// </summary>
+    public required int SentThisWeekCount { get; init; }
+
+    /// <summary>
+    /// List of recent communications (last 5).
+    /// </summary>
+    public required List<CommunicationSummaryDto> RecentCommunications { get; init; }
+}
+
+

--- a/src/web/src/components/admin/dashboard/CommunicationsSummaryCard.tsx
+++ b/src/web/src/components/admin/dashboard/CommunicationsSummaryCard.tsx
@@ -1,0 +1,50 @@
+/**
+ * Communications Summary Card Component
+ * Displays pending and sent communications counts
+ */
+
+export interface CommunicationsSummaryCardProps {
+  pendingCount: number;
+  sentThisWeekCount: number;
+}
+
+export function CommunicationsSummaryCard({
+  pendingCount,
+  sentThisWeekCount,
+}: CommunicationsSummaryCardProps) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6" data-testid="communications-summary-card">
+      <div className="flex items-center justify-between">
+        <div className="flex-1">
+          <p className="text-sm font-medium text-gray-600">Communications</p>
+          <div className="mt-3 space-y-2">
+            <div>
+              <p className="text-xs text-gray-500">Pending</p>
+              <p className="text-2xl font-bold text-gray-900">{pendingCount}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500">Sent This Week</p>
+              <p className="text-2xl font-bold text-gray-900">{sentThisWeekCount}</p>
+            </div>
+          </div>
+        </div>
+        <div className="p-3 rounded-lg bg-purple-50 text-purple-600">
+          <svg
+            className="w-8 h-8"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/admin/dashboard/GivingSummaryCard.tsx
+++ b/src/web/src/components/admin/dashboard/GivingSummaryCard.tsx
@@ -1,0 +1,59 @@
+/**
+ * Giving Summary Card Component
+ * Displays month-to-date and year-to-date giving totals
+ */
+
+export interface GivingSummaryCardProps {
+  monthToDateTotal: number;
+  yearToDateTotal: number;
+}
+
+export function GivingSummaryCard({
+  monthToDateTotal,
+  yearToDateTotal,
+}: GivingSummaryCardProps) {
+  const formatCurrency = (amount: number): string => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(amount);
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6" data-testid="giving-summary-card">
+      <div className="flex items-center justify-between">
+        <div className="flex-1">
+          <p className="text-sm font-medium text-gray-600">Giving Summary</p>
+          <div className="mt-3 space-y-2">
+            <div>
+              <p className="text-xs text-gray-500">Month to Date</p>
+              <p className="text-2xl font-bold text-gray-900">{formatCurrency(monthToDateTotal)}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500">Year to Date</p>
+              <p className="text-2xl font-bold text-gray-900">{formatCurrency(yearToDateTotal)}</p>
+            </div>
+          </div>
+        </div>
+        <div className="p-3 rounded-lg bg-green-50 text-green-600">
+          <svg
+            className="w-8 h-8"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+            />
+          </svg>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/admin/dashboard/RecentBatches.tsx
+++ b/src/web/src/components/admin/dashboard/RecentBatches.tsx
@@ -1,0 +1,95 @@
+/**
+ * Recent Batches Component
+ * Displays list of recent giving batches with status indicators
+ */
+
+import { Link } from 'react-router-dom';
+import type { BatchSummary } from '@/types';
+
+export interface RecentBatchesProps {
+  batches: BatchSummary[];
+}
+
+export function RecentBatches({ batches }: RecentBatchesProps) {
+  const formatCurrency = (amount: number): string => {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    }).format(amount);
+  };
+
+  const formatDate = (dateString: string): string => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  const getStatusColor = (status: BatchSummary['status']): string => {
+    switch (status) {
+      case 'Open':
+        return 'text-blue-700 bg-blue-50 border-blue-200';
+      case 'Pending':
+        return 'text-yellow-700 bg-yellow-50 border-yellow-200';
+      case 'Closed':
+        return 'text-green-700 bg-green-50 border-green-200';
+      default:
+        return 'text-gray-700 bg-gray-50 border-gray-200';
+    }
+  };
+
+  if (batches.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Recent Batches</h2>
+        <div className="text-center py-12">
+          <svg
+            className="w-12 h-12 text-gray-400 mx-auto mb-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+            />
+          </svg>
+          <p className="text-gray-500">No recent batches</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">Recent Batches</h2>
+      <div className="space-y-3">
+        {batches.slice(0, 5).map((batch) => (
+          <Link
+            key={batch.idKey}
+            to={`/admin/giving/batches/${batch.idKey}`}
+            className="flex items-center justify-between p-4 rounded-lg border border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-all group"
+          >
+            <div className="flex-1 min-w-0">
+              <h3 className="text-sm font-semibold text-gray-900 group-hover:text-primary-700">
+                {batch.name}
+              </h3>
+              <p className="mt-1 text-sm text-gray-500">
+                {formatDate(batch.batchDate)} • {formatCurrency(batch.total)}
+              </p>
+            </div>
+            <div className={`px-3 py-1 text-xs font-medium rounded-full border ${getStatusColor(batch.status)}`}>
+              {batch.status}
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/admin/dashboard/RecentCommunications.tsx
+++ b/src/web/src/components/admin/dashboard/RecentCommunications.tsx
@@ -1,0 +1,106 @@
+/**
+ * Recent Communications Component
+ * Displays list of recent communications with type and status indicators
+ */
+
+import { Link } from 'react-router-dom';
+import type { CommunicationSummary } from '@/types';
+
+export interface RecentCommunicationsProps {
+  communications: CommunicationSummary[];
+}
+
+export function RecentCommunications({ communications }: RecentCommunicationsProps) {
+  const formatDate = (dateString: string): string => {
+    return new Date(dateString).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  };
+
+  const getTypeColor = (type: CommunicationSummary['type']): string => {
+    switch (type) {
+      case 'Email':
+        return 'text-blue-700 bg-blue-50 border-blue-200';
+      case 'SMS':
+        return 'text-green-700 bg-green-50 border-green-200';
+      case 'Push':
+        return 'text-purple-700 bg-purple-50 border-purple-200';
+      default:
+        return 'text-gray-700 bg-gray-50 border-gray-200';
+    }
+  };
+
+  const getStatusColor = (status: CommunicationSummary['status']): string => {
+    switch (status) {
+      case 'Draft':
+        return 'text-gray-700 bg-gray-50 border-gray-200';
+      case 'Pending':
+        return 'text-yellow-700 bg-yellow-50 border-yellow-200';
+      case 'Sent':
+        return 'text-green-700 bg-green-50 border-green-200';
+      case 'Failed':
+        return 'text-red-700 bg-red-50 border-red-200';
+      default:
+        return 'text-gray-700 bg-gray-50 border-gray-200';
+    }
+  };
+
+  if (communications.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Recent Communications</h2>
+        <div className="text-center py-12">
+          <svg
+            className="w-12 h-12 text-gray-400 mx-auto mb-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+            />
+          </svg>
+          <p className="text-gray-500">No recent communications</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">Recent Communications</h2>
+      <div className="space-y-3">
+        {communications.slice(0, 5).map((communication) => (
+          <Link
+            key={communication.idKey}
+            to={`/admin/communications/${communication.idKey}`}
+            className="flex items-center justify-between p-4 rounded-lg border border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition-all group"
+          >
+            <div className="flex-1 min-w-0">
+              <h3 className="text-sm font-semibold text-gray-900 group-hover:text-primary-700">
+                {communication.subject}
+              </h3>
+              <p className="mt-1 text-sm text-gray-500">
+                {formatDate(communication.createdDateTime)}
+              </p>
+            </div>
+            <div className="flex items-center gap-2">
+              <div className={`px-3 py-1 text-xs font-medium rounded-full border ${getTypeColor(communication.type)}`}>
+                {communication.type}
+              </div>
+              <div className={`px-3 py-1 text-xs font-medium rounded-full border ${getStatusColor(communication.status)}`}>
+                {communication.status}
+              </div>
+            </div>
+          </Link>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/web/src/components/admin/dashboard/index.ts
+++ b/src/web/src/components/admin/dashboard/index.ts
@@ -5,6 +5,14 @@
 export { StatCard } from './StatCard';
 export { QuickActions } from './QuickActions';
 export { UpcomingSchedules } from './UpcomingSchedules';
+export { GivingSummaryCard } from './GivingSummaryCard';
+export { RecentBatches } from './RecentBatches';
+export { CommunicationsSummaryCard } from './CommunicationsSummaryCard';
+export { RecentCommunications } from './RecentCommunications';
 
 export type { StatCardProps } from './StatCard';
 export type { UpcomingSchedulesProps } from './UpcomingSchedules';
+export type { GivingSummaryCardProps } from './GivingSummaryCard';
+export type { RecentBatchesProps } from './RecentBatches';
+export type { CommunicationsSummaryCardProps } from './CommunicationsSummaryCard';
+export type { RecentCommunicationsProps } from './RecentCommunications';

--- a/src/web/src/pages/admin/DashboardPage.tsx
+++ b/src/web/src/pages/admin/DashboardPage.tsx
@@ -4,7 +4,15 @@
  */
 
 import { useDashboardStats } from '@/hooks/useDashboard';
-import { StatCard, QuickActions, UpcomingSchedules } from '@/components/admin/dashboard';
+import {
+  StatCard,
+  QuickActions,
+  UpcomingSchedules,
+  GivingSummaryCard,
+  RecentBatches,
+  CommunicationsSummaryCard,
+  RecentCommunications,
+} from '@/components/admin/dashboard';
 import { ErrorState } from '@/components/ui';
 
 export function DashboardPage() {
@@ -140,6 +148,36 @@ export function DashboardPage() {
         schedules={stats?.upcomingSchedules ?? []}
         isLoading={isLoading}
       />
+
+      {/* Giving Overview */}
+      {stats?.givingStats && (
+        <section>
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">Giving Overview</h2>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <GivingSummaryCard
+              monthToDateTotal={stats.givingStats.monthToDateTotal}
+              yearToDateTotal={stats.givingStats.yearToDateTotal}
+            />
+            <RecentBatches batches={stats.givingStats.recentBatches} />
+          </div>
+        </section>
+      )}
+
+      {/* Communications Overview */}
+      {stats?.communicationsStats && (
+        <section>
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">Communications Overview</h2>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <CommunicationsSummaryCard
+              pendingCount={stats.communicationsStats.pendingCount}
+              sentThisWeekCount={stats.communicationsStats.sentThisWeekCount}
+            />
+            <RecentCommunications
+              communications={stats.communicationsStats.recentCommunications}
+            />
+          </div>
+        </section>
+      )}
     </div>
   );
 }

--- a/src/web/src/types/dashboard.ts
+++ b/src/web/src/types/dashboard.ts
@@ -20,6 +20,46 @@ export interface UpcomingScheduleDto {
 }
 
 /**
+ * Batch summary for dashboard display
+ */
+export interface BatchSummary {
+  idKey: string;
+  name: string;
+  batchDate: string;
+  status: 'Open' | 'Pending' | 'Closed';
+  total: number;
+}
+
+/**
+ * Giving statistics for dashboard
+ */
+export interface GivingStats {
+  monthToDateTotal: number;
+  yearToDateTotal: number;
+  recentBatches: BatchSummary[];
+}
+
+/**
+ * Communication summary for dashboard display
+ */
+export interface CommunicationSummary {
+  idKey: string;
+  subject: string;
+  type: 'Email' | 'SMS' | 'Push';
+  status: 'Draft' | 'Pending' | 'Sent' | 'Failed';
+  createdDateTime: string;
+}
+
+/**
+ * Communications statistics for dashboard
+ */
+export interface CommunicationsStats {
+  pendingCount: number;
+  sentThisWeekCount: number;
+  recentCommunications: CommunicationSummary[];
+}
+
+/**
  * Dashboard statistics overview
  */
 export interface DashboardStatsDto {
@@ -30,4 +70,6 @@ export interface DashboardStatsDto {
   lastWeekCheckIns: number;
   activeSchedules: number;
   upcomingSchedules: UpcomingScheduleDto[];
+  givingStats?: GivingStats;
+  communicationsStats?: CommunicationsStats;
 }

--- a/tests/Koinon.Api.Tests/Controllers/DashboardControllerTests.cs
+++ b/tests/Koinon.Api.Tests/Controllers/DashboardControllerTests.cs
@@ -50,6 +50,18 @@ public class DashboardControllerTests
                     NextOccurrence = DateTime.UtcNow.AddDays(1),
                     MinutesUntilCheckIn = 60
                 }
+            },
+            GivingStats = new GivingStatsDto
+            {
+                MonthToDateTotal = 0m,
+                YearToDateTotal = 0m,
+                RecentBatches = new List<DashboardBatchDto>()
+            },
+            CommunicationsStats = new CommunicationsStatsDto
+            {
+                PendingCount = 0,
+                SentThisWeekCount = 0,
+                RecentCommunications = new List<CommunicationSummaryDto>()
             }
         };
 
@@ -109,7 +121,19 @@ public class DashboardControllerTests
             TodayCheckIns = 0,
             LastWeekCheckIns = 0,
             ActiveSchedules = 0,
-            UpcomingSchedules = new List<UpcomingScheduleDto>()
+            UpcomingSchedules = new List<UpcomingScheduleDto>(),
+            GivingStats = new GivingStatsDto
+            {
+                MonthToDateTotal = 0m,
+                YearToDateTotal = 0m,
+                RecentBatches = new List<DashboardBatchDto>()
+            },
+            CommunicationsStats = new CommunicationsStatsDto
+            {
+                PendingCount = 0,
+                SentThisWeekCount = 0,
+                RecentCommunications = new List<CommunicationSummaryDto>()
+            }
         };
 
         _dashboardServiceMock

--- a/tests/Koinon.Application.Tests/Services/DashboardServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/DashboardServiceTests.cs
@@ -1,6 +1,7 @@
 using FluentAssertions;
 using Koinon.Application.Services;
 using Koinon.Domain.Entities;
+using Koinon.Domain.Enums;
 using Koinon.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
@@ -274,6 +275,477 @@ public class DashboardServiceTests : IDisposable
             schedule.MinutesUntilCheckIn.Should().NotBe(0); // Should have a calculated value
         }
     }
+
+    #region Giving Stats Tests
+
+    [Fact]
+    public async Task GetStatsAsync_GivingStats_CalculatesMTDTotalCorrectly()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var currentMonth = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc);
+        var lastMonth = currentMonth.AddMonths(-1);
+
+        // Add defined values for transaction type and source
+        var transactionType = new DefinedValue { Id = 100, Value = "Cash", DefinedTypeId = 1, CreatedDateTime = now };
+        var sourceType = new DefinedValue { Id = 101, Value = "Website", DefinedTypeId = 2, CreatedDateTime = now };
+        _context.DefinedValues.AddRange(transactionType, sourceType);
+
+        // Add a batch
+        var batch = new ContributionBatch
+        {
+            Id = 1,
+            Name = "Test Batch",
+            BatchDate = currentMonth,
+            Status = BatchStatus.Open,
+            CreatedDateTime = now
+        };
+        _context.ContributionBatches.Add(batch);
+
+        // Add fund
+        var fund = new Fund { Id = 1, Name = "General Fund", IsActive = true, CreatedDateTime = now };
+        _context.Funds.Add(fund);
+
+        // Add contributions - some in current month, some in previous month
+        var contribution1 = new Contribution
+        {
+            Id = 1,
+            TransactionDateTime = currentMonth.AddDays(5),
+            TransactionTypeValueId = 100,
+            SourceTypeValueId = 101,
+            BatchId = 1,
+            CreatedDateTime = now
+        };
+        var contribution2 = new Contribution
+        {
+            Id = 2,
+            TransactionDateTime = currentMonth.AddDays(10),
+            TransactionTypeValueId = 100,
+            SourceTypeValueId = 101,
+            BatchId = 1,
+            CreatedDateTime = now
+        };
+        var contribution3 = new Contribution
+        {
+            Id = 3,
+            TransactionDateTime = lastMonth.AddDays(5),
+            TransactionTypeValueId = 100,
+            SourceTypeValueId = 101,
+            CreatedDateTime = now
+        };
+        _context.Contributions.AddRange(contribution1, contribution2, contribution3);
+
+        // Add contribution details
+        var detail1 = new ContributionDetail { Id = 1, ContributionId = 1, FundId = 1, Amount = 100.00m, CreatedDateTime = now };
+        var detail2 = new ContributionDetail { Id = 2, ContributionId = 2, FundId = 1, Amount = 250.00m, CreatedDateTime = now };
+        var detail3 = new ContributionDetail { Id = 3, ContributionId = 3, FundId = 1, Amount = 500.00m, CreatedDateTime = now }; // Last month - should not count
+        _context.ContributionDetails.AddRange(detail1, detail2, detail3);
+
+        await _context.SaveChangesAsync();
+
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.GivingStats.Should().NotBeNull();
+        stats.GivingStats.MonthToDateTotal.Should().Be(350.00m); // Only current month contributions
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_GivingStats_CalculatesYTDTotalCorrectly()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var currentYear = new DateTime(now.Year, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var lastYear = currentYear.AddYears(-1);
+
+        // Add defined values
+        var transactionType = new DefinedValue { Id = 100, Value = "Cash", DefinedTypeId = 1, CreatedDateTime = now };
+        var sourceType = new DefinedValue { Id = 101, Value = "Website", DefinedTypeId = 2, CreatedDateTime = now };
+        _context.DefinedValues.AddRange(transactionType, sourceType);
+
+        // Add fund
+        var fund = new Fund { Id = 1, Name = "General Fund", IsActive = true, CreatedDateTime = now };
+        _context.Funds.Add(fund);
+
+        // Add contributions - some in current year, some in previous year
+        var contribution1 = new Contribution
+        {
+            Id = 1,
+            TransactionDateTime = currentYear.AddMonths(1),
+            TransactionTypeValueId = 100,
+            SourceTypeValueId = 101,
+            CreatedDateTime = now
+        };
+        var contribution2 = new Contribution
+        {
+            Id = 2,
+            TransactionDateTime = currentYear.AddMonths(3),
+            TransactionTypeValueId = 100,
+            SourceTypeValueId = 101,
+            CreatedDateTime = now
+        };
+        var contribution3 = new Contribution
+        {
+            Id = 3,
+            TransactionDateTime = lastYear.AddMonths(6),
+            TransactionTypeValueId = 100,
+            SourceTypeValueId = 101,
+            CreatedDateTime = now
+        };
+        _context.Contributions.AddRange(contribution1, contribution2, contribution3);
+
+        // Add contribution details
+        var detail1 = new ContributionDetail { Id = 1, ContributionId = 1, FundId = 1, Amount = 100.00m, CreatedDateTime = now };
+        var detail2 = new ContributionDetail { Id = 2, ContributionId = 2, FundId = 1, Amount = 250.00m, CreatedDateTime = now };
+        var detail3 = new ContributionDetail { Id = 3, ContributionId = 3, FundId = 1, Amount = 1000.00m, CreatedDateTime = now }; // Last year - should not count
+        _context.ContributionDetails.AddRange(detail1, detail2, detail3);
+
+        await _context.SaveChangesAsync();
+
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.GivingStats.Should().NotBeNull();
+        stats.GivingStats.YearToDateTotal.Should().Be(350.00m); // Only current year contributions
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_GivingStats_ReturnsLast5BatchesOrderedByDate()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+
+        // Add 7 batches with different dates
+        var batches = new List<ContributionBatch>();
+        for (int i = 1; i <= 7; i++)
+        {
+            batches.Add(new ContributionBatch
+            {
+                Id = i,
+                Name = $"Batch {i}",
+                BatchDate = now.AddDays(-i),
+                Status = i % 2 == 0 ? BatchStatus.Closed : BatchStatus.Open,
+                CreatedDateTime = now
+            });
+        }
+        _context.ContributionBatches.AddRange(batches);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.GivingStats.Should().NotBeNull();
+        stats.GivingStats.RecentBatches.Should().HaveCount(5); // Maximum 5 batches
+
+        // Verify ordering by BatchDate descending (most recent first)
+        for (int i = 0; i < stats.GivingStats.RecentBatches.Count - 1; i++)
+        {
+            stats.GivingStats.RecentBatches[i].BatchDate.Should().BeOnOrAfter(stats.GivingStats.RecentBatches[i + 1].BatchDate);
+        }
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_GivingStats_CalculatesBatchTotalsCorrectly()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+
+        // Add defined values
+        var transactionType = new DefinedValue { Id = 100, Value = "Cash", DefinedTypeId = 1, CreatedDateTime = now };
+        var sourceType = new DefinedValue { Id = 101, Value = "Website", DefinedTypeId = 2, CreatedDateTime = now };
+        _context.DefinedValues.AddRange(transactionType, sourceType);
+
+        // Add batch
+        var batch = new ContributionBatch
+        {
+            Id = 1,
+            Name = "Test Batch",
+            BatchDate = now,
+            Status = BatchStatus.Open,
+            CreatedDateTime = now
+        };
+        _context.ContributionBatches.Add(batch);
+
+        // Add fund
+        var fund = new Fund { Id = 1, Name = "General Fund", IsActive = true, CreatedDateTime = now };
+        _context.Funds.Add(fund);
+
+        // Add contributions to the batch
+        var contribution1 = new Contribution
+        {
+            Id = 1,
+            TransactionDateTime = now,
+            TransactionTypeValueId = 100,
+            SourceTypeValueId = 101,
+            BatchId = 1,
+            CreatedDateTime = now
+        };
+        var contribution2 = new Contribution
+        {
+            Id = 2,
+            TransactionDateTime = now,
+            TransactionTypeValueId = 100,
+            SourceTypeValueId = 101,
+            BatchId = 1,
+            CreatedDateTime = now
+        };
+        _context.Contributions.AddRange(contribution1, contribution2);
+
+        // Add contribution details
+        var detail1 = new ContributionDetail { Id = 1, ContributionId = 1, FundId = 1, Amount = 125.50m, CreatedDateTime = now };
+        var detail2 = new ContributionDetail { Id = 2, ContributionId = 2, FundId = 1, Amount = 274.50m, CreatedDateTime = now };
+        _context.ContributionDetails.AddRange(detail1, detail2);
+
+        await _context.SaveChangesAsync();
+
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.GivingStats.Should().NotBeNull();
+        stats.GivingStats.RecentBatches.Should().HaveCount(1);
+        stats.GivingStats.RecentBatches[0].Total.Should().Be(400.00m); // Sum of both contributions
+        stats.GivingStats.RecentBatches[0].IdKey.Should().NotBeNullOrEmpty();
+        stats.GivingStats.RecentBatches[0].Name.Should().Be("Test Batch");
+        stats.GivingStats.RecentBatches[0].Status.Should().Be("Open");
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_GivingStats_ExcludesPostedBatches()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+
+        // Add batches with different statuses
+        var openBatch = new ContributionBatch
+        {
+            Id = 1,
+            Name = "Open Batch",
+            BatchDate = now,
+            Status = BatchStatus.Open,
+            CreatedDateTime = now
+        };
+        var closedBatch = new ContributionBatch
+        {
+            Id = 2,
+            Name = "Closed Batch",
+            BatchDate = now.AddDays(-1),
+            Status = BatchStatus.Closed,
+            CreatedDateTime = now
+        };
+        var postedBatch = new ContributionBatch
+        {
+            Id = 3,
+            Name = "Posted Batch",
+            BatchDate = now.AddDays(-2),
+            Status = BatchStatus.Posted,
+            CreatedDateTime = now
+        };
+        _context.ContributionBatches.AddRange(openBatch, closedBatch, postedBatch);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.GivingStats.Should().NotBeNull();
+        stats.GivingStats.RecentBatches.Should().HaveCount(2); // Only Open and Closed, not Posted
+        stats.GivingStats.RecentBatches.Should().Contain(b => b.Name == "Open Batch");
+        stats.GivingStats.RecentBatches.Should().Contain(b => b.Name == "Closed Batch");
+        stats.GivingStats.RecentBatches.Should().NotContain(b => b.Name == "Posted Batch");
+    }
+
+    #endregion
+
+    #region Communications Stats Tests
+
+    [Fact]
+    public async Task GetStatsAsync_CommunicationsStats_CountsPendingCommunicationsCorrectly()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+
+        // Add communications with different statuses
+        var pending1 = new Communication
+        {
+            Id = 1,
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Pending,
+            Body = "Test message 1",
+            CreatedDateTime = now
+        };
+        var pending2 = new Communication
+        {
+            Id = 2,
+            CommunicationType = CommunicationType.Sms,
+            Status = CommunicationStatus.Pending,
+            Body = "Test message 2",
+            CreatedDateTime = now
+        };
+        var sent = new Communication
+        {
+            Id = 3,
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Sent,
+            Body = "Test message 3",
+            CreatedDateTime = now
+        };
+        var draft = new Communication
+        {
+            Id = 4,
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Draft,
+            Body = "Test message 4",
+            CreatedDateTime = now
+        };
+        _context.Communications.AddRange(pending1, pending2, sent, draft);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.CommunicationsStats.Should().NotBeNull();
+        stats.CommunicationsStats.PendingCount.Should().Be(2); // Only pending communications
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_CommunicationsStats_CountsSentThisWeekCorrectly()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+        var sixDaysAgo = now.AddDays(-6);
+        var eightDaysAgo = now.AddDays(-8);
+
+        // Add communications - some within last 7 days, some older
+        var sentRecent1 = new Communication
+        {
+            Id = 1,
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Sent,
+            Body = "Recent 1",
+            CreatedDateTime = sixDaysAgo
+        };
+        var sentRecent2 = new Communication
+        {
+            Id = 2,
+            CommunicationType = CommunicationType.Sms,
+            Status = CommunicationStatus.Sent,
+            Body = "Recent 2",
+            CreatedDateTime = now.AddDays(-3)
+        };
+        var sentOld = new Communication
+        {
+            Id = 3,
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Sent,
+            Body = "Old",
+            CreatedDateTime = eightDaysAgo
+        };
+        var pendingRecent = new Communication
+        {
+            Id = 4,
+            CommunicationType = CommunicationType.Email,
+            Status = CommunicationStatus.Pending,
+            Body = "Pending",
+            CreatedDateTime = now.AddDays(-2)
+        };
+        _context.Communications.AddRange(sentRecent1, sentRecent2, sentOld, pendingRecent);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.CommunicationsStats.Should().NotBeNull();
+        stats.CommunicationsStats.SentThisWeekCount.Should().Be(2); // Only sent within last 7 days
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_CommunicationsStats_ReturnsLast5CommunicationsOrderedByCreatedDateTime()
+    {
+        // Arrange
+        var now = DateTime.UtcNow;
+
+        // Add 7 communications with different created dates
+        var communications = new List<Communication>();
+        for (int i = 1; i <= 7; i++)
+        {
+            communications.Add(new Communication
+            {
+                Id = i,
+                CommunicationType = CommunicationType.Email,
+                Status = CommunicationStatus.Sent,
+                Subject = $"Communication {i}",
+                Body = $"Body {i}",
+                RecipientCount = i * 10,
+                DeliveredCount = i * 8,
+                FailedCount = i * 2,
+                CreatedDateTime = now.AddDays(-i)
+            });
+        }
+        _context.Communications.AddRange(communications);
+        await _context.SaveChangesAsync();
+
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.CommunicationsStats.Should().NotBeNull();
+        stats.CommunicationsStats.RecentCommunications.Should().HaveCount(5); // Maximum 5
+
+        // Verify ordering by CreatedDateTime descending (most recent first)
+        for (int i = 0; i < stats.CommunicationsStats.RecentCommunications.Count - 1; i++)
+        {
+            stats.CommunicationsStats.RecentCommunications[i].CreatedDateTime
+                .Should().BeOnOrAfter(stats.CommunicationsStats.RecentCommunications[i + 1].CreatedDateTime);
+        }
+
+        // Verify first communication has correct data
+        var firstComm = stats.CommunicationsStats.RecentCommunications[0];
+        firstComm.IdKey.Should().NotBeNullOrEmpty();
+        firstComm.Subject.Should().Be("Communication 1");
+        firstComm.CommunicationType.Should().Be("Email");
+        firstComm.Status.Should().Be("Sent");
+        firstComm.RecipientCount.Should().Be(10);
+        firstComm.DeliveredCount.Should().Be(8);
+        firstComm.FailedCount.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_CommunicationsStats_WithNoData_ReturnsZeroCounts()
+    {
+        // Arrange - no communications in database (using existing empty state)
+
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.CommunicationsStats.Should().NotBeNull();
+        stats.CommunicationsStats.PendingCount.Should().Be(0);
+        stats.CommunicationsStats.SentThisWeekCount.Should().Be(0);
+        stats.CommunicationsStats.RecentCommunications.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task GetStatsAsync_GivingStats_WithNoData_ReturnsZeroTotals()
+    {
+        // Arrange - no contributions in database (using existing empty state)
+
+        // Act
+        var stats = await _service.GetStatsAsync(CancellationToken.None);
+
+        // Assert
+        stats.GivingStats.Should().NotBeNull();
+        stats.GivingStats.MonthToDateTotal.Should().Be(0);
+        stats.GivingStats.YearToDateTotal.Should().Be(0);
+        stats.GivingStats.RecentBatches.Should().BeEmpty();
+    }
+
+    #endregion
 
     public void Dispose()
     {

--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1331,6 +1331,22 @@
       "namespace": "Koinon.Application.DTOs",
       "properties": {}
     },
+    "GivingStatsDto": {
+      "name": "GivingStatsDto",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {}
+    },
+    "DashboardBatchDto": {
+      "name": "DashboardBatchDto",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {}
+    },
+    "CommunicationsStatsDto": {
+      "name": "CommunicationsStatsDto",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {},
+      "linked_entity": "Communication"
+    },
     "FamilyDto": {
       "name": "FamilyDto",
       "namespace": "Koinon.Application.DTOs",
@@ -5481,6 +5497,11 @@
       "relationship": "maps_to"
     },
     {
+      "source": "CommunicationsStatsDto",
+      "target": "Communication",
+      "relationship": "maps_to"
+    },
+    {
       "source": "FamilyDto",
       "target": "Family",
       "relationship": "maps_to"
@@ -6533,9 +6554,9 @@
   ],
   "summary": {
     "total_entities": 43,
-    "total_dtos": 90,
+    "total_dtos": 93,
     "total_services": 75,
     "total_controllers": 25,
-    "total_relationships": 226
+    "total_relationships": 227
   }
 }

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -852,6 +852,50 @@
       },
       "path": "types/dashboard.ts"
     },
+    "BatchSummary": {
+      "name": "BatchSummary",
+      "kind": "interface",
+      "properties": {
+        "idKey": "string",
+        "name": "string",
+        "batchDate": "string",
+        "status": "'Open' | 'Pending' | 'Closed'",
+        "total": "number"
+      },
+      "path": "types/dashboard.ts"
+    },
+    "GivingStats": {
+      "name": "GivingStats",
+      "kind": "interface",
+      "properties": {
+        "monthToDateTotal": "number",
+        "yearToDateTotal": "number",
+        "recentBatches": "BatchSummary[]"
+      },
+      "path": "types/dashboard.ts"
+    },
+    "CommunicationSummary": {
+      "name": "CommunicationSummary",
+      "kind": "interface",
+      "properties": {
+        "idKey": "string",
+        "subject": "string",
+        "type": "'Email' | 'SMS' | 'Push'",
+        "status": "'Draft' | 'Pending' | 'Sent' | 'Failed'",
+        "createdDateTime": "string"
+      },
+      "path": "types/dashboard.ts"
+    },
+    "CommunicationsStats": {
+      "name": "CommunicationsStats",
+      "kind": "interface",
+      "properties": {
+        "pendingCount": "number",
+        "sentThisWeekCount": "number",
+        "recentCommunications": "CommunicationSummary[]"
+      },
+      "path": "types/dashboard.ts"
+    },
     "DashboardStatsDto": {
       "name": "DashboardStatsDto",
       "kind": "interface",
@@ -862,7 +906,9 @@
         "todayCheckIns": "number",
         "lastWeekCheckIns": "number",
         "activeSchedules": "number",
-        "upcomingSchedules": "UpcomingScheduleDto[]"
+        "upcomingSchedules": "UpcomingScheduleDto[]",
+        "givingStats": "GivingStats",
+        "communicationsStats": "CommunicationsStats"
       },
       "path": "types/dashboard.ts"
     },
@@ -5504,9 +5550,33 @@
       ],
       "apiCallsDirectly": false
     },
+    "CommunicationsSummaryCard": {
+      "name": "CommunicationsSummaryCard",
+      "path": "components/admin/dashboard/CommunicationsSummaryCard.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "GivingSummaryCard": {
+      "name": "GivingSummaryCard",
+      "path": "components/admin/dashboard/GivingSummaryCard.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
     "QuickActions": {
       "name": "QuickActions",
       "path": "components/admin/dashboard/QuickActions.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "RecentBatches": {
+      "name": "RecentBatches",
+      "path": "components/admin/dashboard/RecentBatches.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "RecentCommunications": {
+      "name": "RecentCommunications",
+      "path": "components/admin/dashboard/RecentCommunications.tsx",
       "hooksUsed": [],
       "apiCallsDirectly": false
     },

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1331,6 +1331,22 @@
       "namespace": "Koinon.Application.DTOs",
       "properties": {}
     },
+    "GivingStatsDto": {
+      "name": "GivingStatsDto",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {}
+    },
+    "DashboardBatchDto": {
+      "name": "DashboardBatchDto",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {}
+    },
+    "CommunicationsStatsDto": {
+      "name": "CommunicationsStatsDto",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {},
+      "linked_entity": "Communication"
+    },
     "FamilyDto": {
       "name": "FamilyDto",
       "namespace": "Koinon.Application.DTOs",
@@ -7813,9 +7829,33 @@
       ],
       "apiCallsDirectly": false
     },
+    "CommunicationsSummaryCard": {
+      "name": "CommunicationsSummaryCard",
+      "path": "components/admin/dashboard/CommunicationsSummaryCard.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "GivingSummaryCard": {
+      "name": "GivingSummaryCard",
+      "path": "components/admin/dashboard/GivingSummaryCard.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
     "QuickActions": {
       "name": "QuickActions",
       "path": "components/admin/dashboard/QuickActions.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "RecentBatches": {
+      "name": "RecentBatches",
+      "path": "components/admin/dashboard/RecentBatches.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "RecentCommunications": {
+      "name": "RecentCommunications",
+      "path": "components/admin/dashboard/RecentCommunications.tsx",
       "hooksUsed": [],
       "apiCallsDirectly": false
     },
@@ -8474,6 +8514,11 @@
     },
     {
       "source": "CommunicationTemplateSummaryDto",
+      "target": "Communication",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "CommunicationsStatsDto",
       "target": "Communication",
       "relationship": "maps_to"
     },
@@ -9767,6 +9812,8 @@
     "dto:UpdateCommunicationTemplateDto": "type:UpdateCommunicationTemplateDto",
     "dto:DashboardStatsDto": "type:DashboardStatsDto",
     "dto:UpcomingScheduleDto": "type:UpcomingScheduleDto",
+    "dto:GivingStatsDto": "type:GivingStats",
+    "dto:CommunicationsStatsDto": "type:CommunicationsStats",
     "dto:FamilyDto": "type:FamilyDto",
     "dto:FamilyMemberDto": "type:FamilyMemberDto",
     "dto:AddressDto": "type:AddressDto",
@@ -9818,13 +9865,13 @@
   },
   "stats": {
     "entities": 43,
-    "dtos": 90,
+    "dtos": 93,
     "services": 75,
     "controllers": 25,
-    "types": 248,
+    "types": 252,
     "api_functions": 133,
     "hooks": 106,
-    "components": 109,
-    "total_edges": 266
+    "components": 113,
+    "total_edges": 267
   }
 }


### PR DESCRIPTION
## Summary
- Extended DashboardStatsDto with GivingStats and CommunicationsStats
- Added giving metrics: MTD/YTD totals, recent batches with calculated totals
- Added communications metrics: pending count, sent this week, recent items
- Created 4 React dashboard widgets for giving and communications display
- Updated DashboardPage to render new widgets in responsive grid layout

## Changes
- **Backend**: Extended dashboard service with giving and communications queries
- **Frontend**: 4 new widget components (GivingSummaryCard, RecentBatches, CommunicationsSummaryCard, RecentCommunications)
- **Tests**: 11 new unit tests for dashboard service methods

## Test plan
- [x] Backend builds with 0 errors
- [x] All 966 backend tests pass
- [x] Frontend type check passes
- [x] All 189 frontend tests pass
- [x] ESLint passes with 0 warnings
- [x] Code-critic review passed

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)