### PR TITLE
test(checkin): add E2E tests for complete check-in flow

### DIFF
--- a/src/web/e2e/fixtures/page-objects/checkin.page.ts
+++ b/src/web/e2e/fixtures/page-objects/checkin.page.ts
@@ -104,13 +104,8 @@ export class CheckinPage {
    * activityIndex is 0-based within that person's opportunity list.
    */
   async selectActivity(personIndex: number, activityIndex: number) {
-    // Activities are rendered as toggle buttons inside each member card section
-    const targetIndex = personIndex * 10 + activityIndex; // rough offset; real DOM is flat
-    const allToggles = await this.page.getByRole('checkbox').all();
-    const toggle = allToggles[targetIndex];
-    if (toggle) {
-      await toggle.click();
-    }
+    const card = this.familyMemberCards.nth(personIndex);
+    await card.getByRole('checkbox').nth(activityIndex).click();
   }
 
   /**

--- a/src/web/e2e/tests/checkin/checkin-complete-flow.spec.ts
+++ b/src/web/e2e/tests/checkin/checkin-complete-flow.spec.ts
@@ -18,7 +18,7 @@
  *   GET  /api/v1/checkin/configuration
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { CheckinPage } from '../../fixtures/page-objects/checkin.page';
 import { testData } from '../../fixtures/test-data';
 
@@ -237,35 +237,46 @@ const supervisorRosterResponse = {
   data: {
     locationIdKey: LOC_ROOM201_ID,
     locationName: 'Room 201',
-    attendees: [
+    children: [
       {
         attendanceIdKey: ATT_JOHNNY_ID,
         personIdKey: PERSON_JOHNNY_ID,
-        personName: testData.people.johnnySmith.fullName,
+        fullName: testData.people.johnnySmith.fullName,
+        firstName: testData.people.johnnySmith.firstName,
+        lastName: testData.people.johnnySmith.lastName,
+        hasCriticalAllergies: false,
         securityCode: 'ABC123',
         checkInTime: '2026-03-29T08:55:00Z',
-        isCheckedOut: false,
+        isFirstTime: false,
       },
     ],
+    totalCount: 1,
+    generatedAt: '2026-03-29T08:55:00Z',
+    isAtCapacity: false,
+    isNearCapacity: false,
   },
 };
 
-/** Valid supervisor login response */
-const supervisorLoginResponse = {
-  sessionToken: 'test-supervisor-token-abc',
-  supervisor: {
-    idKey: 'sup_abc123',
-    fullName: 'Test Supervisor',
-  },
-  expiresAt: new Date(Date.now() + 120_000).toISOString(),
-};
+/** Valid supervisor login response — built fresh each call so expiresAt is never stale */
+function buildSupervisorLoginResponse() {
+  return {
+    sessionToken: 'test-supervisor-token-abc',
+    supervisor: {
+      idKey: 'sup_abc123',
+      fullName: 'Test Supervisor',
+      firstName: 'Test',
+      lastName: 'Supervisor',
+    },
+    expiresAt: new Date(Date.now() + 120_000).toISOString(),
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Helper: wire up the full set of API mocks needed for a happy-path check-in
 // ---------------------------------------------------------------------------
 
 async function setupCheckinMocks(
-  page: Parameters<typeof test>[1] extends { page: infer P } ? P : never,
+  page: Page,
   opts: {
     searchResponse?: unknown;
     checkinResult?: unknown;
@@ -324,16 +335,14 @@ async function setupCheckinMocks(
 // Helper: wire supervisor-specific mocks
 // ---------------------------------------------------------------------------
 
-async function setupSupervisorMocks(
-  page: Parameters<typeof test>[1] extends { page: infer P } ? P : never
-) {
+async function setupSupervisorMocks(page: Page) {
   await page.route('**/api/v1/checkin/supervisor/login', async (route) => {
     const body = JSON.parse(route.request().postData() ?? '{}') as { pin?: string };
     if (body.pin === '1234') {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify(supervisorLoginResponse),
+        body: JSON.stringify(buildSupervisorLoginResponse()),
       });
     } else {
       await route.fulfill({
@@ -369,7 +378,7 @@ async function setupSupervisorMocks(
 // Helper: authenticate supervisor through the PIN modal
 // ---------------------------------------------------------------------------
 
-async function authenticateSupervisor(page: Parameters<typeof test>[1] extends { page: infer P } ? P : never) {
+async function authenticateSupervisor(page: Page) {
   await page.getByRole('button', { name: /supervisor/i }).click();
   await page.getByRole('button', { name: '1' }).click();
   await page.getByRole('button', { name: '2' }).click();
@@ -396,14 +405,6 @@ test.describe('Complete Check-in Flow', () => {
     const checkin = new CheckinPage(page);
 
     // Step 1: Search by phone — single family auto-advances to member selection
-    await checkin.enterPhone(testData.credentials.kiosk.deviceCode.slice(0, 10)); // not used, mocked
-    await page.route('**/api/v1/checkin/search', (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify(smithSearchResponse),
-      })
-    );
     await checkin.enterPhone('5551234567');
     await checkin.submitPhone();
 


### PR DESCRIPTION
## Summary
- 27 Playwright E2E tests covering the complete check-in kiosk flow
- Tests organized in 6 describe blocks: happy path, security codes, offline, supervisor, performance, kiosk touch
- Extended CheckinPage page object with new locators and methods
- All API calls mocked via `page.route()` — no live backend needed

## Test Coverage
- **Happy path:** phone search → family select → member/activity → confirm → security code → done
- **Security codes:** displayed per child, unique per attendance
- **Offline:** queue on disconnect, sync on reconnect
- **Supervisor:** PIN auth, attendance roster, reprint labels, checkout, exit
- **Performance:** <500ms check-in, <2500ms page load, <200ms INP
- **Kiosk touch:** 48px touch targets, tap-based flow

## Review
- Junior reviewer: PASS (2 lint fixes applied)
- TypeScript: clean
- ESLint: clean

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)