### PR TITLE
feat(communications): enhance email sending service

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -41,6 +41,7 @@
     <PackageVersion Include="Hangfire.Core" Version="1.8.17" />
     <PackageVersion Include="Hangfire.AspNetCore" Version="1.8.17" />
     <PackageVersion Include="Hangfire.PostgreSql" Version="1.20.11" />
+    <PackageVersion Include="Polly" Version="8.5.0" />
   </ItemGroup>
   <!-- ===================================================================== -->
   <!-- API Layer -->

--- a/src/Koinon.Api/appsettings.Development.json
+++ b/src/Koinon.Api/appsettings.Development.json
@@ -13,5 +13,14 @@
   },
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=koinon;Username=koinon;Password=koinon"
+  },
+  "Smtp": {
+    "Host": "localhost",
+    "Port": 1025,
+    "Username": "",
+    "Password": "",
+    "UseSsl": false,
+    "FromAddress": "dev@localhost",
+    "FromName": "Koinon Dev"
   }
 }

--- a/src/Koinon.Api/appsettings.json
+++ b/src/Koinon.Api/appsettings.json
@@ -17,5 +17,14 @@
     "Audience": "Koinon.Web",
     "AccessTokenExpirationMinutes": 15,
     "RefreshTokenExpirationDays": 7
+  },
+  "Smtp": {
+    "Host": "smtp.example.com",
+    "Port": 587,
+    "Username": "",
+    "Password": "",
+    "UseSsl": true,
+    "FromAddress": "noreply@koinon.church",
+    "FromName": "Koinon Church"
   }
 }

--- a/src/Koinon.Application/DTOs/Communications/EmailAttachmentDto.cs
+++ b/src/Koinon.Application/DTOs/Communications/EmailAttachmentDto.cs
@@ -1,0 +1,9 @@
+namespace Koinon.Application.DTOs.Communications;
+
+/// <summary>
+/// Represents an email attachment.
+/// </summary>
+public record EmailAttachmentDto(
+    string FileName,
+    byte[] Content,
+    string ContentType);

--- a/src/Koinon.Application/Interfaces/IEmailSender.cs
+++ b/src/Koinon.Application/Interfaces/IEmailSender.cs
@@ -1,3 +1,5 @@
+using Koinon.Application.DTOs.Communications;
+
 namespace Koinon.Application.Interfaces;
 
 /// <summary>
@@ -14,6 +16,8 @@ public interface IEmailSender
     /// <param name="fromName">Sender name (optional).</param>
     /// <param name="subject">Email subject.</param>
     /// <param name="bodyHtml">HTML body content.</param>
+    /// <param name="bodyText">Plain text body content (optional).</param>
+    /// <param name="attachments">Email attachments (optional).</param>
     /// <param name="replyToAddress">Reply-to email address (optional).</param>
     /// <param name="ct">Cancellation token.</param>
     /// <returns>True if sent successfully, false otherwise.</returns>
@@ -24,6 +28,8 @@ public interface IEmailSender
         string? fromName,
         string subject,
         string bodyHtml,
+        string? bodyText = null,
+        IEnumerable<EmailAttachmentDto>? attachments = null,
         string? replyToAddress = null,
         CancellationToken ct = default);
 }

--- a/src/Koinon.Application/Services/CommunicationSender.cs
+++ b/src/Koinon.Application/Services/CommunicationSender.cs
@@ -248,7 +248,9 @@ public class CommunicationSender(
             fromName,
             subject,
             bodyHtml,
-            replyToAddress,
-            cancellationToken);
+            bodyText: null,
+            attachments: null,
+            replyToAddress: replyToAddress,
+            ct: cancellationToken);
     }
 }

--- a/src/Koinon.Infrastructure/Koinon.Infrastructure.csproj
+++ b/src/Koinon.Infrastructure/Koinon.Infrastructure.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Hangfire.AspNetCore" />
     <PackageReference Include="Hangfire.PostgreSql" />
     <PackageReference Include="AspNetCore.HealthChecks.Hangfire" />
+    <PackageReference Include="Polly" />
   </ItemGroup>
 
 </Project>

--- a/tests/Koinon.Application.Tests/Services/CommunicationSenderTests.cs
+++ b/tests/Koinon.Application.Tests/Services/CommunicationSenderTests.cs
@@ -208,6 +208,8 @@ public class CommunicationSenderTests : IDisposable
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<IEnumerable<Koinon.Application.DTOs.Communications.EmailAttachmentDto>>(),
+                It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
@@ -229,13 +231,15 @@ public class CommunicationSenderTests : IDisposable
 
         _mockEmailSender.Verify(
             e => e.SendEmailAsync(
-                "john@example.com",
-                "John Doe",
-                "noreply@example.com",
-                "Test Sender",
-                "Test Subject",
-                "<p>Test email body</p>",
-                "reply@example.com",
+                "john@example.com",          // toAddress
+                "John Doe",                  // toName
+                "noreply@example.com",       // fromAddress
+                "Test Sender",               // fromName
+                "Test Subject",              // subject
+                "<p>Test email body</p>",    // bodyHtml
+                null,                         // bodyText
+                null,                         // attachments
+                "reply@example.com",         // replyToAddress
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
@@ -408,6 +412,8 @@ public class CommunicationSenderTests : IDisposable
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<IEnumerable<Koinon.Application.DTOs.Communications.EmailAttachmentDto>>(),
                 It.IsAny<string>(),
                 It.IsAny<CancellationToken>()),
             Times.Never);
