### PR TITLE
fix(api): configure CORS for separate React frontend

### DIFF
--- a/src/Koinon.Api/Program.cs
+++ b/src/Koinon.Api/Program.cs
@@ -24,6 +24,22 @@ builder.Services.AddControllers();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
+// Configure CORS for separate frontend
+var allowedOrigins = builder.Configuration.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("FrontendPolicy", policy =>
+    {
+        if (allowedOrigins.Length > 0)
+        {
+            policy.WithOrigins(allowedOrigins)
+                  .AllowAnyHeader()
+                  .AllowAnyMethod()
+                  .AllowCredentials();
+        }
+    });
+});
+
 // Add SignalR for real-time notifications
 builder.Services.AddSignalR();
 
@@ -198,6 +214,10 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+// CORS must come before authentication — browsers send preflight OPTIONS requests
+// that must receive CORS headers before auth is checked
+app.UseCors("FrontendPolicy");
 
 // Authentication must come before authorization
 app.UseAuthentication();

--- a/src/Koinon.Api/appsettings.Development.json
+++ b/src/Koinon.Api/appsettings.Development.json
@@ -23,6 +23,9 @@
     "FromAddress": "dev@localhost",
     "FromName": "Koinon Dev"
   },
+  "Cors": {
+    "AllowedOrigins": ["http://localhost:5173"]
+  },
   "Twilio": {
     "_comment": "SECURITY: AccountSid and AuthToken MUST be set via environment variables or user-secrets in production, never committed to source control",
     "AccountSid": "",

--- a/src/Koinon.Api/appsettings.json
+++ b/src/Koinon.Api/appsettings.json
@@ -38,6 +38,9 @@
     "CostPerSmsCents": 1,
     "CostPerMmsCents": 2
   },
+  "Cors": {
+    "AllowedOrigins": []
+  },
   "AuditRetention": {
     "Enabled": true,
     "RetentionDays": 365,

--- a/tests/Koinon.Api.Tests/CorsConfigurationTests.cs
+++ b/tests/Koinon.Api.Tests/CorsConfigurationTests.cs
@@ -1,0 +1,66 @@
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Koinon.Api.Tests;
+
+public class CorsConfigurationTests
+{
+    [Fact]
+    public void AllowedOrigins_WhenNotConfigured_ReturnsEmptyArray()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>())
+            .Build();
+
+        // Act
+        var allowedOrigins = config.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+
+        // Assert
+        allowedOrigins.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void AllowedOrigins_WhenConfigured_ReturnsConfiguredOrigins()
+    {
+        // Arrange
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Cors:AllowedOrigins:0"] = "http://localhost:5173",
+                ["Cors:AllowedOrigins:1"] = "https://app.koinon.church"
+            })
+            .Build();
+
+        // Act
+        var allowedOrigins = config.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+
+        // Assert
+        allowedOrigins.Should().HaveCount(2);
+        allowedOrigins.Should().Contain("http://localhost:5173");
+        allowedOrigins.Should().Contain("https://app.koinon.church");
+    }
+
+    [Fact]
+    public void AllowedOrigins_EmptyArrayInConfig_DoesNotCrash()
+    {
+        // Arrange — mirrors production appsettings.json where AllowedOrigins is []
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                // An empty JSON array produces no keys, so the section exists but has no children
+            })
+            .Build();
+
+        // Act
+        var act = () =>
+        {
+            var allowedOrigins = config.GetSection("Cors:AllowedOrigins").Get<string[]>() ?? Array.Empty<string>();
+            return allowedOrigins.Length; // access result to ensure no lazy exception
+        };
+
+        // Assert
+        act.Should().NotThrow();
+    }
+}


### PR DESCRIPTION
## Summary
- Add CORS policy with config-driven allowed origins (no hardcoded values)
- Development: `http://localhost:5173` (Vite dev server)
- Production: empty by default — set via environment config
- Credentials, any header, any method allowed per policy
- Middleware placed before UseAuthentication per CORS specification

## Test Coverage
- Unit: 3 tests for configuration binding (empty, configured, edge case)
- Backend build: 0 warnings

## Review
- Junior reviewer: PASS (all conventions, ordering, security checks clean)

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)