### PR TITLE
feat(person): add group memberships section to person detail page

### DIFF
--- a/src/web/src/components/admin/people/GroupMembershipsSection.tsx
+++ b/src/web/src/components/admin/people/GroupMembershipsSection.tsx
@@ -1,0 +1,83 @@
+/**
+ * GroupMembershipsSection Component
+ * Displays a person's group memberships in a table layout.
+ */
+
+import { Link } from 'react-router-dom';
+import type { GroupMembershipDto, GroupMemberStatus } from '@/services/api/types';
+
+interface GroupMembershipsSectionProps {
+  memberships: GroupMembershipDto[];
+  isLoading: boolean;
+}
+
+function StatusBadge({ status }: { status: GroupMemberStatus }) {
+  const styles: Record<GroupMemberStatus, string> = {
+    Active: 'bg-green-100 text-green-800',
+    Inactive: 'bg-gray-100 text-gray-700',
+    Pending: 'bg-yellow-100 text-yellow-800',
+  };
+
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full ${styles[status]}`}>
+      {status}
+    </span>
+  );
+}
+
+function formatJoinDate(dateAdded?: string): string {
+  if (!dateAdded) return '\u2014';
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(dateAdded));
+}
+
+export function GroupMembershipsSection({ memberships, isLoading }: GroupMembershipsSectionProps) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">Groups</h2>
+
+      {isLoading ? (
+        <div className="flex items-center justify-center py-8">
+          <div className="w-8 h-8 border-4 border-gray-200 border-t-primary-600 rounded-full animate-spin" />
+        </div>
+      ) : memberships.length === 0 ? (
+        <p className="text-sm text-gray-500">Not a member of any groups.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-gray-200">
+                <th className="text-left font-medium text-gray-700 pb-2 pr-4">Group</th>
+                <th className="text-left font-medium text-gray-700 pb-2 pr-4">Type</th>
+                <th className="text-left font-medium text-gray-700 pb-2 pr-4">Role</th>
+                <th className="text-left font-medium text-gray-700 pb-2 pr-4">Status</th>
+                <th className="text-left font-medium text-gray-700 pb-2">Joined</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {memberships.map((membership) => (
+                <tr key={membership.group.idKey} className="hover:bg-gray-50">
+                  <td className="py-3 pr-4">
+                    <Link
+                      to={`/admin/groups/${membership.group.idKey}`}
+                      className="text-primary-600 hover:text-primary-700 font-medium"
+                    >
+                      {membership.group.name}
+                    </Link>
+                  </td>
+                  <td className="py-3 pr-4 text-gray-600">{membership.group.groupTypeName}</td>
+                  <td className="py-3 pr-4 text-gray-600">{membership.role.name}</td>
+                  <td className="py-3 pr-4"><StatusBadge status={membership.status} /></td>
+                  <td className="py-3 text-gray-600">{formatJoinDate(membership.dateAdded)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/web/src/pages/admin/people/PersonDetailPage.tsx
+++ b/src/web/src/pages/admin/people/PersonDetailPage.tsx
@@ -8,6 +8,7 @@ import { useParams, Link, useNavigate } from 'react-router-dom';
 import { usePerson, usePersonFamily, usePersonGroups, useDeletePerson } from '@/hooks/usePeople';
 import { CommunicationPreferences } from '@/components/admin/people/CommunicationPreferences';
 import { AttendanceHistorySection } from '@/components/admin/people/AttendanceHistorySection';
+import { GroupMembershipsSection } from '@/components/admin/people/GroupMembershipsSection';
 import { useToast } from '@/contexts/ToastContext';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 
@@ -19,7 +20,7 @@ export function PersonDetailPage() {
 
   const { data: person, isLoading, error } = usePerson(idKey);
   const { data: familyData } = usePersonFamily(idKey);
-  const { data: groupsData } = usePersonGroups(idKey);
+  const { data: groupsData, isLoading: isGroupsLoading } = usePersonGroups(idKey);
 
   const deleteMutation = useDeletePerson();
 
@@ -272,27 +273,7 @@ export function PersonDetailPage() {
         </div>
       )}
 
-      {/* Groups */}
-      {groups.length > 0 && (
-        <div className="bg-white rounded-lg border border-gray-200 p-6">
-          <h2 className="text-lg font-semibold text-gray-900 mb-4">Groups</h2>
-          <ul className="space-y-2">
-            {groups.map((membership) => (
-              <li key={membership.group.idKey} className="flex items-center gap-2">
-                <Link
-                  to={`/admin/groups/${membership.group.idKey}`}
-                  className="text-primary-600 hover:text-primary-700"
-                >
-                  {membership.group.name}
-                </Link>
-                <span className="text-xs text-gray-500">
-                  ({membership.role.name} - {membership.status})
-                </span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+      <GroupMembershipsSection memberships={groups} isLoading={isGroupsLoading} />
 
       <AttendanceHistorySection personIdKey={idKey!} />
 


### PR DESCRIPTION
## Summary
- Extracts inline group memberships list into dedicated `GroupMembershipsSection` component
- Table layout with Group (linked), Type, Role, Status badges (Active/Inactive/Pending), Join date
- Handles loading and empty states gracefully
- Frontend-only change — uses existing `usePersonGroups` hook and `GroupMembershipDto` type

## Files Changed (2)
- `src/web/src/components/admin/people/GroupMembershipsSection.tsx` — new component
- `src/web/src/pages/admin/people/PersonDetailPage.tsx` — wire up component, remove inline code

## Test Coverage
- Frontend: 189 unit tests pass, tsc + eslint clean
- Backend: 1406 tests pass (unchanged)

Supersedes #515. Closes #485

🤖 Generated with [Claude Code](https://claude.com/claude-code)