@@ -609,6 +615,8 @@ public class CommunicationSenderTests : IDisposable
                 It.IsAny<string>(),
                 It.IsAny<string>(),
                 It.IsAny<string>(),
+                It.IsAny<IEnumerable<Koinon.Application.DTOs.Communications.EmailAttachmentDto>>(),
+                It.IsAny<string>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(true);
 
@@ -628,13 +636,15 @@ public class CommunicationSenderTests : IDisposable
 
         _mockEmailSender.Verify(
             e => e.SendEmailAsync(
-                "john@example.com",
-                "John Doe",
-                "noreply@example.com",
-                "Test Sender",
-                "Welcome John!",
-                "<p>Hello John Doe, welcome to our community.</p>",
-                It.IsAny<string>(),
+                "john@example.com",                                              // toAddress
+                "John Doe",                                                      // toName
+                "noreply@example.com",                                           // fromAddress
+                "Test Sender",                                                   // fromName
+                "Welcome John!",                                                 // subject
+                "<p>Hello John Doe, welcome to our community.</p>",              // bodyHtml
+                null,                                                             // bodyText
+                null,                                                             // attachments
+                It.IsAny<string>(),                                              // replyToAddress
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "Should send email with personalized subject and body");

--- a/tests/Koinon.Infrastructure.Tests/Services/SmtpEmailSenderTests.cs
+++ b/tests/Koinon.Infrastructure.Tests/Services/SmtpEmailSenderTests.cs
@@ -1,0 +1,541 @@
+using FluentAssertions;
+using Koinon.Application.DTOs.Communications;
+using Koinon.Infrastructure.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Infrastructure.Tests.Services;
+
+/// <summary>
+/// Tests for SmtpEmailSender service.
+/// These tests focus on configuration handling and parameter validation.
+/// SMTP client behavior is integration-tested separately due to MailKit's concrete SmtpClient.
+/// </summary>
+public class SmtpEmailSenderTests
+{
+    private readonly Mock<IConfiguration> _mockConfiguration;
+    private readonly Mock<ILogger<SmtpEmailSender>> _mockLogger;
+
+    public SmtpEmailSenderTests()
+    {
+        _mockConfiguration = new Mock<IConfiguration>();
+        _mockLogger = new Mock<ILogger<SmtpEmailSender>>();
+    }
+
+    private SmtpEmailSender CreateService()
+    {
+        return new SmtpEmailSender(_mockConfiguration.Object, _mockLogger.Object);
+    }
+
+    [Fact]
+    public void Constructor_WithValidDependencies_ShouldSucceed()
+    {
+        // Arrange & Act
+        var service = CreateService();
+
+        // Assert
+        service.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_MissingSmtpHost_ShouldUseLocalhostDefault()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns((string?)null);
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("25");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("false");
+
+        var service = CreateService();
+
+        // Act - This will fail to connect (no SMTP server), but we can verify the configuration logic
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>");
+
+        // Assert - Should return false (connection will fail), but we verify it attempted with defaults
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_InvalidPort_Uses587Default()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("invalid-port");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("true");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>");
+
+        // Assert - Should log warning about invalid port and use default
+        result.Should().BeFalse();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Invalid SMTP port configuration")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_MissingPort_Uses587Default()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns((string?)null);
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("true");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>");
+
+        // Assert
+        result.Should().BeFalse();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Invalid SMTP port configuration")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_InvalidUseSsl_UsesTrueDefault()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("587");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("not-a-boolean");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>");
+
+        // Assert - Should log warning about invalid UseSsl and use default
+        result.Should().BeFalse();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Invalid SMTP UseSsl configuration")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_MissingUseSsl_UsesTrueDefault()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("587");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns((string?)null);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>");
+
+        // Assert
+        result.Should().BeFalse();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Invalid SMTP UseSsl configuration")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_NoCredentials_SkipsAuthentication()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("25");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("false");
+        _mockConfiguration.Setup(c => c["Smtp:Username"]).Returns((string?)null);
+        _mockConfiguration.Setup(c => c["Smtp:Password"]).Returns((string?)null);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>");
+
+        // Assert - Should attempt to send without authentication (will fail without real server)
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithCredentials_AttemptsAuthentication()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("587");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("true");
+        _mockConfiguration.Setup(c => c["Smtp:Username"]).Returns("user@example.com");
+        _mockConfiguration.Setup(c => c["Smtp:Password"]).Returns("password123");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>");
+
+        // Assert - Should attempt authentication (will fail without real server)
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithPlainTextBody_ShouldIncludeBothFormats()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("25");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("false");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>HTML Body</p>",
+            bodyText: "Plain Text Body");
+
+        // Assert
+        result.Should().BeFalse(); // No real SMTP server
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithAttachments_ShouldIncludeAllAttachments()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("25");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("false");
+
+        var service = CreateService();
+
+        var attachments = new List<EmailAttachmentDto>
+        {
+            new EmailAttachmentDto(
+                FileName: "document.pdf",
+                Content: new byte[] { 0x25, 0x50, 0x44, 0x46 }, // PDF header
+                ContentType: "application/pdf"),
+            new EmailAttachmentDto(
+                FileName: "image.jpg",
+                Content: new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 }, // JPEG header
+                ContentType: "image/jpeg")
+        };
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test with Attachments",
+            bodyHtml: "<p>See attached files</p>",
+            attachments: attachments);
+
+        // Assert
+        result.Should().BeFalse(); // No real SMTP server
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithReplyTo_ShouldSetReplyToHeader()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("25");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("false");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>",
+            replyToAddress: "replyto@example.com");
+
+        // Assert
+        result.Should().BeFalse(); // No real SMTP server
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithoutToName_ShouldUseEmailAsName()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("25");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("false");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: null,
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>");
+
+        // Assert
+        result.Should().BeFalse(); // No real SMTP server
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithoutFromName_ShouldUseEmailAsName()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("25");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("false");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: null,
+            subject: "Test",
+            bodyHtml: "<p>Test</p>");
+
+        // Assert
+        result.Should().BeFalse(); // No real SMTP server
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithEmptyReplyTo_ShouldNotSetReplyToHeader()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("25");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("false");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>",
+            replyToAddress: "");
+
+        // Assert
+        result.Should().BeFalse(); // No real SMTP server
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithNullAttachments_ShouldSucceed()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("25");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("false");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>",
+            attachments: null);
+
+        // Assert
+        result.Should().BeFalse(); // No real SMTP server
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithEmptyAttachmentsList_ShouldSucceed()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("25");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("false");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>",
+            attachments: new List<EmailAttachmentDto>());
+
+        // Assert
+        result.Should().BeFalse(); // No real SMTP server
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_ConnectionFailure_ShouldReturnFalse()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("invalid-host-that-does-not-exist.local");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("25");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("false");
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>");
+
+        // Assert
+        result.Should().BeFalse();
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("after retries")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_WithCancellationToken_ShouldThrowOperationCanceledException()
+    {
+        // Arrange
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns("localhost");
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns("25");
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns("false");
+
+        var service = CreateService();
+        var cts = new CancellationTokenSource();
+        cts.Cancel(); // Cancel immediately
+
+        // Act & Assert
+        await Assert.ThrowsAsync<OperationCanceledException>(async () =>
+        {
+            await service.SendEmailAsync(
+                toAddress: "test@example.com",
+                toName: "Test User",
+                fromAddress: "sender@example.com",
+                fromName: "Sender",
+                subject: "Test",
+                bodyHtml: "<p>Test</p>",
+                ct: cts.Token);
+        });
+    }
+
+    [Fact]
+    public async Task SendEmailAsync_AllConfigurationDefaults_ShouldUseAllDefaults()
+    {
+        // Arrange - No configuration values set
+        _mockConfiguration.Setup(c => c["Smtp:Host"]).Returns((string?)null);
+        _mockConfiguration.Setup(c => c["Smtp:Port"]).Returns((string?)null);
+        _mockConfiguration.Setup(c => c["Smtp:UseSsl"]).Returns((string?)null);
+        _mockConfiguration.Setup(c => c["Smtp:Username"]).Returns((string?)null);
+        _mockConfiguration.Setup(c => c["Smtp:Password"]).Returns((string?)null);
+
+        var service = CreateService();
+
+        // Act
+        var result = await service.SendEmailAsync(
+            toAddress: "test@example.com",
+            toName: "Test User",
+            fromAddress: "sender@example.com",
+            fromName: "Sender",
+            subject: "Test",
+            bodyHtml: "<p>Test</p>");
+
+        // Assert - Should use defaults: localhost:587, SSL=true, no auth
+        result.Should().BeFalse();
+
+        // Verify warnings for missing configuration
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Invalid SMTP port configuration")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+
+        _mockLogger.Verify(
+            x => x.Log(
+                LogLevel.Warning,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, t) => v.ToString()!.Contains("Invalid SMTP UseSsl configuration")),
+                It.IsAny<Exception>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
- Extended IEmailSender interface to support plain text body and attachments
- Created EmailAttachmentDto record for managing email attachments
- Updated SmtpEmailSender to incorporate Polly v8 retry policy for transient failures
- Added SMTP configuration options to appsettings (host, port, credentials, SSL)
- Implemented 19 unit tests for the updated SmtpEmailSender

## Technical Details
- Utilized ResiliencePipeline from Polly v8.5.0 for enhanced fault tolerance
- Applied exponential backoff retry policy (1s, 2s, 4s) for SocketException and SmtpProtocolException
- Integrated MailKit for handling multipart emails and attachments

## Test plan
- [x] All 1044 backend tests pass
- [x] All 189 frontend tests pass
- [ ] CI validates

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)