### PR TITLE
feat(graph): Link Financial/Giving DTOs to graph baseline (#471)

### DIFF
--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-01-24T19:15:33.109846+00:00",
+  "generated_at": "2026-01-25T16:08:58.498892+00:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -2030,7 +2030,8 @@
         "MonthToDateTotal": "decimal",
         "YearToDateTotal": "decimal",
         "RecentBatches": "List<DashboardBatchDto>"
-      }
+      },
+      "linked_entity": "Contribution"
     },
     "DashboardBatchDto": {
       "name": "DashboardBatchDto",
@@ -2231,7 +2232,8 @@
         "ItemCountVariance": "int?",
         "Variance": "decimal",
         "IsBalanced": "bool"
-      }
+      },
+      "linked_entity": "ContributionBatch"
     },
     "ContributionBatchDto": {
       "name": "ContributionBatchDto",
@@ -2304,7 +2306,8 @@
         "FundName": "string",
         "Amount": "decimal",
         "CheckNumber": "string?"
-      }
+      },
+      "linked_entity": "ContributionStatement"
     },
     "GenerateStatementRequest": {
       "name": "GenerateStatementRequest",
@@ -2313,7 +2316,8 @@
         "PersonIdKey": "string",
         "StartDate": "DateTime",
         "EndDate": "DateTime"
-      }
+      },
+      "linked_entity": "ContributionStatement"
     },
     "BatchStatementRequest": {
       "name": "BatchStatementRequest",
@@ -2322,7 +2326,8 @@
         "StartDate": "DateTime",
         "EndDate": "DateTime",
         "MinimumAmount": "decimal"
-      }
+      },
+      "linked_entity": "ContributionStatement"
     },
     "StatementPreviewDto": {
       "name": "StatementPreviewDto",
@@ -2337,7 +2342,8 @@
         "Contributions": "List<StatementContributionDto>",
         "ChurchName": "string",
         "ChurchAddress": "string"
-      }
+      },
+      "linked_entity": "ContributionStatement"
     },
     "EligiblePersonDto": {
       "name": "EligiblePersonDto",
@@ -2347,7 +2353,8 @@
         "PersonName": "string",
         "TotalAmount": "decimal",
         "ContributionCount": "int"
-      }
+      },
+      "linked_entity": "ContributionStatement"
     },
     "FundDto": {
       "name": "FundDto",
@@ -3357,7 +3364,8 @@
         "ControlItemCount": "int?",
         "CampusIdKey": "string?",
         "Note": "string?"
-      }
+      },
+      "linked_entity": "ContributionBatch"
     },
     "AddContributionRequest": {
       "name": "AddContributionRequest",
@@ -3379,7 +3387,8 @@
         "FundIdKey": "string",
         "Amount": "decimal",
         "Summary": "string?"
-      }
+      },
+      "linked_entity": "ContributionDetail"
     },
     "UpdateContributionRequest": {
       "name": "UpdateContributionRequest",
@@ -3404,7 +3413,8 @@
         "EndDate": "DateTime?",
         "PageNumber": "int",
         "PageSize": "int"
-      }
+      },
+      "linked_entity": "ContributionBatch"
     },
     "ChangePasswordRequest": {
       "name": "ChangePasswordRequest",
@@ -8832,6 +8842,11 @@
       "relationship": "maps_to"
     },
     {
+      "source": "GivingStatsDto",
+      "target": "Contribution",
+      "relationship": "maps_to"
+    },
+    {
       "source": "DashboardBatchDto",
       "target": "ContributionBatch",
       "relationship": "maps_to"
@@ -8892,6 +8907,11 @@
       "relationship": "maps_to"
     },
     {
+      "source": "BatchSummaryDto",
+      "target": "ContributionBatch",
+      "relationship": "maps_to"
+    },
+    {
       "source": "ContributionBatchDto",
       "target": "ContributionBatch",
       "relationship": "maps_to"
@@ -8908,6 +8928,31 @@
     },
     {
       "source": "ContributionStatementDto",
+      "target": "ContributionStatement",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "StatementContributionDto",
+      "target": "ContributionStatement",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "GenerateStatementRequest",
+      "target": "ContributionStatement",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "BatchStatementRequest",
+      "target": "ContributionStatement",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "StatementPreviewDto",
+      "target": "ContributionStatement",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "EligiblePersonDto",
       "target": "ContributionStatement",
       "relationship": "maps_to"
     },
