### PR TITLE
feat(graph): Group DTO mappings, IdKey regex fix, exempt controllers (#468, #464, #465)

### DIFF
--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-02-03T09:31:38-05:00",
+  "generated_at": "2026-02-06T21:29:42-05:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -2828,7 +2828,8 @@
         "Campus": "CampusSummaryDto?",
         "CreatedDateTime": "DateTime",
         "ModifiedDateTime": "DateTime?"
-      }
+      },
+      "linked_entity": "Group"
     },
     "MyInvolvementDto": {
       "name": "MyInvolvementDto",
@@ -2837,7 +2838,8 @@
         "Groups": "IReadOnlyList<MyInvolvementGroupDto>",
         "RecentAttendanceCount": "int",
         "TotalGroupsCount": "int"
-      }
+      },
+      "linked_entity": "GroupMember"
     },
     "MyInvolvementGroupDto": {
       "name": "MyInvolvementGroupDto",
@@ -2852,7 +2854,8 @@
         "LastAttendanceDate": "DateTime?",
         "JoinedDate": "DateTime?",
         "Campus": "CampusSummaryDto?"
-      }
+      },
+      "linked_entity": "Group"
     },
     "MyProfileDto": {
       "name": "MyProfileDto",
@@ -3201,7 +3204,8 @@
         "MeetingDay": "string?",
         "MeetingTime": "TimeOnly?",
         "MeetingScheduleSummary": "string?"
-      }
+      },
+      "linked_entity": "Group"
     },
     "ReportDefinitionDto": {
       "name": "ReportDefinitionDto",
@@ -3701,7 +3705,8 @@
       "properties": {
         "Status": "string",
         "Note": "string?"
-      }
+      },
+      "linked_entity": "GroupMemberRequest"
     },
     "RecordAttendanceRequest": {
       "name": "RecordAttendanceRequest",
@@ -3710,7 +3715,8 @@
         "OccurrenceDate": "DateOnly",
         "AttendedPersonIds": "IReadOnlyList<string>",
         "Notes": "string?"
-      }
+      },
+      "linked_entity": "Attendance"
     },
     "CreateScheduleRequest": {
       "name": "CreateScheduleRequest",
@@ -3769,7 +3775,8 @@
       "namespace": "Koinon.Application.DTOs.Requests",
       "properties": {
         "Note": "string?"
-      }
+      },
+      "linked_entity": "GroupMemberRequest"
     },
     "TwoFactorVerifyRequest": {
       "name": "TwoFactorVerifyRequest",
@@ -6688,9 +6695,10 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": true,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "IAttendanceAnalyticsService",
@@ -6770,7 +6778,8 @@
         "response_envelope": true,
         "idkey_routes": false,
         "problem_details": true,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "IAuthService",
@@ -6831,7 +6840,7 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": true,
         "result_pattern": false
       },
@@ -7027,7 +7036,7 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": true,
         "result_pattern": false
       },
@@ -7059,7 +7068,7 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": true,
         "result_pattern": false
       },
@@ -7221,7 +7230,8 @@
         "response_envelope": true,
         "idkey_routes": false,
         "problem_details": false,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "IDashboardService",
@@ -7625,7 +7635,7 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": true,
         "result_pattern": false
       },
@@ -7995,9 +8005,10 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": false,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "IMyGroupsService"
@@ -8056,9 +8067,10 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": false,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "IMyProfileService"
@@ -8388,7 +8400,7 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": true,
         "result_pattern": false
       },
@@ -8636,7 +8648,8 @@
         "response_envelope": false,
         "idkey_routes": false,
         "problem_details": true,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "IGlobalSearchService",
@@ -8662,7 +8675,8 @@
         "response_envelope": false,
         "idkey_routes": false,
         "problem_details": false,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "ILogger<TwilioWebhookController>",
