### PR TITLE
feat(person): add giving history section to person detail page

### DIFF
--- a/src/Koinon.Api/Controllers/PeopleController.cs
+++ b/src/Koinon.Api/Controllers/PeopleController.cs
@@ -2,6 +2,7 @@ using Koinon.Api.Filters;
 using Koinon.Application.Common;
 using Koinon.Application.DTOs;
 using Koinon.Application.DTOs.Files;
+using Koinon.Application.DTOs.Giving;
 using Koinon.Application.DTOs.Requests;
 using Koinon.Application.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -381,6 +382,43 @@ public class PeopleController(
         var history = await checkinAttendanceService.GetPersonAttendanceHistoryAsync(idKey, days, ct);
         logger.LogDebug("Attendance history retrieved for person: IdKey={IdKey}, Days={Days}, Count={Count}", idKey, days, history.Count);
         return Ok(new { data = history });
+    }
+
+    /// <summary>
+    /// Gets the giving summary for a person, including YTD total, last contribution date,
+    /// and the 10 most recent contribution line items.
+    /// </summary>
+    /// <param name="idKey">The person's IdKey</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Giving summary</returns>
+    /// <response code="200">Returns giving summary</response>
+    /// <response code="404">Person not found</response>
+    [HttpGet("{idKey}/giving-summary")]
+    [ValidateIdKey]
+    [ProducesResponseType(typeof(PersonGivingSummaryDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetGivingSummary(string idKey, CancellationToken ct = default)
+    {
+        var result = await personService.GetGivingSummaryAsync(idKey, ct);
+
+        if (result.IsFailure)
+        {
+            logger.LogDebug("Person not found for giving summary: IdKey={IdKey}", idKey);
+
+            return NotFound(new ProblemDetails
+            {
+                Title = "Person not found",
+                Detail = result.Error!.Message,
+                Status = StatusCodes.Status404NotFound,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        logger.LogDebug(
+            "Giving summary retrieved for person: IdKey={IdKey}, YTD={YtdTotal}",
+            idKey, result.Value!.YearToDateTotal);
+
+        return Ok(new { data = result.Value });
     }
 
     /// <summary>

--- a/src/Koinon.Application/DTOs/Giving/PersonGivingSummaryDto.cs
+++ b/src/Koinon.Application/DTOs/Giving/PersonGivingSummaryDto.cs
@@ -1,0 +1,23 @@
+namespace Koinon.Application.DTOs.Giving;
+
+/// <summary>
+/// Summary of a person's giving activity.
+/// </summary>
+public record PersonGivingSummaryDto
+{
+    public required decimal YearToDateTotal { get; init; }
+    public DateTime? LastContributionDate { get; init; }
+    public required List<RecentContributionDto> RecentContributions { get; init; }
+}
+
+/// <summary>
+/// A single contribution detail line item for the giving history view.
+/// </summary>
+public record RecentContributionDto
+{
+    public required string IdKey { get; init; }
+    public required DateTime TransactionDateTime { get; init; }
+    public required decimal Amount { get; init; }
+    public required string FundName { get; init; }
+    public string? TransactionType { get; init; }
+}

--- a/src/Koinon.Application/Interfaces/IPersonService.cs
+++ b/src/Koinon.Application/Interfaces/IPersonService.cs
@@ -1,5 +1,6 @@
 using Koinon.Application.Common;
 using Koinon.Application.DTOs;
+using Koinon.Application.DTOs.Giving;
 using Koinon.Application.DTOs.Requests;
 
 namespace Koinon.Application.Interfaces;
@@ -75,4 +76,13 @@ public interface IPersonService
         int page = 1,
         int pageSize = 25,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a giving summary for a person including YTD total, last contribution date,
+    /// and the 10 most recent contribution detail records.
+    /// </summary>
+    /// <param name="idKey">Person's IdKey</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Giving summary DTO, or a not-found error when the person doesn't exist</returns>
+    Task<Result<PersonGivingSummaryDto>> GetGivingSummaryAsync(string idKey, CancellationToken ct = default);
 }

--- a/src/Koinon.Application/Services/PersonService.cs
+++ b/src/Koinon.Application/Services/PersonService.cs
@@ -4,6 +4,7 @@ using FluentValidation;
 using Koinon.Application.Common;
 using Koinon.Application.Constants;
 using Koinon.Application.DTOs;
+using Koinon.Application.DTOs.Giving;
 using Koinon.Application.DTOs.Requests;
 using Koinon.Application.Interfaces;
 using Koinon.Domain.Data;
@@ -585,6 +586,86 @@ public class PersonService(
 
         return new PagedResult<PersonGroupMembershipDto>(
             items, totalCount, page, pageSize);
+    }
+
+    public async Task<Result<PersonGivingSummaryDto>> GetGivingSummaryAsync(
+        string idKey,
+        CancellationToken ct = default)
+    {
+        if (!IdKeyHelper.TryDecode(idKey, out int id))
+        {
+            return Result<PersonGivingSummaryDto>.Failure(Error.NotFound("Person", idKey));
+        }
+
+        var personExists = await context.People.AnyAsync(p => p.Id == id, ct);
+        if (!personExists)
+        {
+            return Result<PersonGivingSummaryDto>.Failure(Error.NotFound("Person", idKey));
+        }
+
+        // Gather all PersonAlias IDs for this person (supports merged records)
+        var aliasIds = await context.PersonAliases
+            .AsNoTracking()
+            .Where(pa => pa.PersonId == id)
+            .Select(pa => pa.Id)
+            .ToListAsync(ct);
+
+        var currentYear = DateTime.UtcNow.Year;
+
+        // Year-to-date total across all ContributionDetail records linked to this person
+        var ytdTotal = await context.ContributionDetails
+            .AsNoTracking()
+            .Where(cd =>
+                cd.Contribution != null &&
+                cd.Contribution.PersonAliasId != null &&
+                aliasIds.Contains(cd.Contribution.PersonAliasId.Value) &&
+                cd.Contribution.TransactionDateTime.Year == currentYear)
+            .SumAsync(cd => (decimal?)cd.Amount, ct) ?? 0m;
+
+        // Date of the most recent contribution header
+        var lastContributionDate = await context.Contributions
+            .AsNoTracking()
+            .Where(c => c.PersonAliasId != null && aliasIds.Contains(c.PersonAliasId.Value))
+            .OrderByDescending(c => c.TransactionDateTime)
+            .Select(c => (DateTime?)c.TransactionDateTime)
+            .FirstOrDefaultAsync(ct);
+
+        // 10 most recent contribution detail line items
+        var recentContributions = await context.ContributionDetails
+            .AsNoTracking()
+            .Include(cd => cd.Contribution)
+                .ThenInclude(c => c!.TransactionTypeValue)
+            .Include(cd => cd.Fund)
+            .Where(cd =>
+                cd.Contribution != null &&
+                cd.Contribution.PersonAliasId != null &&
+                aliasIds.Contains(cd.Contribution.PersonAliasId.Value))
+            .OrderByDescending(cd => cd.Contribution!.TransactionDateTime)
+            .Take(10)
+            .Select(cd => new RecentContributionDto
+            {
+                IdKey = IdKeyHelper.Encode(cd.Id),
+                TransactionDateTime = cd.Contribution!.TransactionDateTime,
+                Amount = cd.Amount,
+                FundName = cd.Fund != null ? cd.Fund.Name : "(Unknown Fund)",
+                TransactionType = cd.Contribution.TransactionTypeValue != null
+                    ? cd.Contribution.TransactionTypeValue.Value
+                    : null
+            })
+            .ToListAsync(ct);
+
+        logger.LogInformation(
+            "Retrieved giving summary for person {PersonId}: YTD={YtdTotal}, LastDate={LastDate}, RecentCount={Count}",
+            id, ytdTotal, lastContributionDate, recentContributions.Count);
+
+        var summary = new PersonGivingSummaryDto
+        {
+            YearToDateTotal = ytdTotal,
+            LastContributionDate = lastContributionDate,
+            RecentContributions = recentContributions
+        };
+
+        return Result<PersonGivingSummaryDto>.Success(summary);
     }
 
 }

--- a/src/web/src/components/admin/people/GivingHistorySection.tsx
+++ b/src/web/src/components/admin/people/GivingHistorySection.tsx
@@ -1,0 +1,154 @@
+import { Link } from 'react-router-dom';
+import { usePersonGivingSummary } from '@/hooks/usePeople';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { EmptyState } from '@/components/ui/EmptyState';
+import type { RecentContributionDto } from '@/services/api/types';
+
+interface GivingHistorySectionProps {
+  personIdKey: string;
+}
+
+const usdFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+});
+
+function formatDate(isoString: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(isoString));
+}
+
+function GivingSummarySkeleton() {
+  return (
+    <div className="space-y-4" role="status" aria-label="Loading giving history">
+      <div className="flex gap-8">
+        <div className="space-y-1">
+          <Skeleton variant="text" height={14} width={80} />
+          <Skeleton variant="text" height={28} width={120} />
+        </div>
+        <div className="space-y-1">
+          <Skeleton variant="text" height={14} width={100} />
+          <Skeleton variant="text" height={20} width={100} />
+        </div>
+      </div>
+      <div className="space-y-2 mt-4">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <div key={i} className="flex gap-4 py-3 border-b border-gray-100">
+            <Skeleton variant="text" height={16} width="20%" />
+            <Skeleton variant="text" height={16} width="15%" />
+            <Skeleton variant="text" height={16} width="30%" />
+            <Skeleton variant="text" height={16} width="20%" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface ContributionsTableProps {
+  contributions: RecentContributionDto[];
+}
+
+function ContributionsTable({ contributions }: ContributionsTableProps) {
+  return (
+    <div className="overflow-x-auto mt-4">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-gray-200 text-left">
+            <th className="pb-2 pr-4 font-medium text-gray-600">Date</th>
+            <th className="pb-2 pr-4 font-medium text-gray-600">Amount</th>
+            <th className="pb-2 pr-4 font-medium text-gray-600">Fund</th>
+            <th className="pb-2 font-medium text-gray-600">Type</th>
+          </tr>
+        </thead>
+        <tbody>
+          {contributions.map((contribution) => (
+            <tr
+              key={contribution.idKey}
+              className="border-b border-gray-100 hover:bg-gray-50"
+            >
+              <td className="py-3 pr-4 text-gray-900">
+                {formatDate(contribution.transactionDateTime)}
+              </td>
+              <td className="py-3 pr-4 text-gray-900 font-medium tabular-nums">
+                {usdFormatter.format(contribution.amount)}
+              </td>
+              <td className="py-3 pr-4 text-gray-700">{contribution.fundName}</td>
+              <td className="py-3 text-gray-500">
+                {contribution.transactionType ?? (
+                  <span className="text-gray-400">—</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function GivingHistorySection({ personIdKey }: GivingHistorySectionProps) {
+  const { data: summary, isLoading, isError } = usePersonGivingSummary(personIdKey);
+
+  return (
+    <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-900">Giving History</h2>
+        <Link
+          to="/admin/giving/statements"
+          className="text-sm text-primary-600 hover:text-primary-700"
+        >
+          View statements
+        </Link>
+      </div>
+
+      {isLoading && <GivingSummarySkeleton />}
+
+      {isError && (
+        <EmptyState
+          title="Failed to load giving history"
+          description="There was a problem loading this person's giving records. Please try again."
+        />
+      )}
+
+      {!isLoading && !isError && summary !== undefined && (
+        <>
+          {/* Summary stats */}
+          <div className="flex flex-wrap gap-8 mb-2">
+            <div>
+              <p className="text-sm font-medium text-gray-500">
+                Year-to-Date Total
+              </p>
+              <p className="text-2xl font-bold text-gray-900 tabular-nums">
+                {usdFormatter.format(summary.yearToDateTotal)}
+              </p>
+            </div>
+            <div>
+              <p className="text-sm font-medium text-gray-500">
+                Last Contribution
+              </p>
+              <p className="text-base text-gray-900">
+                {summary.lastContributionDate
+                  ? formatDate(summary.lastContributionDate)
+                  : <span className="text-gray-400">None on record</span>}
+              </p>
+            </div>
+          </div>
+
+          {/* Recent contributions table */}
+          {summary.recentContributions.length === 0 ? (
+            <EmptyState
+              title="No giving history found"
+              description="This person has no contribution records."
+            />
+          ) : (
+            <ContributionsTable contributions={summary.recentContributions} />
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/web/src/hooks/usePeople.ts
+++ b/src/web/src/hooks/usePeople.ts
@@ -127,3 +127,15 @@ export function usePersonAttendance(personIdKey?: string, days = 90) {
     enabled: !!personIdKey,
   });
 }
+
+/**
+ * Get giving summary for a person (YTD total, last contribution date, recent contributions)
+ */
+export function usePersonGivingSummary(idKey?: string) {
+  return useQuery({
+    queryKey: ['people', idKey, 'giving-summary'],
+    queryFn: () => peopleApi.getPersonGivingSummary(idKey!),
+    enabled: !!idKey,
+    staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}

--- a/src/web/src/pages/admin/people/PersonDetailPage.tsx
+++ b/src/web/src/pages/admin/people/PersonDetailPage.tsx
@@ -9,6 +9,7 @@ import { usePerson, usePersonFamily, usePersonGroups, useDeletePerson } from '@/
 import { CommunicationPreferences } from '@/components/admin/people/CommunicationPreferences';
 import { AttendanceHistorySection } from '@/components/admin/people/AttendanceHistorySection';
 import { GroupMembershipsSection } from '@/components/admin/people/GroupMembershipsSection';
+import { GivingHistorySection } from '@/components/admin/people/GivingHistorySection';
 import { useToast } from '@/contexts/ToastContext';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 
@@ -274,6 +275,8 @@ export function PersonDetailPage() {
       )}
 
       <GroupMembershipsSection memberships={groups} isLoading={isGroupsLoading} />
+
+      <GivingHistorySection personIdKey={idKey!} />
 
       <AttendanceHistorySection personIdKey={idKey!} />
 

--- a/src/web/src/services/api/people.ts
+++ b/src/web/src/services/api/people.ts
@@ -14,6 +14,7 @@ import type {
   GroupMembershipDto,
   PersonGroupsParams,
   AttendanceSummaryDto,
+  PersonGivingSummaryDto,
 } from './types';
 
 /**
@@ -115,6 +116,18 @@ export async function getPersonAttendance(
 ): Promise<AttendanceSummaryDto[]> {
   const response = await get<{ data: AttendanceSummaryDto[] }>(
     `/people/${personIdKey}/attendance?days=${days}`
+  );
+  return response.data;
+}
+
+/**
+ * Get the giving summary for a person (YTD total + recent contributions)
+ */
+export async function getPersonGivingSummary(
+  personIdKey: string
+): Promise<PersonGivingSummaryDto> {
+  const response = await get<{ data: PersonGivingSummaryDto }>(
+    `/people/${personIdKey}/giving-summary`
   );
   return response.data;
 }

--- a/src/web/src/services/api/types.ts
+++ b/src/web/src/services/api/types.ts
@@ -1450,6 +1450,24 @@ export interface AttendanceSummaryDto {
 }
 
 // ============================================================================
+// Giving History Types
+// ============================================================================
+
+export interface PersonGivingSummaryDto {
+  yearToDateTotal: number;
+  lastContributionDate?: DateTime;
+  recentContributions: RecentContributionDto[];
+}
+
+export interface RecentContributionDto {
+  idKey: IdKey;
+  transactionDateTime: DateTime;
+  amount: number;
+  fundName: string;
+  transactionType?: string;
+}
+
+// ============================================================================
 // Data Export Types
 // ============================================================================
 

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-03-26T23:23:13-04:00",
+  "generated_at": "2026-03-27T15:54:16-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -2435,6 +2435,27 @@
         "IsPublic": "bool"
       },
       "linked_entity": "Fund"
+    },
+    "PersonGivingSummaryDto": {
+      "name": "PersonGivingSummaryDto",
+      "namespace": "Koinon.Application.DTOs.Giving",
+      "properties": {
+        "YearToDateTotal": "decimal",
+        "LastContributionDate": "DateTime?",
+        "RecentContributions": "List<RecentContributionDto>"
+      },
+      "linked_entity": "Person"
+    },
+    "RecentContributionDto": {
+      "name": "RecentContributionDto",
+      "namespace": "Koinon.Application.DTOs.Giving",
+      "properties": {
+        "IdKey": "string",
+        "TransactionDateTime": "DateTime",
+        "Amount": "decimal",
+        "FundName": "string",
+        "TransactionType": "string?"
+      }
     },
     "PersonLookupDto": {
       "name": "PersonLookupDto",
@@ -6083,6 +6104,11 @@
           "name": "GetGroupsAsync",
           "return_type": "Task<PagedResult<PersonGroupMembershipDto>>",
           "is_async": false
+        },
+        {
+          "name": "GetGivingSummaryAsync",
+          "return_type": "Task<Result<PersonGivingSummaryDto>>",
+          "is_async": false
         }
       ],
       "dependencies": [
@@ -8478,6 +8504,24 @@
           "required_roles": []
         },
         {
+          "name": "GetAttendanceHistory",
+          "method": "GET",
+          "route": "{idKey}/attendance",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
+          "name": "GetGivingSummary",
+          "method": "GET",
+          "route": "{idKey}/giving-summary",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
           "name": "UploadPhoto",
           "method": "POST",
           "route": "{idKey}/photo",
@@ -8514,6 +8558,7 @@
       "dependencies": [
         "IPersonService",
         "IFileService",
+        "ICheckinAttendanceService",
         "ILogger<PeopleController>"
       ]
     },
@@ -9348,15 +9393,20 @@
       "kind": "interface",
       "properties": {
         "idKey": "IdKey",
-        "person": "CheckinPersonSummaryDtoCore",
-        "location": "CheckinLocationSummaryDtoCore",
+        "person": "{\n    idKey: IdKey",
+        "fullName": "string",
+        "firstName": "string",
+        "lastName": "string",
+        "location": "{\n    idKey: IdKey",
+        "name": "string",
+        "fullPath": "string",
         "startDateTime": "DateTime",
         "endDateTime": "DateTime",
         "securityCode": "string",
         "isFirstTime": "boolean",
         "note": "string"
       },
-      "path": "types/checkin-extended.ts"
+      "path": "services/api/types.ts"
     },
     "ExtendedCheckinRequestDto": {
       "name": "ExtendedCheckinRequestDto",
@@ -12773,6 +12823,28 @@
       },
       "path": "services/api/types.ts"
     },
+    "PersonGivingSummaryDto": {
+      "name": "PersonGivingSummaryDto",
+      "kind": "interface",
+      "properties": {
+        "yearToDateTotal": "number",
+        "lastContributionDate": "DateTime",
+        "recentContributions": "RecentContributionDto[]"
+      },
+      "path": "services/api/types.ts"
+    },
+    "RecentContributionDto": {
+      "name": "RecentContributionDto",
+      "kind": "interface",
+      "properties": {
+        "idKey": "IdKey",
+        "transactionDateTime": "DateTime",
+        "amount": "number",
+        "fundName": "string",
+        "transactionType": "string"
+      },
+      "path": "services/api/types.ts"
+    },
     "DataExportJobDto": {
       "name": "DataExportJobDto",
       "kind": "interface",
@@ -14381,6 +14453,32 @@
       "usesMutation": false,
       "dependencies": []
     },
+    "usePersonAttendance": {
+      "name": "usePersonAttendance",
+      "path": "hooks/usePeople.ts",
+      "apiBinding": "",
+      "queryKey": [
+        "person-attendance"
+      ],
+      "usesQuery": true,
+      "usesMutation": false,
+      "dependencies": [
+        "getPersonAttendance"
+      ]
+    },
+    "usePersonGivingSummary": {
+      "name": "usePersonGivingSummary",
+      "path": "hooks/usePeople.ts",
+      "apiBinding": "",
+      "queryKey": [
+        "people"
+      ],
+      "usesQuery": true,
+      "usesMutation": false,
+      "dependencies": [
+        "getPersonGivingSummary"
+      ]
+    },
     "useDuplicates": {
       "name": "useDuplicates",
       "path": "hooks/usePersonMerge.ts",
@@ -15778,6 +15876,20 @@
       "method": "GET",
       "responseType": "PersonFamilyResponse"
     },
+    "getPersonAttendance": {
+      "name": "getPersonAttendance",
+      "path": "services/api/people.ts",
+      "endpoint": "/people/${personIdKey}/attendance?days=${days}",
+      "method": "GET",
+      "responseType": "AttendanceSummaryDto[]"
+    },
+    "getPersonGivingSummary": {
+      "name": "getPersonGivingSummary",
+      "path": "services/api/people.ts",
+      "endpoint": "/people/${personIdKey}/giving-summary",
+      "method": "GET",
+      "responseType": "PersonGivingSummaryDto"
+    },
     "uploadPersonPhoto": {
       "name": "uploadPersonPhoto",
       "path": "services/api/people.ts",
@@ -16235,6 +16347,14 @@
       ],
       "apiCallsDirectly": false
     },
+    "AttendanceHistorySection": {
+      "name": "AttendanceHistorySection",
+      "path": "components/admin/people/AttendanceHistorySection.tsx",
+      "hooksUsed": [
+        "usePersonAttendance"
+      ],
+      "apiCallsDirectly": false
+    },
     "CommunicationPreferences": {
       "name": "CommunicationPreferences",
       "path": "components/admin/people/CommunicationPreferences.tsx",
@@ -16242,6 +16362,20 @@
         "useCommunicationPreferences",
         "useUpdateCommunicationPreference"
       ],
+      "apiCallsDirectly": false
+    },
+    "GivingHistorySection": {
+      "name": "GivingHistorySection",
+      "path": "components/admin/people/GivingHistorySection.tsx",
+      "hooksUsed": [
+        "usePersonGivingSummary"
+      ],
+      "apiCallsDirectly": false
+    },
+    "GroupMembershipsSection": {
+      "name": "GroupMembershipsSection",
+      "path": "components/admin/people/GroupMembershipsSection.tsx",
+      "hooksUsed": [],
       "apiCallsDirectly": false
     },
     "PersonCard": {
@@ -17234,6 +17368,11 @@
       "relationship": "maps_to"
     },
     {
+      "source": "PersonGivingSummaryDto",
+      "target": "Person",
+      "relationship": "maps_to"
+    },
+    {
       "source": "PersonLookupDto",
       "target": "Person",
       "relationship": "maps_to"
@@ -18021,6 +18160,11 @@
     {
       "source": "PeopleController",
       "target": "IFileService",
+      "relationship": "depends_on"
+    },
+    {
+      "source": "PeopleController",
+      "target": "ICheckinAttendanceService",
       "relationship": "depends_on"
     },
     {
@@ -18899,6 +19043,11 @@
       "relationship": "returns"
     },
     {
+      "source": "PersonService",
+      "target": "PersonGivingSummaryDto",
+      "relationship": "returns"
+    },
+    {
       "source": "PublicGroupService",
       "target": "GroupDto",
       "relationship": "returns"
@@ -19439,6 +19588,11 @@
       "type": "uses_hook"
     },
     {
+      "from": "AttendanceHistorySection",
+      "to": "usePersonAttendance",
+      "type": "uses_hook"
+    },
+    {
       "from": "CommunicationPreferences",
       "to": "useCommunicationPreferences",
       "type": "uses_hook"
@@ -19446,6 +19600,11 @@
     {
       "from": "CommunicationPreferences",
       "to": "useUpdateCommunicationPreference",
+      "type": "uses_hook"
+    },
+    {
+      "from": "GivingHistorySection",
+      "to": "usePersonGivingSummary",
       "type": "uses_hook"
     },
     {
@@ -19719,6 +19878,8 @@
     "dto:StatementPreviewDto": "type:StatementPreviewDto",
     "dto:EligiblePersonDto": "type:EligiblePersonDto",
     "dto:FundDto": "type:FundDto",
+    "dto:PersonGivingSummaryDto": "type:PersonGivingSummaryDto",
+    "dto:RecentContributionDto": "type:RecentContributionDto",
     "dto:PersonLookupDto": "type:PersonLookupDto",
     "dto:GlobalSearchResultDto": "type:GlobalSearchResult",
     "dto:GlobalSearchResponse": "type:GlobalSearchResponse",
@@ -19832,13 +19993,13 @@
   },
   "stats": {
     "entities": 59,
-    "dtos": 202,
+    "dtos": 204,
     "services": 109,
     "controllers": 35,
-    "types": 302,
-    "api_functions": 171,
-    "hooks": 149,
-    "components": 130,
-    "total_edges": 556
+    "types": 304,
+    "api_functions": 173,
+    "hooks": 151,
+    "components": 133,
+    "total_edges": 561
   }
 }


### PR DESCRIPTION
## Summary
- Adds giving history section to person detail page with YTD total, last contribution date, and recent contributions table
- Backend: `GET /api/v1/people/{idKey}/giving-summary` endpoint with `PersonGivingSummaryDto`
- Service queries `ContributionDetails` via `PersonAliases` for accurate per-person giving data
- Frontend: `GivingHistorySection` component with loading/empty states and currency formatting

## Files Changed (9 code + 3 graph)
- `src/Koinon.Application/DTOs/Giving/PersonGivingSummaryDto.cs` — new DTO
- `src/Koinon.Application/Interfaces/IPersonService.cs` — new method signature
- `src/Koinon.Application/Services/PersonService.cs` — implementation
- `src/Koinon.Api/Controllers/PeopleController.cs` — new endpoint
- `src/web/src/services/api/types.ts` — frontend types
- `src/web/src/services/api/people.ts` — API function
- `src/web/src/hooks/usePeople.ts` — hook
- `src/web/src/components/admin/people/GivingHistorySection.tsx` — component
- `src/web/src/pages/admin/people/PersonDetailPage.tsx` — wired up

## Test Coverage
- Backend: 1406 tests pass (0 failures)
- Frontend: 189 tests pass, tsc + eslint clean
- Graph baseline: updated and verified

Supersedes #516. Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)