### PR TITLE
fix(graph): resolve TypeScript interface inheritance in frontend graph generator

### DIFF
--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-02-07T09:04:24-05:00",
+  "generated_at": "2026-03-27T09:57:49-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -4727,7 +4727,6 @@
       ],
       "dependencies": [
         "IApplicationDbContext",
-        "ICheckinSearchService",
         "IValidator<KioskFamilyRegistrationRequest>",
         "ILogger<CheckinRegistrationService>"
       ]

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-03-27T00:14:56.973Z",
+  "generated_at": "2026-03-27T14:27:47.710Z",
   "types": {
     "AttendanceAnalyticsDto": {
       "name": "AttendanceAnalyticsDto",
@@ -295,20 +295,20 @@
       "name": "CheckinFamilySearchResultDto",
       "kind": "interface",
       "properties": {
-        "familyIdKey": "IdKey",
+        "familyIdKey": "string",
         "familyName": "string",
         "addressSummary": "string",
         "campusName": "string",
         "members": "CheckinFamilyMemberDto[]",
         "recentCheckInCount": "number"
       },
-      "path": "types/checkin-extended.ts"
+      "path": "services/api/types.ts"
     },
     "CheckinFamilyMemberDto": {
       "name": "CheckinFamilyMemberDto",
       "kind": "interface",
       "properties": {
-        "personIdKey": "IdKey",
+        "personIdKey": "string",
         "fullName": "string",
         "firstName": "string",
         "lastName": "string",
@@ -319,13 +319,13 @@
         "roleName": "string",
         "isChild": "boolean",
         "hasRecentCheckIn": "boolean",
-        "lastCheckIn": "DateTime",
+        "lastCheckIn": "string",
         "grade": "string",
         "allergies": "string",
         "hasCriticalAllergies": "boolean",
         "specialNeeds": "string"
       },
-      "path": "types/checkin-extended.ts"
+      "path": "services/api/types.ts"
     },
     "AttendanceSummaryDto": {
       "name": "AttendanceSummaryDto",
@@ -2042,6 +2042,10 @@
       "name": "PersonSearchParams",
       "kind": "interface",
       "properties": {
+        "sortBy": "string",
+        "sortDir": "'asc' | 'desc'",
+        "page": "number",
+        "pageSize": "number",
         "q": "string",
         "firstName": "string",
         "lastName": "string",
@@ -2052,7 +2056,11 @@
         "campusId": "IdKey",
         "includeInactive": "boolean"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams",
+        "SortParams"
+      ]
     },
     "DuplicateMatchDto": {
       "name": "DuplicateMatchDto",
@@ -2659,11 +2667,16 @@
       "name": "FamiliesSearchParams",
       "kind": "interface",
       "properties": {
+        "page": "number",
+        "pageSize": "number",
         "q": "string",
         "campusId": "IdKey",
         "includeInactive": "boolean"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams"
+      ]
     },
     "FamilyDetailDto": {
       "name": "FamilyDetailDto",
@@ -2775,13 +2788,18 @@
       "name": "GroupsSearchParams",
       "kind": "interface",
       "properties": {
+        "page": "number",
+        "pageSize": "number",
         "q": "string",
         "groupTypeId": "IdKey",
         "parentGroupId": "IdKey",
         "campusId": "IdKey",
         "includeInactive": "boolean"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams"
+      ]
     },
     "GroupDetailDto": {
       "name": "GroupDetailDto",
@@ -2807,10 +2825,15 @@
       "name": "GroupMembersParams",
       "kind": "interface",
       "properties": {
+        "page": "number",
+        "pageSize": "number",
         "status": "'Active' | 'Inactive' | 'Pending' | 'All'",
         "roleId": "IdKey"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams"
+      ]
     },
     "AddGroupMemberRequest": {
       "name": "AddGroupMemberRequest",
@@ -2827,10 +2850,15 @@
       "name": "PersonGroupsParams",
       "kind": "interface",
       "properties": {
+        "page": "number",
+        "pageSize": "number",
         "groupTypeId": "IdKey",
         "includeInactive": "boolean"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams"
+      ]
     },
     "PersonFamilyResponse": {
       "name": "PersonFamilyResponse",
@@ -3019,6 +3047,27 @@
       },
       "path": "services/api/types.ts"
     },
