### PR TITLE
feat(security): add role-based authorization to pager next-number endpoint (#431)

### DIFF
--- a/src/Koinon.Api/Controllers/PagerController.cs
+++ b/src/Koinon.Api/Controllers/PagerController.cs
@@ -187,13 +187,15 @@ public class PagerController(
     /// <summary>
     /// Gets the next available pager number for a campus.
     /// Used during check-in to assign pager numbers sequentially.
+    /// Restricted to Supervisor role.
     /// </summary>
     /// <param name="campusId">Optional campus IdKey for scoping</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns>Next available pager number (starting at 100)</returns>
     /// <response code="200">Returns next available pager number</response>
-    /// <response code="401">Not authenticated</response>
+    /// <response code="401">Not authenticated or not authorized</response>
     [HttpGet("next-number")]
+    [Authorize(Roles = "Supervisor")]
     [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
     public async Task<IActionResult> GetNextPagerNumber(


### PR DESCRIPTION
## Summary
Adds role-based authorization to the pager next-number endpoint to prevent unauthorized access to pager sequence information.

## Security Issue
The `GET /api/v1/pager/next-number` endpoint currently requires only authentication, allowing any authenticated user to see pager numbers being assigned. This endpoint should be restricted to supervisors.

## Changes
- **PagerController.cs**: Added `[Authorize(Roles = "Supervisor")]` to GetNextPagerNumber endpoint
  - Updated XML documentation to indicate role restriction
  - Updated 401 response description to include authorization requirement

## Impact
- Low severity - information disclosure only
- Aligns with other pager endpoints which all require Supervisor role
- Prevents non-supervisors from seeing pager sequence activity

## Testing
- [x] Backend builds successfully
- [ ] CI tests pass
- [ ] 401 response for non-supervisor users
- [ ] 200 response for supervisor users

Fixes #431