### PR TITLE
test(api): add missing controller tests (#430)

### DIFF
--- a/tests/Koinon.Api.Tests/Controllers/AuthControllerTests.cs
+++ b/tests/Koinon.Api.Tests/Controllers/AuthControllerTests.cs
@@ -1,0 +1,235 @@
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Koinon.Api.Controllers;
+using Koinon.Application.DTOs;
+using Koinon.Application.DTOs.Auth;
+using Koinon.Application.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Api.Tests.Controllers;
+
+public class AuthControllerTests
+{
+    private readonly Mock<IAuthService> _authServiceMock;
+    private readonly Mock<IValidator<LoginRequest>> _loginValidatorMock;
+    private readonly Mock<ILogger<AuthController>> _loggerMock;
+    private readonly AuthController _controller;
+
+    public AuthControllerTests()
+    {
+        _authServiceMock = new Mock<IAuthService>();
+        _loginValidatorMock = new Mock<IValidator<LoginRequest>>();
+        _loggerMock = new Mock<ILogger<AuthController>>();
+
+        _controller = new AuthController(
+            _authServiceMock.Object,
+            _loginValidatorMock.Object,
+            _loggerMock.Object);
+
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+    }
+
+    [Fact]
+    public async Task Login_WithValidCredentials_ReturnsOkWithTokens()
+    {
+        // Arrange
+        var request = new LoginRequest("test@example.com", "Password123!");
+        var expectedResponse = new TokenResponse(
+            AccessToken: "access_token_jwt",
+            RefreshToken: "refresh_token",
+            ExpiresAt: DateTime.UtcNow.AddHours(1),
+            User: new PersonSummaryDto
+            {
+                IdKey = "abc123",
+                FirstName = "Test",
+                LastName = "User",
+                FullName = "Test User",
+                Gender = "Male",
+                Email = "test@example.com"
+            });
+
+        _loginValidatorMock
+            .Setup(v => v.ValidateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        _authServiceMock
+            .Setup(s => s.LoginAsync(request, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Login(request, CancellationToken.None);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value!;
+        var dataProperty = response.GetType().GetProperty("data");
+        var tokenResponse = dataProperty!.GetValue(response).Should().BeOfType<TokenResponse>().Subject;
+
+        tokenResponse.AccessToken.Should().Be("access_token_jwt");
+        tokenResponse.RefreshToken.Should().Be("refresh_token");
+        tokenResponse.User.Email.Should().Be("test@example.com");
+    }
+
+    [Fact]
+    public async Task Login_WithInvalidCredentials_ReturnsUnauthorized()
+    {
+        // Arrange
+        var request = new LoginRequest("test@example.com", "WrongPassword");
+
+        _loginValidatorMock
+            .Setup(v => v.ValidateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult());
+
+        _authServiceMock
+            .Setup(s => s.LoginAsync(request, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TokenResponse?)null);
+
+        // Act
+        var result = await _controller.Login(request, CancellationToken.None);
+
+        // Assert
+        var unauthorizedResult = result.Should().BeOfType<UnauthorizedObjectResult>().Subject;
+        var problemDetails = unauthorizedResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status401Unauthorized);
+        problemDetails.Detail.Should().Contain("Invalid email or password");
+    }
+
+    [Fact]
+    public async Task Login_WithValidationErrors_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new LoginRequest("invalid-email", "");
+        var validationFailures = new List<ValidationFailure>
+        {
+            new("Email", "Email is not valid"),
+            new("Password", "Password is required")
+        };
+
+        _loginValidatorMock
+            .Setup(v => v.ValidateAsync(request, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidationResult(validationFailures));
+
+        // Act
+        var result = await _controller.Login(request, CancellationToken.None);
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ValidationProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+        problemDetails.Errors.Should().ContainKey("Email");
+        problemDetails.Errors.Should().ContainKey("Password");
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithValidToken_ReturnsOkWithNewTokens()
+    {
+        // Arrange
+        var request = new RefreshTokenRequest("valid_refresh_token");
+        var expectedResponse = new TokenResponse(
+            AccessToken: "new_access_token",
+            RefreshToken: "new_refresh_token",
+            ExpiresAt: DateTime.UtcNow.AddHours(1),
+            User: new PersonSummaryDto
+            {
+                IdKey = "abc123",
+                FirstName = "Test",
+                LastName = "User",
+                FullName = "Test User",
+                Gender = "Male",
+                Email = "test@example.com"
+            });
+
+        _authServiceMock
+            .Setup(s => s.RefreshTokenAsync("valid_refresh_token", It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.RefreshToken(request, CancellationToken.None);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value!;
+        var dataProperty = response.GetType().GetProperty("data");
+        var tokenResponse = dataProperty!.GetValue(response).Should().BeOfType<TokenResponse>().Subject;
+
+        tokenResponse.AccessToken.Should().Be("new_access_token");
+        tokenResponse.RefreshToken.Should().Be("new_refresh_token");
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithMissingToken_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new RefreshTokenRequest("");
+
+        // Act
+        var result = await _controller.RefreshToken(request, CancellationToken.None);
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+        problemDetails.Detail.Should().Contain("Refresh token is required");
+    }
+
+    [Fact]
+    public async Task RefreshToken_WithInvalidToken_ReturnsUnauthorized()
+    {
+        // Arrange
+        var request = new RefreshTokenRequest("invalid_or_expired_token");
+
+        _authServiceMock
+            .Setup(s => s.RefreshTokenAsync("invalid_or_expired_token", It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TokenResponse?)null);
+
+        // Act
+        var result = await _controller.RefreshToken(request, CancellationToken.None);
+
+        // Assert
+        var unauthorizedResult = result.Should().BeOfType<UnauthorizedObjectResult>().Subject;
+        var problemDetails = unauthorizedResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status401Unauthorized);
+        problemDetails.Detail.Should().Contain("Invalid or expired refresh token");
+    }
+
+    [Fact]
+    public async Task Logout_WithValidToken_ReturnsNoContent()
+    {
+        // Arrange
+        var request = new RefreshTokenRequest("valid_refresh_token");
+
+        _authServiceMock
+            .Setup(s => s.LogoutAsync("valid_refresh_token", It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act
+        var result = await _controller.Logout(request, CancellationToken.None);
+
+        // Assert
+        result.Should().BeOfType<NoContentResult>();
+    }
+
+    [Fact]
+    public async Task Logout_WithMissingToken_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new RefreshTokenRequest("");
+
+        // Act
+        var result = await _controller.Logout(request, CancellationToken.None);
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var problemDetails = badRequestResult.Value.Should().BeOfType<ProblemDetails>().Subject;
+        problemDetails.Status.Should().Be(StatusCodes.Status400BadRequest);
+        problemDetails.Detail.Should().Contain("Refresh token is required");
+    }
+}

--- a/tests/Koinon.Api.Tests/Controllers/SearchControllerTests.cs
+++ b/tests/Koinon.Api.Tests/Controllers/SearchControllerTests.cs
@@ -1,0 +1,217 @@
+using FluentAssertions;
+using Koinon.Api.Controllers;
+using Koinon.Application.DTOs;
+using Koinon.Application.Interfaces;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Api.Tests.Controllers;
+
+public class SearchControllerTests
+{
+    private readonly Mock<IGlobalSearchService> _searchServiceMock;
+    private readonly Mock<ILogger<SearchController>> _loggerMock;
+    private readonly SearchController _controller;
+
+    public SearchControllerTests()
+    {
+        _searchServiceMock = new Mock<IGlobalSearchService>();
+        _loggerMock = new Mock<ILogger<SearchController>>();
+
+        _controller = new SearchController(
+            _searchServiceMock.Object,
+            _loggerMock.Object);
+
+        _controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext()
+        };
+    }
+
+    [Fact]
+    public async Task Search_WithValidQuery_ReturnsOkWithResults()
+    {
+        // Arrange
+        const string query = "john";
+        var expectedResults = new List<GlobalSearchResultDto>
+        {
+            new("People", "abc123", "John Doe", "john.doe@example.com", null),
+            new("Families", "def456", "Doe Family", "123 Main St", null)
+        };
+
+        var expectedResponse = new GlobalSearchResponse(
+            Results: expectedResults,
+            TotalCount: 2,
+            PageNumber: 1,
+            PageSize: 20,
+            CategoryCounts: new Dictionary<string, int>
+            {
+                { "People", 1 },
+                { "Families", 1 },
+                { "Groups", 0 }
+            });
+
+        _searchServiceMock
+            .Setup(s => s.SearchAsync(query, null, 1, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Search(query, null, 1, 20, CancellationToken.None);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value.Should().BeOfType<GlobalSearchResponse>().Subject;
+
+        response.Results.Should().HaveCount(2);
+        response.TotalCount.Should().Be(2);
+        response.Results.First().Title.Should().Be("John Doe");
+    }
+
+    [Fact]
+    public async Task Search_WithEmptyQuery_ReturnsBadRequest()
+    {
+        // Arrange
+        const string query = "";
+
+        // Act
+        var result = await _controller.Search(query, null, 1, 20, CancellationToken.None);
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var response = badRequestResult.Value!;
+        var errorProperty = response.GetType().GetProperty("error");
+        var error = errorProperty!.GetValue(response).Should().BeOfType<string>().Subject;
+        error.Should().Contain("Query parameter 'q' is required");
+    }
+
+    [Fact]
+    public async Task Search_WithShortQuery_ReturnsBadRequest()
+    {
+        // Arrange
+        const string query = "a";
+
+        // Act
+        var result = await _controller.Search(query, null, 1, 20, CancellationToken.None);
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var response = badRequestResult.Value!;
+        var errorProperty = response.GetType().GetProperty("error");
+        var error = errorProperty!.GetValue(response).Should().BeOfType<string>().Subject;
+        error.Should().Contain("Query must be at least 2 characters long");
+    }
+
+    [Fact]
+    public async Task Search_WithInvalidCategory_ReturnsBadRequest()
+    {
+        // Arrange
+        const string query = "john";
+        const string invalidCategory = "InvalidCategory";
+
+        // Act
+        var result = await _controller.Search(query, invalidCategory, 1, 20, CancellationToken.None);
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var response = badRequestResult.Value!;
+        var errorProperty = response.GetType().GetProperty("error");
+        var error = errorProperty!.GetValue(response).Should().BeOfType<string>().Subject;
+        error.Should().Contain("Invalid category");
+        error.Should().Contain("People, Families, Groups");
+    }
+
+    [Fact]
+    public async Task Search_WithValidCategory_ReturnsFilteredResults()
+    {
+        // Arrange
+        const string query = "john";
+        const string category = "People";
+        var expectedResults = new List<GlobalSearchResultDto>
+        {
+            new("People", "abc123", "John Doe", "john.doe@example.com", null)
+        };
+
+        var expectedResponse = new GlobalSearchResponse(
+            Results: expectedResults,
+            TotalCount: 1,
+            PageNumber: 1,
+            PageSize: 20,
+            CategoryCounts: new Dictionary<string, int>
+            {
+                { "People", 1 },
+                { "Families", 0 },
+                { "Groups", 0 }
+            });
+
+        _searchServiceMock
+            .Setup(s => s.SearchAsync(query, category, 1, 20, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Search(query, category, 1, 20, CancellationToken.None);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value.Should().BeOfType<GlobalSearchResponse>().Subject;
+
+        response.Results.Should().HaveCount(1);
+        response.Results.First().Category.Should().Be("People");
+        response.CategoryCounts["People"].Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Search_WithInvalidPageNumber_ReturnsBadRequest()
+    {
+        // Arrange
+        const string query = "john";
+        const int invalidPageNumber = 0;
+
+        // Act
+        var result = await _controller.Search(query, null, invalidPageNumber, 20, CancellationToken.None);
+
+        // Assert
+        var badRequestResult = result.Should().BeOfType<BadRequestObjectResult>().Subject;
+        var response = badRequestResult.Value!;
+        var errorProperty = response.GetType().GetProperty("error");
+        var error = errorProperty!.GetValue(response).Should().BeOfType<string>().Subject;
+        error.Should().Contain("Page number must be at least 1");
+    }
+
+    [Fact]
+    public async Task Search_WithLargePageSize_ClampsTo100()
+    {
+        // Arrange
+        const string query = "john";
+        const int largePageSize = 500;
+        var expectedResponse = new GlobalSearchResponse(
+            Results: new List<GlobalSearchResultDto>(),
+            TotalCount: 0,
+            PageNumber: 1,
+            PageSize: 100, // Should be clamped
+            CategoryCounts: new Dictionary<string, int>
+            {
+                { "People", 0 },
+                { "Families", 0 },
+                { "Groups", 0 }
+            });
+
+        _searchServiceMock
+            .Setup(s => s.SearchAsync(query, null, 1, 100, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedResponse);
+
+        // Act
+        var result = await _controller.Search(query, null, 1, largePageSize, CancellationToken.None);
+
+        // Assert
+        var okResult = result.Should().BeOfType<OkObjectResult>().Subject;
+        var response = okResult.Value.Should().BeOfType<GlobalSearchResponse>().Subject;
+
+        response.PageSize.Should().Be(100);
+        _searchServiceMock.Verify(
+            s => s.SearchAsync(query, null, 1, 100, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}


### PR DESCRIPTION
## Summary
Add comprehensive unit tests for AuthController and SearchController to improve test coverage and regression protection.

**Closes #430**

## Changes

### AuthControllerTests.cs (8 test cases)
- `Login_WithValidCredentials_ReturnsOkWithTokens` - Validates successful authentication returns TokenResponse
- `Login_WithInvalidCredentials_ReturnsUnauthorized` - Validates invalid credentials return 401
- `Login_WithValidationErrors_ReturnsBadRequest` - Validates FluentValidation integration
- `RefreshToken_WithValidToken_ReturnsOkWithNewTokens` - Validates token rotation
- `RefreshToken_WithMissingToken_ReturnsBadRequest` - Validates empty token rejection
- `RefreshToken_WithInvalidToken_ReturnsUnauthorized` - Validates expired token handling
- `Logout_WithValidToken_ReturnsNoContent` - Validates successful logout returns 204
- `Logout_WithMissingToken_ReturnsBadRequest` - Validates logout validation

### SearchControllerTests.cs (7 test cases)
- `Search_WithValidQuery_ReturnsOkWithResults` - Validates multi-entity search
- `Search_WithEmptyQuery_ReturnsBadRequest` - Validates query requirement
- `Search_WithShortQuery_ReturnsBadRequest` - Validates 2-character minimum
- `Search_WithInvalidCategory_ReturnsBadRequest` - Validates category enum (People/Families/Groups)
- `Search_WithValidCategory_ReturnsFilteredResults` - Validates category filtering
- `Search_WithInvalidPageNumber_ReturnsBadRequest` - Validates page >= 1
- `Search_WithLargePageSize_ClampsTo100` - Validates page size maximum

## Test Coverage
- Total new tests: **15 test cases** (8 auth + 7 search)
- Backend test count: **1,352 tests** (previously 1,337)
- Pattern: Follows established CampusesControllerTests.cs conventions
- Frameworks: Moq + FluentAssertions + xUnit

## Pre-Push Validation
All checks passed locally (131s):
- ✅ Backend build
- ✅ Backend tests (1,352 total, 0 failures)
- ✅ Frontend type check
- ✅ Frontend lint
- ✅ Frontend tests (189 total)
- ✅ Graph validation

## Review Notes
- **Code-critic review**: 0 issues found (2 files, 1 pass, 3min)
- **Ollama first-pass**: Minor suggestions (magic strings, test coverage) - not blocking
- Tests use reflection to extract anonymous response objects (matches existing pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)