### PR TITLE
feat(person): add giving history section to person detail page

### DIFF
--- a/src/Koinon.Api/Controllers/PeopleController.cs
+++ b/src/Koinon.Api/Controllers/PeopleController.cs
@@ -2,6 +2,7 @@ using Koinon.Api.Filters;
 using Koinon.Application.Common;
 using Koinon.Application.DTOs;
 using Koinon.Application.DTOs.Files;
+using Koinon.Application.DTOs.Giving;
 using Koinon.Application.DTOs.Requests;
 using Koinon.Application.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -320,6 +321,42 @@ public class PeopleController(
                 totalPages = (int)Math.Ceiling(result.TotalCount / (double)result.PageSize)
             }
         });
+    }
+
+    /// <summary>
+    /// Gets a person's giving summary including YTD total, last contribution date, and recent contributions.
+    /// </summary>
+    /// <param name="idKey">The person's IdKey</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Giving summary with YTD total and last 10 contributions</returns>
+    /// <response code="200">Returns the giving summary</response>
+    /// <response code="404">Person not found</response>
+    [HttpGet("{idKey}/giving-summary")]
+    [ValidateIdKey]
+    [ProducesResponseType(typeof(PersonGivingSummaryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetGivingSummary(string idKey, CancellationToken ct = default)
+    {
+        var result = await personService.GetGivingSummaryAsync(idKey, ct);
+
+        if (result.IsFailure)
+        {
+            logger.LogDebug("Person not found for giving summary: IdKey={IdKey}", idKey);
+
+            return NotFound(new ProblemDetails
+            {
+                Title = "Person not found",
+                Detail = result.Error!.Message,
+                Status = StatusCodes.Status404NotFound,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        logger.LogInformation(
+            "Giving summary retrieved for person: IdKey={IdKey}, YTD={YtdTotal}",
+            idKey, result.Value!.YearToDateTotal);
+
+        return Ok(new { data = result.Value });
     }
 
     /// <summary>

--- a/src/Koinon.Application/DTOs/Giving/PersonGivingSummaryDto.cs
+++ b/src/Koinon.Application/DTOs/Giving/PersonGivingSummaryDto.cs
@@ -1,0 +1,53 @@
+namespace Koinon.Application.DTOs.Giving;
+
+/// <summary>
+/// DTO representing a person's giving summary including YTD total and recent contributions.
+/// </summary>
+public record PersonGivingSummaryDto
+{
+    /// <summary>
+    /// Sum of all contributions in the current calendar year.
+    /// </summary>
+    public required decimal YearToDateTotal { get; init; }
+
+    /// <summary>
+    /// Date and time of the most recent contribution, or null if no contributions exist.
+    /// </summary>
+    public DateTime? LastContributionDate { get; init; }
+
+    /// <summary>
+    /// The 10 most recent contributions, ordered by transaction date descending.
+    /// </summary>
+    public required List<RecentContributionDto> RecentContributions { get; init; }
+}
+
+/// <summary>
+/// DTO representing a single recent contribution line item.
+/// </summary>
+public record RecentContributionDto
+{
+    /// <summary>
+    /// URL-safe IdKey for the contribution detail record.
+    /// </summary>
+    public required string IdKey { get; init; }
+
+    /// <summary>
+    /// Date and time when the contribution occurred.
+    /// </summary>
+    public required DateTime TransactionDateTime { get; init; }
+
+    /// <summary>
+    /// Amount allocated to the fund for this line item.
+    /// </summary>
+    public required decimal Amount { get; init; }
+
+    /// <summary>
+    /// Name of the fund this contribution was allocated to.
+    /// </summary>
+    public required string FundName { get; init; }
+
+    /// <summary>
+    /// Transaction type label (Cash, Check, Card, ACH), or null if not set.
+    /// </summary>
+    public string? TransactionType { get; init; }
+}

--- a/src/Koinon.Application/Interfaces/IPersonService.cs
+++ b/src/Koinon.Application/Interfaces/IPersonService.cs
@@ -1,5 +1,6 @@
 using Koinon.Application.Common;
 using Koinon.Application.DTOs;
+using Koinon.Application.DTOs.Giving;
 using Koinon.Application.DTOs.Requests;
 
 namespace Koinon.Application.Interfaces;
@@ -75,4 +76,13 @@ public interface IPersonService
         int page = 1,
         int pageSize = 25,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a person's giving summary: YTD total, last contribution date, and last 10 contributions.
+    /// Returns Failure(NotFound) when the person does not exist.
+    /// </summary>
+    /// <param name="idKey">Person's IdKey</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Result containing the giving summary DTO</returns>
+    Task<Result<PersonGivingSummaryDto>> GetGivingSummaryAsync(string idKey, CancellationToken ct = default);
 }

--- a/src/Koinon.Application/Services/PersonService.cs
+++ b/src/Koinon.Application/Services/PersonService.cs
@@ -4,6 +4,7 @@ using FluentValidation;
 using Koinon.Application.Common;
 using Koinon.Application.Constants;
 using Koinon.Application.DTOs;
+using Koinon.Application.DTOs.Giving;
 using Koinon.Application.DTOs.Requests;
 using Koinon.Application.Interfaces;
 using Koinon.Domain.Data;
@@ -585,6 +586,88 @@ public class PersonService(
 
         return new PagedResult<PersonGroupMembershipDto>(
             items, totalCount, page, pageSize);
+    }
+
+    public async Task<Result<PersonGivingSummaryDto>> GetGivingSummaryAsync(
+        string idKey,
+        CancellationToken ct = default)
+    {
+        if (!IdKeyHelper.TryDecode(idKey, out int id))
+        {
+            return Result<PersonGivingSummaryDto>.Failure(Error.NotFound("Person", idKey));
+        }
+
+        var personExists = await context.People.AnyAsync(p => p.Id == id, ct);
+        if (!personExists)
+        {
+            return Result<PersonGivingSummaryDto>.Failure(Error.NotFound("Person", idKey));
+        }
+
+        // Collect all PersonAlias IDs for this person
+        var aliasIds = await context.PersonAliases
+            .AsNoTracking()
+            .Where(pa => pa.PersonId == id)
+            .Select(pa => pa.Id)
+            .ToListAsync(ct);
+
+        var currentYear = DateTime.UtcNow.Year;
+
+        // YTD total: sum all ContributionDetail amounts for contributions in the current year
+        var ytdTotal = await context.ContributionDetails
+            .AsNoTracking()
+            .Where(cd =>
+                cd.Contribution != null &&
+                cd.Contribution.PersonAliasId != null &&
+                aliasIds.Contains(cd.Contribution.PersonAliasId.Value) &&
+                cd.Contribution.TransactionDateTime.Year == currentYear)
+            .SumAsync(cd => cd.Amount, ct);
+
+        // Last contribution date across all contributions linked to this person's aliases
+        var lastContributionDate = await context.Contributions
+            .AsNoTracking()
+            .Where(c =>
+                c.PersonAliasId != null &&
+                aliasIds.Contains(c.PersonAliasId.Value))
+            .OrderByDescending(c => c.TransactionDateTime)
+            .Select(c => (DateTime?)c.TransactionDateTime)
+            .FirstOrDefaultAsync(ct);
+
+        // Last 10 contribution details (one row per fund allocation), newest first
+        var recentContributions = await context.ContributionDetails
+            .AsNoTracking()
+            .Include(cd => cd.Contribution)
+                .ThenInclude(c => c!.TransactionTypeValue)
+            .Include(cd => cd.Fund)
+            .Where(cd =>
+                cd.Contribution != null &&
+                cd.Contribution.PersonAliasId != null &&
+                aliasIds.Contains(cd.Contribution.PersonAliasId.Value))
+            .OrderByDescending(cd => cd.Contribution!.TransactionDateTime)
+            .Take(10)
+            .Select(cd => new RecentContributionDto
+            {
+                IdKey = IdKeyHelper.Encode(cd.Id),
+                TransactionDateTime = cd.Contribution!.TransactionDateTime,
+                Amount = cd.Amount,
+                FundName = cd.Fund != null ? cd.Fund.Name : "(Unknown Fund)",
+                TransactionType = cd.Contribution.TransactionTypeValue != null
+                    ? cd.Contribution.TransactionTypeValue.Value
+                    : null
+            })
+            .ToListAsync(ct);
+
+        logger.LogInformation(
+            "Retrieved giving summary for person {PersonId}: YTD={YtdTotal}, RecentCount={Count}",
+            id, ytdTotal, recentContributions.Count);
+
+        var summary = new PersonGivingSummaryDto
+        {
+            YearToDateTotal = ytdTotal,
+            LastContributionDate = lastContributionDate,
+            RecentContributions = recentContributions
+        };
+
+        return Result<PersonGivingSummaryDto>.Success(summary);
     }
 
 }

--- a/src/web/src/components/admin/people/GivingHistorySection.tsx
+++ b/src/web/src/components/admin/people/GivingHistorySection.tsx
@@ -1,0 +1,128 @@
+/**
+ * GivingHistorySection Component
+ * Displays year-to-date giving total and recent contribution history for a person
+ */
+
+import { Link } from 'react-router-dom';
+import { usePersonGivingSummary } from '@/hooks/usePeople';
+
+interface GivingHistorySectionProps {
+  personIdKey: string;
+}
+
+function formatCurrency(amount: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+  }).format(amount);
+}
+
+function formatDate(dateTime: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(dateTime));
+}
+
+export function GivingHistorySection({ personIdKey }: GivingHistorySectionProps) {
+  const { data: summary, isLoading, error } = usePersonGivingSummary(personIdKey);
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Giving History</h2>
+        <div className="flex items-center justify-center py-8">
+          <div className="w-8 h-8 border-4 border-gray-200 border-t-primary-600 rounded-full animate-spin" />
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">Giving History</h2>
+        <p className="text-red-600 text-sm">Failed to load giving history</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-900">Giving History</h2>
+        <Link
+          to="/admin/giving/statements"
+          className="text-sm text-primary-600 hover:text-primary-700"
+        >
+          View Statements
+        </Link>
+      </div>
+
+      {/* Summary row */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6 p-4 bg-gray-50 rounded-lg">
+        <div>
+          <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+            Year-to-Date Total
+          </p>
+          <p className="mt-1 text-2xl font-semibold text-gray-900">
+            {formatCurrency(summary?.yearToDateTotal ?? 0)}
+          </p>
+        </div>
+        <div>
+          <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+            Last Contribution
+          </p>
+          <p className="mt-1 text-base text-gray-900">
+            {summary?.lastContributionDate
+              ? formatDate(summary.lastContributionDate)
+              : 'None on record'}
+          </p>
+        </div>
+      </div>
+
+      {/* Recent contributions table */}
+      {!summary?.recentContributions.length ? (
+        <p className="text-sm text-gray-500 text-center py-6">No contributions on record.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200">
+                <th className="pb-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wide">
+                  Date
+                </th>
+                <th className="pb-2 text-right text-xs font-medium text-gray-500 uppercase tracking-wide">
+                  Amount
+                </th>
+                <th className="pb-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wide pl-4">
+                  Fund
+                </th>
+                <th className="pb-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wide pl-4">
+                  Type
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {summary.recentContributions.map((contribution) => (
+                <tr key={contribution.idKey}>
+                  <td className="py-3 text-gray-900 whitespace-nowrap">
+                    {formatDate(contribution.transactionDateTime)}
+                  </td>
+                  <td className="py-3 text-right text-gray-900 font-medium whitespace-nowrap">
+                    {formatCurrency(contribution.amount)}
+                  </td>
+                  <td className="py-3 text-gray-700 pl-4">{contribution.fundName}</td>
+                  <td className="py-3 text-gray-500 pl-4">
+                    {contribution.transactionType ?? '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/web/src/hooks/usePeople.ts
+++ b/src/web/src/hooks/usePeople.ts
@@ -116,3 +116,15 @@ export function usePersonGroups(idKey?: string) {
     staleTime: 5 * 60 * 1000, // 5 minutes
   });
 }
+
+/**
+ * Get giving summary for a person (YTD total + recent contributions)
+ */
+export function usePersonGivingSummary(idKey?: string) {
+  return useQuery({
+    queryKey: ['people', idKey, 'giving-summary'],
+    queryFn: () => peopleApi.getPersonGivingSummary(idKey!),
+    enabled: !!idKey,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}

--- a/src/web/src/pages/admin/people/PersonDetailPage.tsx
+++ b/src/web/src/pages/admin/people/PersonDetailPage.tsx
@@ -7,6 +7,7 @@ import { useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { usePerson, usePersonFamily, usePersonGroups, useDeletePerson } from '@/hooks/usePeople';
 import { CommunicationPreferences } from '@/components/admin/people/CommunicationPreferences';
+import { GivingHistorySection } from '@/components/admin/people/GivingHistorySection';
 import { useToast } from '@/contexts/ToastContext';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 
@@ -292,6 +293,9 @@ export function PersonDetailPage() {
           </ul>
         </div>
       )}
+
+      {/* Giving History */}
+      <GivingHistorySection personIdKey={idKey!} />
 
       {/* Delete Confirmation Dialog */}
       <ConfirmDialog

--- a/src/web/src/services/api/people.ts
+++ b/src/web/src/services/api/people.ts
@@ -13,6 +13,7 @@ import type {
   PersonFamilyResponse,
   GroupMembershipDto,
   PersonGroupsParams,
+  PersonGivingSummaryDto,
 } from './types';
 
 /**
@@ -103,6 +104,14 @@ export async function getPersonGroups(
   const endpoint = `/people/${idKey}/groups${query ? `?${query}` : ''}`;
 
   return get<PagedResult<GroupMembershipDto>>(endpoint);
+}
+
+/**
+ * Get giving summary for a person (YTD total + recent contributions)
+ */
+export async function getPersonGivingSummary(idKey: string): Promise<PersonGivingSummaryDto> {
+  const response = await get<{ data: PersonGivingSummaryDto }>(`/people/${idKey}/giving-summary`);
+  return response.data;
 }
 
 /**

--- a/src/web/src/services/api/types.ts
+++ b/src/web/src/services/api/types.ts
@@ -1376,6 +1376,24 @@ export interface AuditLogExportParams {
 }
 
 // ============================================================================
+// Giving Types
+// ============================================================================
+
+export interface PersonGivingSummaryDto {
+  yearToDateTotal: number;
+  lastContributionDate?: DateTime;
+  recentContributions: RecentContributionDto[];
+}
+
+export interface RecentContributionDto {
+  idKey: IdKey;
+  transactionDateTime: DateTime;
+  amount: number;
+  fundName: string;
+  transactionType?: string;
+}
+
+// ============================================================================
 // Data Export Types
 // ============================================================================
 

--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-03-27T09:57:49-04:00",
+  "generated_at": "2026-03-27T10:46:06-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -2391,6 +2391,27 @@
         "IsPublic": "bool"
       },
       "linked_entity": "Fund"
+    },
+    "PersonGivingSummaryDto": {
+      "name": "PersonGivingSummaryDto",
+      "namespace": "Koinon.Application.DTOs.Giving",
+      "properties": {
+        "YearToDateTotal": "decimal",
+        "LastContributionDate": "DateTime?",
+        "RecentContributions": "List<RecentContributionDto>"
+      },
+      "linked_entity": "Person"
+    },
+    "RecentContributionDto": {
+      "name": "RecentContributionDto",
+      "namespace": "Koinon.Application.DTOs.Giving",
+      "properties": {
+        "IdKey": "string",
+        "TransactionDateTime": "DateTime",
+        "Amount": "decimal",
+        "FundName": "string",
+        "TransactionType": "string?"
+      }
     },
     "PersonLookupDto": {
       "name": "PersonLookupDto",
@@ -5964,6 +5985,11 @@
           "name": "GetGroupsAsync",
           "return_type": "Task<PagedResult<PersonGroupMembershipDto>>",
           "is_async": false
+        },
+        {
+          "name": "GetGivingSummaryAsync",
+          "return_type": "Task<Result<PersonGivingSummaryDto>>",
+          "is_async": false
         }
       ],
       "dependencies": [
@@ -8291,6 +8317,15 @@
           "required_roles": []
         },
         {
+          "name": "GetGivingSummary",
+          "method": "GET",
+          "route": "{idKey}/giving-summary",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
           "name": "GetFamily",
           "method": "GET",
           "route": "{idKey}/family",
@@ -9188,6 +9223,11 @@
     {
       "source": "FundDto",
       "target": "Fund",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "PersonGivingSummaryDto",
+      "target": "Person",
       "relationship": "maps_to"
     },
     {
@@ -10816,6 +10856,11 @@
       "relationship": "returns"
     },
     {
+      "source": "PersonService",
+      "target": "PersonGivingSummaryDto",
+      "relationship": "returns"
+    },
+    {
       "source": "PublicGroupService",
       "target": "GroupDto",
       "relationship": "returns"
@@ -11223,9 +11268,9 @@
   ],
   "summary": {
     "total_entities": 59,
-    "total_dtos": 197,
+    "total_dtos": 199,
     "total_services": 107,
     "total_controllers": 34,
-    "total_relationships": 476
+    "total_relationships": 478
   }
 }

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-03-27T14:27:47.710Z",
+  "generated_at": "2026-03-27T15:19:36.854Z",
   "types": {
     "AttendanceAnalyticsDto": {
       "name": "AttendanceAnalyticsDto",
@@ -3676,6 +3676,28 @@
       },
       "path": "services/api/types.ts"
     },
+    "PersonGivingSummaryDto": {
+      "name": "PersonGivingSummaryDto",
+      "kind": "interface",
+      "properties": {
+        "yearToDateTotal": "number",
+        "lastContributionDate": "DateTime",
+        "recentContributions": "RecentContributionDto[]"
+      },
+      "path": "services/api/types.ts"
+    },
+    "RecentContributionDto": {
+      "name": "RecentContributionDto",
+      "kind": "interface",
+      "properties": {
+        "idKey": "IdKey",
+        "transactionDateTime": "DateTime",
+        "amount": "number",
+        "fundName": "string",
+        "transactionType": "string"
+      },
+      "path": "services/api/types.ts"
+    },
     "DataExportJobDto": {
       "name": "DataExportJobDto",
       "kind": "interface",
@@ -4751,6 +4773,13 @@
       "endpoint": "/people/${idKey}/family",
       "method": "GET",
       "responseType": "PersonFamilyResponse"
+    },
+    "getPersonGivingSummary": {
+      "name": "getPersonGivingSummary",
+      "path": "services/api/people.ts",
+      "endpoint": "/people/${idKey}/giving-summary",
+      "method": "GET",
+      "responseType": "PersonGivingSummaryDto"
     },
     "uploadPersonPhoto": {
       "name": "uploadPersonPhoto",
@@ -6365,6 +6394,19 @@
       "usesMutation": false,
       "dependencies": []
     },
+    "usePersonGivingSummary": {
+      "name": "usePersonGivingSummary",
+      "path": "hooks/usePeople.ts",
+      "apiBinding": "",
+      "queryKey": [
+        "people"
+      ],
+      "usesQuery": true,
+      "usesMutation": false,
+      "dependencies": [
+        "getPersonGivingSummary"
+      ]
+    },
     "useDuplicates": {
       "name": "useDuplicates",
       "path": "hooks/usePersonMerge.ts",
@@ -7026,6 +7068,14 @@
       "hooksUsed": [
         "useCommunicationPreferences",
         "useUpdateCommunicationPreference"
+      ],
+      "apiCallsDirectly": false
+    },
+    "GivingHistorySection": {
+      "name": "GivingHistorySection",
+      "path": "components/admin/people/GivingHistorySection.tsx",
+      "hooksUsed": [
+        "usePersonGivingSummary"
       ],
       "apiCallsDirectly": false
     },
@@ -7786,6 +7836,11 @@
     {
       "from": "CommunicationPreferences",
       "to": "useUpdateCommunicationPreference",
+      "type": "uses_hook"
+    },
+    {
+      "from": "GivingHistorySection",
+      "to": "usePersonGivingSummary",
       "type": "uses_hook"
     },
     {

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-03-27T09:57:49-04:00",
+  "generated_at": "2026-03-27T10:46:06-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -2391,6 +2391,27 @@
         "IsPublic": "bool"
       },
       "linked_entity": "Fund"
+    },
+    "PersonGivingSummaryDto": {
+      "name": "PersonGivingSummaryDto",
+      "namespace": "Koinon.Application.DTOs.Giving",
+      "properties": {
+        "YearToDateTotal": "decimal",
+        "LastContributionDate": "DateTime?",
+        "RecentContributions": "List<RecentContributionDto>"
+      },
+      "linked_entity": "Person"
+    },
+    "RecentContributionDto": {
+      "name": "RecentContributionDto",
+      "namespace": "Koinon.Application.DTOs.Giving",
+      "properties": {
+        "IdKey": "string",
+        "TransactionDateTime": "DateTime",
+        "Amount": "decimal",
+        "FundName": "string",
+        "TransactionType": "string?"
+      }
     },
     "PersonLookupDto": {
       "name": "PersonLookupDto",
@@ -5964,6 +5985,11 @@
           "name": "GetGroupsAsync",
           "return_type": "Task<PagedResult<PersonGroupMembershipDto>>",
           "is_async": false
+        },
+        {
+          "name": "GetGivingSummaryAsync",
+          "return_type": "Task<Result<PersonGivingSummaryDto>>",
+          "is_async": false
         }
       ],
       "dependencies": [
@@ -8285,6 +8311,15 @@
           "name": "GetGroups",
           "method": "GET",
           "route": "{idKey}/groups",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
+          "name": "GetGivingSummary",
+          "method": "GET",
+          "route": "{idKey}/giving-summary",
           "request_type": null,
           "response_type": null,
           "requires_auth": true,
@@ -12514,6 +12549,28 @@
       },
       "path": "services/api/types.ts"
     },
+    "PersonGivingSummaryDto": {
+      "name": "PersonGivingSummaryDto",
+      "kind": "interface",
+      "properties": {
+        "yearToDateTotal": "number",
+        "lastContributionDate": "DateTime",
+        "recentContributions": "RecentContributionDto[]"
+      },
+      "path": "services/api/types.ts"
+    },
+    "RecentContributionDto": {
+      "name": "RecentContributionDto",
+      "kind": "interface",
+      "properties": {
+        "idKey": "IdKey",
+        "transactionDateTime": "DateTime",
+        "amount": "number",
+        "fundName": "string",
+        "transactionType": "string"
+      },
+      "path": "services/api/types.ts"
+    },
     "DataExportJobDto": {
       "name": "DataExportJobDto",
       "kind": "interface",
@@ -14046,6 +14103,19 @@
       "usesMutation": false,
       "dependencies": []
     },
+    "usePersonGivingSummary": {
+      "name": "usePersonGivingSummary",
+      "path": "hooks/usePeople.ts",
+      "apiBinding": "",
+      "queryKey": [
+        "people"
+      ],
+      "usesQuery": true,
+      "usesMutation": false,
+      "dependencies": [
+        "getPersonGivingSummary"
+      ]
+    },
     "useDuplicates": {
       "name": "useDuplicates",
       "path": "hooks/usePersonMerge.ts",
@@ -15401,6 +15471,13 @@
       "method": "GET",
       "responseType": "PersonFamilyResponse"
     },
+    "getPersonGivingSummary": {
+      "name": "getPersonGivingSummary",
+      "path": "services/api/people.ts",
+      "endpoint": "/people/${idKey}/giving-summary",
+      "method": "GET",
+      "responseType": "PersonGivingSummaryDto"
+    },
     "uploadPersonPhoto": {
       "name": "uploadPersonPhoto",
       "path": "services/api/people.ts",
@@ -15864,6 +15941,14 @@
       "hooksUsed": [
         "useCommunicationPreferences",
         "useUpdateCommunicationPreference"
+      ],
+      "apiCallsDirectly": false
+    },
+    "GivingHistorySection": {
+      "name": "GivingHistorySection",
+      "path": "components/admin/people/GivingHistorySection.tsx",
+      "hooksUsed": [
+        "usePersonGivingSummary"
       ],
       "apiCallsDirectly": false
     },
@@ -16844,6 +16929,11 @@
     {
       "source": "FundDto",
       "target": "Fund",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "PersonGivingSummaryDto",
+      "target": "Person",
       "relationship": "maps_to"
     },
     {
@@ -18472,6 +18562,11 @@
       "relationship": "returns"
     },
     {
+      "source": "PersonService",
+      "target": "PersonGivingSummaryDto",
+      "relationship": "returns"
+    },
+    {
       "source": "PublicGroupService",
       "target": "GroupDto",
       "relationship": "returns"
@@ -19007,6 +19102,11 @@
       "type": "uses_hook"
     },
     {
+      "from": "GivingHistorySection",
+      "to": "usePersonGivingSummary",
+      "type": "uses_hook"
+    },
+    {
       "from": "PersonComparisonView",
       "to": "usePersonComparison",
       "type": "uses_hook"
@@ -19275,6 +19375,8 @@
     "dto:StatementPreviewDto": "type:StatementPreviewDto",
     "dto:EligiblePersonDto": "type:EligiblePersonDto",
     "dto:FundDto": "type:FundDto",
+    "dto:PersonGivingSummaryDto": "type:PersonGivingSummaryDto",
+    "dto:RecentContributionDto": "type:RecentContributionDto",
     "dto:PersonLookupDto": "type:PersonLookupDto",
     "dto:GlobalSearchResultDto": "type:GlobalSearchResult",
     "dto:GlobalSearchResponse": "type:GlobalSearchResponse",
@@ -19386,13 +19488,13 @@
   },
   "stats": {
     "entities": 59,
-    "dtos": 197,
+    "dtos": 199,
     "services": 107,
     "controllers": 34,
-    "types": 297,
-    "api_functions": 165,
-    "hooks": 143,
-    "components": 130,
-    "total_edges": 543
+    "types": 299,
+    "api_functions": 166,
+    "hooks": 144,
+    "components": 131,
+    "total_edges": 546
   }
 }


### PR DESCRIPTION
## Summary
- Add `GET /people/{idKey}/giving-summary` endpoint with YTD total, last contribution date, and recent contributions
- Create `GivingHistorySection` component on person detail page with currency formatting and contribution table
- Full-stack: PersonGivingSummaryDto, PersonService method, PeopleController endpoint, frontend hook + component

## Test plan
- [ ] Giving summary displays YTD total and last contribution date
- [ ] Recent contributions table shows date, amount, fund, type
- [ ] Empty state shows "No contributions on record"

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)