@@ -9197,13 +9242,28 @@
       "relationship": "maps_to"
     },
     {
+      "source": "CreateBatchRequest",
+      "target": "ContributionBatch",
+      "relationship": "maps_to"
+    },
+    {
       "source": "AddContributionRequest",
       "target": "Contribution",
       "relationship": "maps_to"
     },
     {
+      "source": "ContributionDetailRequest",
+      "target": "ContributionDetail",
+      "relationship": "maps_to"
+    },
+    {
       "source": "UpdateContributionRequest",
       "target": "Contribution",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "BatchFilterRequest",
+      "target": "ContributionBatch",
       "relationship": "maps_to"
     },
     {
@@ -10812,6 +10872,6 @@
     "total_dtos": 195,
     "total_services": 105,
     "total_controllers": 34,
-    "total_relationships": 417
+    "total_relationships": 427
   }
 }

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-01-24T19:15:33.332Z",
+  "generated_at": "2026-01-25T16:09:05.289Z",
   "types": {
     "AttendanceAnalyticsDto": {
       "name": "AttendanceAnalyticsDto",

--- a/tools/graph/generate-backend.py
+++ b/tools/graph/generate-backend.py
@@ -463,6 +463,20 @@ class BackendGraphGenerator:
             'PickupVerificationResultDto': 'PickupLog',
             'VerifyPickupRequest': 'PickupLog',
             'RecordPickupRequest': 'PickupLog',
+
+            # Financial/Giving DTOs (Issue #471)
+            'CreateBatchRequest': 'ContributionBatch',
+            'AddContributionRequest': 'Contribution',
+            'ContributionDetailRequest': 'ContributionDetail',
+            'UpdateContributionRequest': 'Contribution',
+            'BatchFilterRequest': 'ContributionBatch',
+            'BatchSummaryDto': 'ContributionBatch',
+            'StatementContributionDto': 'ContributionStatement',
+            'GenerateStatementRequest': 'ContributionStatement',
+            'BatchStatementRequest': 'ContributionStatement',
+            'StatementPreviewDto': 'ContributionStatement',
+            'EligiblePersonDto': 'ContributionStatement',
+            'GivingStatsDto': 'Contribution',
         }
 
         if dto_name in manual_mappings:

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-01-24T19:15:33.502076+00:00",
+  "generated_at": "2026-01-25T16:09:05.460536+00:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -2030,7 +2030,8 @@
         "MonthToDateTotal": "decimal",
         "YearToDateTotal": "decimal",
         "RecentBatches": "List<DashboardBatchDto>"
-      }
+      },
+      "linked_entity": "Contribution"
     },
     "DashboardBatchDto": {
       "name": "DashboardBatchDto",
@@ -2231,7 +2232,8 @@
         "ItemCountVariance": "int?",
         "Variance": "decimal",
         "IsBalanced": "bool"
-      }
+      },
+      "linked_entity": "ContributionBatch"
     },
     "ContributionBatchDto": {
       "name": "ContributionBatchDto",
@@ -2304,7 +2306,8 @@
         "FundName": "string",
         "Amount": "decimal",
         "CheckNumber": "string?"
-      }
+      },
+      "linked_entity": "ContributionStatement"
     },
     "GenerateStatementRequest": {
       "name": "GenerateStatementRequest",
@@ -2313,7 +2316,8 @@
         "PersonIdKey": "string",
         "StartDate": "DateTime",
         "EndDate": "DateTime"
-      }
+      },
+      "linked_entity": "ContributionStatement"
     },
     "BatchStatementRequest": {
       "name": "BatchStatementRequest",
@@ -2322,7 +2326,8 @@
         "StartDate": "DateTime",
         "EndDate": "DateTime",
         "MinimumAmount": "decimal"
-      }
+      },
+      "linked_entity": "ContributionStatement"
     },
     "StatementPreviewDto": {
       "name": "StatementPreviewDto",
@@ -2337,7 +2342,8 @@
         "Contributions": "List<StatementContributionDto>",
         "ChurchName": "string",
         "ChurchAddress": "string"
-      }
+      },
+      "linked_entity": "ContributionStatement"
     },
     "EligiblePersonDto": {
       "name": "EligiblePersonDto",
@@ -2347,7 +2353,8 @@
         "PersonName": "string",
         "TotalAmount": "decimal",
         "ContributionCount": "int"
-      }
+      },
+      "linked_entity": "ContributionStatement"
     },
     "FundDto": {
       "name": "FundDto",
@@ -3357,7 +3364,8 @@
         "ControlItemCount": "int?",
         "CampusIdKey": "string?",
         "Note": "string?"
-      }
+      },
+      "linked_entity": "ContributionBatch"
     },
     "AddContributionRequest": {
       "name": "AddContributionRequest",
@@ -3379,7 +3387,8 @@
         "FundIdKey": "string",
         "Amount": "decimal",
         "Summary": "string?"
-      }
+      },
+      "linked_entity": "ContributionDetail"
     },
     "UpdateContributionRequest": {
       "name": "UpdateContributionRequest",
@@ -3404,7 +3413,8 @@
         "EndDate": "DateTime?",
         "PageNumber": "int",
         "PageSize": "int"
-      }
+      },
+      "linked_entity": "ContributionBatch"
     },
     "ChangePasswordRequest": {
       "name": "ChangePasswordRequest",
@@ -16396,6 +16406,11 @@
       "relationship": "maps_to"
     },
     {
+      "source": "GivingStatsDto",
+      "target": "Contribution",
+      "relationship": "maps_to"
+    },
+    {
       "source": "DashboardBatchDto",
       "target": "ContributionBatch",
       "relationship": "maps_to"
@@ -16456,6 +16471,11 @@
       "relationship": "maps_to"
     },
     {
+      "source": "BatchSummaryDto",
+      "target": "ContributionBatch",
+      "relationship": "maps_to"
+    },
+    {
       "source": "ContributionBatchDto",
       "target": "ContributionBatch",
       "relationship": "maps_to"
@@ -16472,6 +16492,31 @@
     },
     {
       "source": "ContributionStatementDto",
+      "target": "ContributionStatement",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "StatementContributionDto",
+      "target": "ContributionStatement",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "GenerateStatementRequest",
+      "target": "ContributionStatement",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "BatchStatementRequest",
+      "target": "ContributionStatement",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "StatementPreviewDto",
+      "target": "ContributionStatement",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "EligiblePersonDto",
       "target": "ContributionStatement",
       "relationship": "maps_to"
     },