@@ -9246,6 +9260,21 @@
       "relationship": "maps_to"
     },
     {
+      "source": "MyGroupDto",
+      "target": "Group",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "MyInvolvementDto",
+      "target": "GroupMember",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "MyInvolvementGroupDto",
+      "target": "Group",
+      "relationship": "maps_to"
+    },
+    {
       "source": "MyProfileDto",
       "target": "Person",
       "relationship": "maps_to"
@@ -9343,6 +9372,11 @@
     {
       "source": "PickupVerificationResultDto",
       "target": "PickupLog",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "PublicGroupDto",
+      "target": "Group",
       "relationship": "maps_to"
     },
     {
@@ -9526,6 +9560,16 @@
       "relationship": "maps_to"
     },
     {
+      "source": "ProcessMembershipRequestDto",
+      "target": "GroupMemberRequest",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "RecordAttendanceRequest",
+      "target": "Attendance",
+      "relationship": "maps_to"
+    },
+    {
       "source": "CreateScheduleRequest",
       "target": "Schedule",
       "relationship": "maps_to"
@@ -9538,6 +9582,11 @@
     {
       "source": "StartImportRequest",
       "target": "ImportJob",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "SubmitMembershipRequestDto",
+      "target": "GroupMemberRequest",
       "relationship": "maps_to"
     },
     {
@@ -11106,6 +11155,6 @@
     "total_dtos": 195,
     "total_services": 105,
     "total_controllers": 34,
-    "total_relationships": 466
+    "total_relationships": 473
   }
 }

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-02-03T16:41:22.564Z",
+  "generated_at": "2026-02-07T03:37:28.574Z",
   "types": {
     "AttendanceAnalyticsDto": {
       "name": "AttendanceAnalyticsDto",

--- a/tools/graph/generate-backend.py
+++ b/tools/graph/generate-backend.py
@@ -318,14 +318,28 @@ class CSharpParser:
                     })
         return endpoints
 
-    def extract_patterns(self, content: str) -> Dict[str, bool]:
+    # Controllers that legitimately do not need IdKey in their primary route.
+    # Auth-context controllers resolve entities from the authenticated user.
+    IDKEY_EXEMPT_CONTROLLERS: Dict[str, str] = {
+        'MyGroupsController': 'Auth-context controller, resolves groups from authenticated user',
+        'MyProfileController': 'Auth-context controller, resolves person from authenticated user',
+        'AnalyticsController': 'Aggregate data queries, no entity-specific routes',
+        'AuthController': 'Authentication operations (login/refresh/logout), no entity routes',
+        'DashboardController': 'Aggregate dashboard statistics, no entity-specific routes',
+        'SearchController': 'Global search operations, no entity-specific routes',
+        'TwilioWebhookController': 'External webhook receiver, no entity-specific routes',
+    }
+
+    def extract_patterns(self, content: str, class_name: str = '') -> Dict[str, Any]:
         """Extract architectural patterns used in controller."""
-        patterns = {
+        patterns: Dict[str, Any] = {
             'response_envelope': bool(re.search(r'new\s*\{\s*(?:data|Data)\s*=', content)),
-            'idkey_routes': bool(re.search(r'\{idKey\}', content)),
+            'idkey_routes': bool(re.search(r'\{[a-zA-Z]*[Ii]dKey\}', content)),
             'problem_details': bool(re.search(r'Problem\(|ProblemDetails', content)),
             'result_pattern': bool(re.search(r'Result<', content))
         }
+        if class_name in self.IDKEY_EXEMPT_CONTROLLERS:
+            patterns['idkey_exempt'] = True
         return patterns
 
 
@@ -535,6 +549,15 @@ class BackendGraphGenerator:
             'BulkMarkAttendanceResultDto': 'Attendance',
             'OccurrenceRosterEntryDto': 'Attendance',
             'CheckinValidationResult': 'Attendance',
+
+            # Group DTOs (Issue #468)
+            'MyGroupDto': 'Group',
+            'MyInvolvementDto': 'GroupMember',
+            'MyInvolvementGroupDto': 'Group',
+            'PublicGroupDto': 'Group',
+            'SubmitMembershipRequestDto': 'GroupMemberRequest',
+            'ProcessMembershipRequestDto': 'GroupMemberRequest',
+            'RecordAttendanceRequest': 'Attendance',
         }
 
         if dto_name in manual_mappings:
@@ -623,7 +646,7 @@ class BackendGraphGenerator:
                 route = f"api/v1/{self.parser.camel_to_snake(controller_base)}"
 
             endpoints = self.parser.extract_endpoints(content)
-            patterns = self.parser.extract_patterns(content)
+            patterns = self.parser.extract_patterns(content, class_name)
             dependencies = self.parser.extract_constructor_dependencies(content)
 
             self.controllers[class_name] = {

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-02-03T09:31:38-05:00",
+  "generated_at": "2026-02-06T21:29:42-05:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -2828,7 +2828,8 @@
         "Campus": "CampusSummaryDto?",
         "CreatedDateTime": "DateTime",
         "ModifiedDateTime": "DateTime?"
-      }
+      },
+      "linked_entity": "Group"
     },
     "MyInvolvementDto": {
       "name": "MyInvolvementDto",
@@ -2837,7 +2838,8 @@
         "Groups": "IReadOnlyList<MyInvolvementGroupDto>",
         "RecentAttendanceCount": "int",
         "TotalGroupsCount": "int"
-      }
+      },
+      "linked_entity": "GroupMember"
     },
     "MyInvolvementGroupDto": {
       "name": "MyInvolvementGroupDto",
@@ -2852,7 +2854,8 @@
         "LastAttendanceDate": "DateTime?",
         "JoinedDate": "DateTime?",
         "Campus": "CampusSummaryDto?"
-      }
+      },
+      "linked_entity": "Group"
     },
     "MyProfileDto": {
       "name": "MyProfileDto",
@@ -3201,7 +3204,8 @@
         "MeetingDay": "string?",
         "MeetingTime": "TimeOnly?",
         "MeetingScheduleSummary": "string?"
-      }
+      },
+      "linked_entity": "Group"
     },
     "ReportDefinitionDto": {
       "name": "ReportDefinitionDto",
@@ -3701,7 +3705,8 @@
       "properties": {
         "Status": "string",
         "Note": "string?"
-      }
+      },
+      "linked_entity": "GroupMemberRequest"
     },
     "RecordAttendanceRequest": {
       "name": "RecordAttendanceRequest",
@@ -3710,7 +3715,8 @@
         "OccurrenceDate": "DateOnly",
         "AttendedPersonIds": "IReadOnlyList<string>",
         "Notes": "string?"
-      }
+      },
+      "linked_entity": "Attendance"
     },
     "CreateScheduleRequest": {
       "name": "CreateScheduleRequest",
@@ -3769,7 +3775,8 @@
       "namespace": "Koinon.Application.DTOs.Requests",
       "properties": {
         "Note": "string?"
-      }
+      },
+      "linked_entity": "GroupMemberRequest"
     },
     "TwoFactorVerifyRequest": {
       "name": "TwoFactorVerifyRequest",
@@ -6688,9 +6695,10 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": true,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "IAttendanceAnalyticsService",
@@ -6770,7 +6778,8 @@
         "response_envelope": true,
         "idkey_routes": false,
         "problem_details": true,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "IAuthService",
@@ -6831,7 +6840,7 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": true,
         "result_pattern": false
       },
