### PR TITLE
docs(api-contracts): fix LoginRequest field from username to email (#423)

### DIFF
--- a/docs/reference/api-contracts.md
+++ b/docs/reference/api-contracts.md
@@ -79,7 +79,7 @@ Authenticate and receive JWT tokens.
 **Request:**
 ```typescript
 interface LoginRequest {
-  username: string;
+  email: string;
   password: string;
 }
 ```


### PR DESCRIPTION
## Summary
Fixes API contract documentation mismatch where LoginRequest specified `username` but implementation uses `email`.

## Changes
- Updated `docs/reference/api-contracts.md` to change LoginRequest field from `username` to `email`

## Verification
- Backend implementation: `LoginRequest.cs` uses `Email` property
- Frontend implementation: `types.ts` uses `email` property
- Documentation now matches actual implementation

Fixes #423