@@ -16761,13 +16806,28 @@
       "relationship": "maps_to"
     },
     {
+      "source": "CreateBatchRequest",
+      "target": "ContributionBatch",
+      "relationship": "maps_to"
+    },
+    {
       "source": "AddContributionRequest",
       "target": "Contribution",
       "relationship": "maps_to"
     },
     {
+      "source": "ContributionDetailRequest",
+      "target": "ContributionDetail",
+      "relationship": "maps_to"
+    },
+    {
       "source": "UpdateContributionRequest",
       "target": "Contribution",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "BatchFilterRequest",
+      "target": "ContributionBatch",
       "relationship": "maps_to"
     },
     {
@@ -18885,6 +18945,6 @@
     "api_functions": 164,
     "hooks": 143,
     "components": 129,
-    "total_edges": 484
+    "total_edges": 494
   }
 }


### PR DESCRIPTION
## Summary
Added 12 Financial/Giving DTO mappings to graph baseline per issue #471.

## Changes
- Added manual mappings in `generate-backend.py` for Financial/Giving DTOs
- Updated `backend-graph.json` with `linked_entity` fields for 12 DTOs
- Regenerated `graph-baseline.json` with merged cross-layer mappings

## DTO Mappings
- `CreateBatchRequest` → ContributionBatch
- `AddContributionRequest` → Contribution
- `ContributionDetailRequest` → ContributionDetail
- `UpdateContributionRequest` → Contribution
- `BatchFilterRequest` → ContributionBatch
- `BatchSummaryDto` → ContributionBatch
- `StatementContributionDto` → ContributionStatement
- `GenerateStatementRequest` → ContributionStatement
- `BatchStatementRequest` → ContributionStatement
- `StatementPreviewDto` → ContributionStatement
- `EligiblePersonDto` → ContributionStatement
- `GivingStatsDto` → Contribution

## Test Plan
- [x] Graph validation passes (`npm run graph:validate`)
- [x] Backend build passes
- [x] Backend tests pass (1399 tests)
- [x] Frontend tests pass (189 tests)
- [x] Code-critic review approved (0 issues)

Closes #471

🤖 Generated with [Claude Code](https://claude.com/claude-code)