@@ -7027,7 +7036,7 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": true,
         "result_pattern": false
       },
@@ -7059,7 +7068,7 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": true,
         "result_pattern": false
       },
@@ -7221,7 +7230,8 @@
         "response_envelope": true,
         "idkey_routes": false,
         "problem_details": false,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "IDashboardService",
@@ -7625,7 +7635,7 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": true,
         "result_pattern": false
       },
@@ -7995,9 +8005,10 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": false,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "IMyGroupsService"
@@ -8056,9 +8067,10 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": false,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "IMyProfileService"
@@ -8388,7 +8400,7 @@
       ],
       "patterns": {
         "response_envelope": true,
-        "idkey_routes": false,
+        "idkey_routes": true,
         "problem_details": true,
         "result_pattern": false
       },
@@ -8636,7 +8648,8 @@
         "response_envelope": false,
         "idkey_routes": false,
         "problem_details": true,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "IGlobalSearchService",
@@ -8662,7 +8675,8 @@
         "response_envelope": false,
         "idkey_routes": false,
         "problem_details": false,
-        "result_pattern": false
+        "result_pattern": false,
+        "idkey_exempt": true
       },
       "dependencies": [
         "ILogger<TwilioWebhookController>",
@@ -16810,6 +16824,21 @@
       "relationship": "maps_to"
     },
     {
+      "source": "MyGroupDto",
+      "target": "Group",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "MyInvolvementDto",
+      "target": "GroupMember",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "MyInvolvementGroupDto",
+      "target": "Group",
+      "relationship": "maps_to"
+    },
+    {
       "source": "MyProfileDto",
       "target": "Person",
       "relationship": "maps_to"
@@ -16907,6 +16936,11 @@
     {
       "source": "PickupVerificationResultDto",
       "target": "PickupLog",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "PublicGroupDto",
+      "target": "Group",
       "relationship": "maps_to"
     },
     {
@@ -17090,6 +17124,16 @@
       "relationship": "maps_to"
     },
     {
+      "source": "ProcessMembershipRequestDto",
+      "target": "GroupMemberRequest",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "RecordAttendanceRequest",
+      "target": "Attendance",
+      "relationship": "maps_to"
+    },
+    {
       "source": "CreateScheduleRequest",
       "target": "Schedule",
       "relationship": "maps_to"
@@ -17102,6 +17146,11 @@
     {
       "source": "StartImportRequest",
       "target": "ImportJob",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "SubmitMembershipRequestDto",
+      "target": "GroupMemberRequest",
       "relationship": "maps_to"
     },
     {
@@ -19179,6 +19228,6 @@
     "api_functions": 164,
     "hooks": 143,
     "components": 129,
-    "total_edges": 533
+    "total_edges": 540
   }
 }


### PR DESCRIPTION
## Summary
- **#468**: Added 7 Group DTO manual mappings (MyGroupDto, MyInvolvementDto, MyInvolvementGroupDto, PublicGroupDto, SubmitMembershipRequestDto, ProcessMembershipRequestDto, RecordAttendanceRequest)
- **#464**: Fixed IdKey route regex from `\{idKey\}` to `\{[a-zA-Z]*[Ii]dKey\}` to match all variants (e.g., `{personIdKey}`, `{groupIdKey}`)
- **#465**: Added IDKEY_EXEMPT_CONTROLLERS dict with 7 controllers that legitimately don't need IdKey routes (MyGroups, MyProfile, Analytics, Auth, Dashboard, Search, TwilioWebhook)
- Updated `extract_patterns` method signature to accept `class_name` for exempt lookup
- Regenerated backend-graph.json and graph-baseline.json

Closes #464, closes #465, closes #468

Supersedes #504 and #505 (rebased clean on main after #503 merged)

## Test plan
- [x] All 1,441 backend tests pass
- [x] All 189 frontend tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] Graph validation passes (verify-contracts.py)
- [x] Verified all 7 Group DTOs have correct `linked_entity` values
- [x] Verified all 7 exempt controllers have `idkey_exempt: true` in graph
- [x] IdKey regex correctly matches `{personIdKey}`, `{groupIdKey}`, `{idKey}` variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)