+    "KioskChildRegistrationRequest": {
+      "name": "KioskChildRegistrationRequest",
+      "kind": "interface",
+      "properties": {
+        "firstName": "string",
+        "lastName": "string",
+        "birthDate": "string"
+      },
+      "path": "services/api/types.ts"
+    },
+    "KioskFamilyRegistrationRequest": {
+      "name": "KioskFamilyRegistrationRequest",
+      "kind": "interface",
+      "properties": {
+        "parentFirstName": "string",
+        "parentLastName": "string",
+        "phoneNumber": "string",
+        "children": "KioskChildRegistrationRequest[]"
+      },
+      "path": "services/api/types.ts"
+    },
     "CheckinRequest": {
       "name": "CheckinRequest",
       "kind": "interface",
@@ -3191,6 +3240,23 @@
       "name": "GroupTypeDetailAdminDto",
       "kind": "interface",
       "properties": {
+        "idKey": "IdKey",
+        "guid": "Guid",
+        "name": "string",
+        "description": "string",
+        "iconCssClass": "string",
+        "color": "string",
+        "groupTerm": "string",
+        "groupMemberTerm": "string",
+        "takesAttendance": "boolean",
+        "allowSelfRegistration": "boolean",
+        "requiresMemberApproval": "boolean",
+        "defaultIsPublic": "boolean",
+        "defaultGroupCapacity": "number",
+        "isSystem": "boolean",
+        "isArchived": "boolean",
+        "order": "number",
+        "groupCount": "number",
         "showInGroupList": "boolean",
         "showInNavigation": "boolean",
         "attendanceCountsAsWeekendService": "boolean",
@@ -3204,7 +3270,10 @@
         "createdDateTime": "DateTime",
         "modifiedDateTime": "DateTime"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "GroupTypeAdminDto"
+      ]
     },
     "CreateGroupTypeRequest": {
       "name": "CreateGroupTypeRequest",
@@ -3296,11 +3365,16 @@
       "name": "ScheduleSearchParams",
       "kind": "interface",
       "properties": {
+        "page": "number",
+        "pageSize": "number",
         "query": "string",
         "dayOfWeek": "number",
         "includeInactive": "boolean"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams"
+      ]
     },
     "ScheduleSummaryDto": {
       "name": "ScheduleSummaryDto",
@@ -3575,6 +3649,8 @@
       "name": "AuditLogSearchParams",
       "kind": "interface",
       "properties": {
+        "page": "number",
+        "pageSize": "number",
         "startDate": "DateTime",
         "endDate": "DateTime",
         "entityType": "string",
@@ -3582,7 +3658,10 @@
         "personIdKey": "IdKey",
         "entityIdKey": "IdKey"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams"
+      ]
     },
     "AuditLogExportParams": {
       "name": "AuditLogExportParams",
@@ -3944,6 +4023,13 @@
       "endpoint": "/checkin/roster?${queryParams.toString()}",
       "method": "GET",
       "responseType": "RoomRosterDto[]"
+    },
+    "registerFamily": {
+      "name": "registerFamily",
+      "path": "services/api/checkin.ts",
+      "endpoint": "/checkin/register-family",
+      "method": "POST",
+      "responseType": "CheckinFamilyDto"
     },
     "checkoutFromRoster": {
       "name": "checkoutFromRoster",
@@ -7058,6 +7144,12 @@
     "IdleWarningModal": {
       "name": "IdleWarningModal",
       "path": "components/checkin/IdleWarningModal.tsx",
+      "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "KioskFamilyRegistration": {
+      "name": "KioskFamilyRegistration",
+      "path": "components/checkin/KioskFamilyRegistration.tsx",
       "hooksUsed": [],
       "apiCallsDirectly": false
     },

--- a/tools/graph/generate-frontend.js
+++ b/tools/graph/generate-frontend.js
@@ -77,6 +77,42 @@ function extractBalancedBody(content) {
 }
 
 /**
+ * Resolve TypeScript interface inheritance by flattening parent properties
+ * into child types. Handles multi-level inheritance and multiple parents.
+ * @param {Object} types - Map of type name → type object
+ */
+function resolveInheritance(types) {
+  const resolved = new Set();
+  const visiting = new Set();
+
+  function resolve(name) {
+    if (resolved.has(name)) return;
+    if (visiting.has(name)) return; // cycle guard
+    const type = types[name];
+    if (!type || !type.extends || type.extends.length === 0) {
+      resolved.add(name);
+      return;
+    }
+    visiting.add(name);
+    for (const parentName of type.extends) {
+      // Strip generic parameters: Base<Foo> → Base
+      const bareName = parentName.replace(/<.*>/, '').trim();
+      if (types[bareName]) {
+        resolve(bareName);
+        // Merge parent props (child's own props take precedence)
+        type.properties = { ...types[bareName].properties, ...type.properties };
+      }
+    }
+    visiting.delete(name);
+    resolved.add(name);
+  }
+
+  for (const name of Object.keys(types)) {
+    resolve(name);
+  }
+}
+
+/**
  * Extract interface/type definitions from a TypeScript file
  * @param {string} content - File content
  * @param {string} filePath - Relative path for tracking
@@ -84,21 +120,28 @@ function extractBalancedBody(content) {
 function parseTypes(content, filePath = 'services/api/types.ts') {
   const types = {};
 
-  // Match: export interface Name { ... } with balanced braces
-  const interfaceStartRegex = /export\s+interface\s+(\w+)\s*(?:extends\s+[\w<>,\s]+)?\s*\{/g;
+  // Match: export interface Name [extends Parents] { ... } with balanced braces
+  const interfaceStartRegex = /export\s+interface\s+(\w+)\s*(?:extends\s+([\w<>,\s]+?))?\s*\{/g;
   let match;
 
   while ((match = interfaceStartRegex.exec(content)) !== null) {
     const name = match[1];
+    const extendsClause = match[2];
     const startPos = match.index + match[0].length;
     const body = extractBalancedBody(content.substring(startPos));
     const properties = parseProperties(body);
+
+    // Parse extends clause into array of parent names
+    const parentTypes = extendsClause
+      ? extendsClause.split(',').map(s => s.trim()).filter(Boolean)
+      : [];
 
     types[name] = {
       name,
       kind: 'interface',
       properties,
       path: filePath,
+      ...(parentTypes.length > 0 && { extends: parentTypes }),
     };
   }
 
@@ -125,6 +168,9 @@ function parseTypes(content, filePath = 'services/api/types.ts') {
       path: filePath,
     };
   }
+
+  // Resolve within-file inheritance
+  resolveInheritance(types);
 
   return types;
 }
@@ -606,6 +652,8 @@ async function main() {
 
     // 3. Merge types (types.ts takes precedence for duplicates)
     const mergedTypes = { ...typesFromDir, ...types };
+    // Resolve cross-file inheritance (e.g. types/ extending types.ts)
+    resolveInheritance(mergedTypes);
     console.log(`  Total merged: ${Object.keys(mergedTypes).length} types\n`);
     types = mergedTypes;
 

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-03-26T21:08:02-04:00",
+  "generated_at": "2026-03-27T09:57:49-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -10880,6 +10880,10 @@
       "name": "PersonSearchParams",
       "kind": "interface",
       "properties": {
+        "sortBy": "string",
+        "sortDir": "'asc' | 'desc'",
+        "page": "number",
+        "pageSize": "number",
         "q": "string",
         "firstName": "string",
         "lastName": "string",
@@ -10890,7 +10894,11 @@
         "campusId": "IdKey",
         "includeInactive": "boolean"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams",
+        "SortParams"
+      ]
     },
     "DuplicateMatchDto": {
       "name": "DuplicateMatchDto",
@@ -11497,11 +11505,16 @@
       "name": "FamiliesSearchParams",
       "kind": "interface",
       "properties": {
+        "page": "number",
+        "pageSize": "number",
         "q": "string",
         "campusId": "IdKey",
         "includeInactive": "boolean"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams"
+      ]
     },
     "FamilyDetailDto": {
       "name": "FamilyDetailDto",
@@ -11613,13 +11626,18 @@
       "name": "GroupsSearchParams",
       "kind": "interface",
       "properties": {
+        "page": "number",
+        "pageSize": "number",
         "q": "string",
         "groupTypeId": "IdKey",
         "parentGroupId": "IdKey",
         "campusId": "IdKey",
         "includeInactive": "boolean"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams"
+      ]
     },
     "GroupDetailDto": {
       "name": "GroupDetailDto",
@@ -11645,10 +11663,15 @@
       "name": "GroupMembersParams",
       "kind": "interface",
       "properties": {
+        "page": "number",
+        "pageSize": "number",
         "status": "'Active' | 'Inactive' | 'Pending' | 'All'",
         "roleId": "IdKey"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams"
+      ]
     },
     "AddGroupMemberRequest": {
       "name": "AddGroupMemberRequest",
@@ -11665,10 +11688,15 @@
       "name": "PersonGroupsParams",
       "kind": "interface",
       "properties": {
+        "page": "number",
+        "pageSize": "number",
         "groupTypeId": "IdKey",
         "includeInactive": "boolean"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams"
+      ]
     },
     "PersonFamilyResponse": {
       "name": "PersonFamilyResponse",
@@ -12050,6 +12078,23 @@
       "name": "GroupTypeDetailAdminDto",
       "kind": "interface",
       "properties": {
+        "idKey": "IdKey",
+        "guid": "Guid",
+        "name": "string",
+        "description": "string",
+        "iconCssClass": "string",
+        "color": "string",
+        "groupTerm": "string",
+        "groupMemberTerm": "string",
+        "takesAttendance": "boolean",
+        "allowSelfRegistration": "boolean",
+        "requiresMemberApproval": "boolean",
+        "defaultIsPublic": "boolean",
+        "defaultGroupCapacity": "number",
+        "isSystem": "boolean",
+        "isArchived": "boolean",
+        "order": "number",
+        "groupCount": "number",
         "showInGroupList": "boolean",
         "showInNavigation": "boolean",
         "attendanceCountsAsWeekendService": "boolean",
@@ -12063,7 +12108,10 @@
         "createdDateTime": "DateTime",
         "modifiedDateTime": "DateTime"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "GroupTypeAdminDto"
+      ]
     },
     "CreateGroupTypeRequest": {
       "name": "CreateGroupTypeRequest",
@@ -12155,11 +12203,16 @@
       "name": "ScheduleSearchParams",
       "kind": "interface",
       "properties": {
+        "page": "number",
+        "pageSize": "number",
         "query": "string",
         "dayOfWeek": "number",
         "includeInactive": "boolean"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams"
+      ]
     },
     "ScheduleSummaryDto": {
       "name": "ScheduleSummaryDto",
@@ -12434,6 +12487,8 @@
       "name": "AuditLogSearchParams",
       "kind": "interface",
       "properties": {
+        "page": "number",
+        "pageSize": "number",
         "startDate": "DateTime",
         "endDate": "DateTime",
         "entityType": "string",
@@ -12441,7 +12496,10 @@
         "personIdKey": "IdKey",
         "entityIdKey": "IdKey"
       },
-      "path": "services/api/types.ts"
+      "path": "services/api/types.ts",
+      "extends": [
+        "PaginationParams"
+      ]
     },
     "AuditLogExportParams": {
       "name": "AuditLogExportParams",


### PR DESCRIPTION
## Summary
- Fix false positive graph validation failures caused by TypeScript interface inheritance not being resolved
- Add `resolveInheritance()` function that flattens parent properties into child types (handles multi-level and multiple parents)
- Capture `extends` clause in interface regex and store parent references
- Run resolution both within-file and cross-file after merge

This unblocks PRs #508, #512, #513 which all fail Graph Validation due to types extending other interfaces.

## Test plan
- [x] `npm run graph:verify` passes (0 blocking violations)
- [x] Types with `extends` (e.g. GroupTypeDetailAdminDto) include inherited properties
- [x] All backend tests pass (1384 passed)
- [x] Frontend typecheck and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Code <noreply@anthropic.com>