### PR TITLE
feat(notes): add person notes/interaction log with security

### DIFF
--- a/src/Koinon.Api/Controllers/PeopleController.cs
+++ b/src/Koinon.Api/Controllers/PeopleController.cs
@@ -425,15 +425,23 @@ public class PeopleController(
     /// Gets all notes for a person, ordered by note date descending.
     /// </summary>
     /// <param name="idKey">The person's IdKey</param>
+    /// <param name="page">Page number (1-based, default 1)</param>
+    /// <param name="pageSize">Items per page (1-100, default 25)</param>
     /// <param name="ct">Cancellation token</param>
     /// <returns>List of person notes</returns>
     /// <response code="200">Returns list of notes</response>
     [HttpGet("{idKey}/notes")]
     [ValidateIdKey]
     [ProducesResponseType(typeof(IEnumerable<PersonNoteDto>), StatusCodes.Status200OK)]
-    public async Task<ActionResult<IEnumerable<PersonNoteDto>>> GetPersonNotes(string idKey, CancellationToken ct)
+    public async Task<ActionResult<IEnumerable<PersonNoteDto>>> GetPersonNotes(
+        string idKey,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 25,
+        CancellationToken ct = default)
     {
-        var notes = await personService.GetNotesAsync(idKey, ct);
+        page = Math.Max(1, page);
+        pageSize = Math.Clamp(pageSize, 1, 100);
+        var notes = await personService.GetNotesAsync(idKey, page, pageSize, ct);
 
         logger.LogDebug("Notes retrieved for person: IdKey={IdKey}", idKey);
 

--- a/src/Koinon.Api/Controllers/PeopleController.cs
+++ b/src/Koinon.Api/Controllers/PeopleController.cs
@@ -422,6 +422,147 @@ public class PeopleController(
     }
 
     /// <summary>
+    /// Gets all notes for a person, ordered by note date descending.
+    /// </summary>
+    /// <param name="idKey">The person's IdKey</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>List of person notes</returns>
+    /// <response code="200">Returns list of notes</response>
+    [HttpGet("{idKey}/notes")]
+    [ValidateIdKey]
+    [ProducesResponseType(typeof(IEnumerable<PersonNoteDto>), StatusCodes.Status200OK)]
+    public async Task<ActionResult<IEnumerable<PersonNoteDto>>> GetPersonNotes(string idKey, CancellationToken ct)
+    {
+        var notes = await personService.GetNotesAsync(idKey, ct);
+
+        logger.LogDebug("Notes retrieved for person: IdKey={IdKey}", idKey);
+
+        return Ok(new { data = notes });
+    }
+
+    /// <summary>
+    /// Creates a new note on a person record.
+    /// </summary>
+    /// <param name="idKey">The person's IdKey</param>
+    /// <param name="request">Note creation details</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Created note</returns>
+    /// <response code="201">Note created successfully</response>
+    /// <response code="404">Person not found</response>
+    [HttpPost("{idKey}/notes")]
+    [ValidateIdKey]
+    [ProducesResponseType(typeof(PersonNoteDto), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<PersonNoteDto>> CreatePersonNote(
+        string idKey,
+        [FromBody] CreatePersonNoteRequest request,
+        CancellationToken ct)
+    {
+        try
+        {
+            var note = await personService.CreateNoteAsync(idKey, request, ct);
+
+            logger.LogInformation(
+                "Note created for person: IdKey={IdKey}, NoteIdKey={NoteIdKey}",
+                idKey, note.IdKey);
+
+            return CreatedAtAction(
+                nameof(GetPersonNotes),
+                new { idKey },
+                new { data = note });
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound(new ProblemDetails
+            {
+                Title = "Person not found",
+                Detail = $"No person found with IdKey '{idKey}'",
+                Status = StatusCodes.Status404NotFound,
+                Instance = HttpContext.Request.Path
+            });
+        }
+    }
+
+    /// <summary>
+    /// Updates an existing note on a person record.
+    /// </summary>
+    /// <param name="idKey">The person's IdKey</param>
+    /// <param name="noteIdKey">The note's IdKey</param>
+    /// <param name="request">Note update details</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Updated note</returns>
+    /// <response code="200">Note updated successfully</response>
+    /// <response code="404">Person or note not found</response>
+    [HttpPut("{idKey}/notes/{noteIdKey}")]
+    [ValidateIdKey]
+    [ProducesResponseType(typeof(PersonNoteDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult<PersonNoteDto>> UpdatePersonNote(
+        string idKey,
+        string noteIdKey,
+        [FromBody] UpdatePersonNoteRequest request,
+        CancellationToken ct)
+    {
+        try
+        {
+            var note = await personService.UpdateNoteAsync(idKey, noteIdKey, request, ct);
+
+            logger.LogInformation(
+                "Note updated: IdKey={IdKey}, NoteIdKey={NoteIdKey}",
+                idKey, noteIdKey);
+
+            return Ok(new { data = note });
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound(new ProblemDetails
+            {
+                Title = "Note not found",
+                Detail = $"No note '{noteIdKey}' found for person '{idKey}'",
+                Status = StatusCodes.Status404NotFound,
+                Instance = HttpContext.Request.Path
+            });
+        }
+    }
+
+    /// <summary>
+    /// Deletes a note from a person record.
+    /// </summary>
+    /// <param name="idKey">The person's IdKey</param>
+    /// <param name="noteIdKey">The note's IdKey</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>No content</returns>
+    /// <response code="204">Note deleted successfully</response>
+    /// <response code="404">Person or note not found</response>
+    [HttpDelete("{idKey}/notes/{noteIdKey}")]
+    [ValidateIdKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<ActionResult> DeletePersonNote(string idKey, string noteIdKey, CancellationToken ct)
+    {
+        try
+        {
+            await personService.DeleteNoteAsync(idKey, noteIdKey, ct);
+
+            logger.LogInformation(
+                "Note deleted: IdKey={IdKey}, NoteIdKey={NoteIdKey}",
+                idKey, noteIdKey);
+
+            return NoContent();
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound(new ProblemDetails
+            {
+                Title = "Note not found",
+                Detail = $"No note '{noteIdKey}' found for person '{idKey}'",
+                Status = StatusCodes.Status404NotFound,
+                Instance = HttpContext.Request.Path
+            });
+        }
+    }
+
+    /// <summary>
     /// Maximum photo file size in bytes (5MB).
     /// </summary>
     private const long MaxPhotoSizeBytes = 5 * 1024 * 1024;

--- a/src/Koinon.Application/DTOs/PersonNoteDto.cs
+++ b/src/Koinon.Application/DTOs/PersonNoteDto.cs
@@ -1,0 +1,31 @@
+namespace Koinon.Application.DTOs;
+
+/// <summary>DTO for displaying a person note.</summary>
+public record PersonNoteDto(
+    string IdKey,
+    string Text,
+    DateTime NoteDate,
+    string? NoteType,
+    string? CreatedByName,
+    bool IsPrivate,
+    bool IsAlert,
+    DateTime CreatedDateTime
+);
+
+/// <summary>Request to create a person note.</summary>
+public record CreatePersonNoteRequest(
+    string Text,
+    DateTime NoteDate,
+    string? NoteTypeDefinedValueIdKey,
+    bool IsPrivate = false,
+    bool IsAlert = false
+);
+
+/// <summary>Request to update a person note.</summary>
+public record UpdatePersonNoteRequest(
+    string Text,
+    DateTime NoteDate,
+    string? NoteTypeDefinedValueIdKey,
+    bool IsPrivate = false,
+    bool IsAlert = false
+);

--- a/src/Koinon.Application/Interfaces/IApplicationDbContext.cs
+++ b/src/Koinon.Application/Interfaces/IApplicationDbContext.cs
@@ -13,6 +13,7 @@ public interface IApplicationDbContext
 {
     DbSet<Person> People { get; }
     DbSet<PersonAlias> PersonAliases { get; }
+    DbSet<PersonNote> PersonNotes { get; }
     DbSet<PhoneNumber> PhoneNumbers { get; }
     DbSet<Group> Groups { get; }
     DbSet<GroupType> GroupTypes { get; }

--- a/src/Koinon.Application/Interfaces/IPersonService.cs
+++ b/src/Koinon.Application/Interfaces/IPersonService.cs
@@ -89,7 +89,7 @@ public interface IPersonService
     /// <summary>
     /// Gets all notes for a person, ordered by note date descending.
     /// </summary>
-    Task<IEnumerable<PersonNoteDto>> GetNotesAsync(string personIdKey, CancellationToken ct = default);
+    Task<IEnumerable<PersonNoteDto>> GetNotesAsync(string personIdKey, int page = 1, int pageSize = 25, CancellationToken ct = default);
 
     /// <summary>
     /// Creates a new note on a person record.

--- a/src/Koinon.Application/Interfaces/IPersonService.cs
+++ b/src/Koinon.Application/Interfaces/IPersonService.cs
@@ -85,4 +85,24 @@ public interface IPersonService
     /// <param name="ct">Cancellation token</param>
     /// <returns>Giving summary DTO, or a not-found error when the person doesn't exist</returns>
     Task<Result<PersonGivingSummaryDto>> GetGivingSummaryAsync(string idKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets all notes for a person, ordered by note date descending.
+    /// </summary>
+    Task<IEnumerable<PersonNoteDto>> GetNotesAsync(string personIdKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Creates a new note on a person record.
+    /// </summary>
+    Task<PersonNoteDto> CreateNoteAsync(string personIdKey, CreatePersonNoteRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Updates an existing note, verifying it belongs to the specified person.
+    /// </summary>
+    Task<PersonNoteDto> UpdateNoteAsync(string personIdKey, string noteIdKey, UpdatePersonNoteRequest request, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes a note, verifying it belongs to the specified person.
+    /// </summary>
+    Task DeleteNoteAsync(string personIdKey, string noteIdKey, CancellationToken ct = default);
 }

--- a/src/Koinon.Application/Services/PersonService.cs
+++ b/src/Koinon.Application/Services/PersonService.cs
@@ -12,6 +12,7 @@ using Koinon.Domain.Entities;
 using Koinon.Domain.Enums;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using System.Collections.Generic;
 
 namespace Koinon.Application.Services;
 
@@ -666,6 +667,219 @@ public class PersonService(
         };
 
         return Result<PersonGivingSummaryDto>.Success(summary);
+    }
+
+    public async Task<IEnumerable<PersonNoteDto>> GetNotesAsync(
+        string personIdKey,
+        CancellationToken ct = default)
+    {
+        if (!IdKeyHelper.TryDecode(personIdKey, out int personId))
+        {
+            return Enumerable.Empty<PersonNoteDto>();
+        }
+
+        var notes = await context.PersonNotes
+            .AsNoTracking()
+            .Include(n => n.NoteTypeDefinedValue)
+            .Include(n => n.CreatedByPersonAlias)
+                .ThenInclude(pa => pa!.Person)
+            .Where(n => n.PersonId == personId)
+            .OrderByDescending(n => n.NoteDate)
+            .Select(n => new PersonNoteDto(
+                IdKeyHelper.Encode(n.Id),
+                n.Text,
+                n.NoteDate,
+                n.NoteTypeDefinedValue != null ? n.NoteTypeDefinedValue.Value : null,
+                n.CreatedByPersonAlias != null && n.CreatedByPersonAlias.Person != null
+                    ? n.CreatedByPersonAlias.Person.FullName
+                    : n.CreatedByPersonAlias != null
+                        ? n.CreatedByPersonAlias.Name
+                        : null,
+                n.IsPrivate,
+                n.IsAlert,
+                n.CreatedDateTime
+            ))
+            .ToListAsync(ct);
+
+        logger.LogInformation(
+            "Retrieved {Count} notes for person {PersonId}",
+            notes.Count, personId);
+
+        return notes;
+    }
+
+    public async Task<PersonNoteDto> CreateNoteAsync(
+        string personIdKey,
+        CreatePersonNoteRequest request,
+        CancellationToken ct = default)
+    {
+        if (!IdKeyHelper.TryDecode(personIdKey, out int personId))
+        {
+            throw new ArgumentException($"Invalid person IdKey: {personIdKey}", nameof(personIdKey));
+        }
+
+        var personExists = await context.People.AnyAsync(p => p.Id == personId, ct);
+        if (!personExists)
+        {
+            throw new KeyNotFoundException($"Person not found: {personIdKey}");
+        }
+
+        // Resolve note type if provided
+        int? noteTypeDefinedValueId = null;
+        if (!string.IsNullOrWhiteSpace(request.NoteTypeDefinedValueIdKey))
+        {
+            if (IdKeyHelper.TryDecode(request.NoteTypeDefinedValueIdKey, out int noteTypeId))
+            {
+                noteTypeDefinedValueId = noteTypeId;
+            }
+        }
+
+        var note = new PersonNote
+        {
+            PersonId = personId,
+            Text = request.Text,
+            NoteDate = request.NoteDate,
+            NoteTypeDefinedValueId = noteTypeDefinedValueId,
+            IsPrivate = request.IsPrivate,
+            IsAlert = request.IsAlert,
+            CreatedDateTime = DateTime.UtcNow
+        };
+
+        await context.PersonNotes.AddAsync(note, ct);
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation(
+            "Created note {NoteId} for person {PersonId}",
+            note.Id, personId);
+
+        // Fetch with includes for full DTO
+        var created = await context.PersonNotes
+            .AsNoTracking()
+            .Include(n => n.NoteTypeDefinedValue)
+            .Include(n => n.CreatedByPersonAlias)
+                .ThenInclude(pa => pa!.Person)
+            .Where(n => n.Id == note.Id)
+            .Select(n => new PersonNoteDto(
+                IdKeyHelper.Encode(n.Id),
+                n.Text,
+                n.NoteDate,
+                n.NoteTypeDefinedValue != null ? n.NoteTypeDefinedValue.Value : null,
+                n.CreatedByPersonAlias != null && n.CreatedByPersonAlias.Person != null
+                    ? n.CreatedByPersonAlias.Person.FullName
+                    : n.CreatedByPersonAlias != null
+                        ? n.CreatedByPersonAlias.Name
+                        : null,
+                n.IsPrivate,
+                n.IsAlert,
+                n.CreatedDateTime
+            ))
+            .FirstAsync(ct);
+
+        return created;
+    }
+
+    public async Task<PersonNoteDto> UpdateNoteAsync(
+        string personIdKey,
+        string noteIdKey,
+        UpdatePersonNoteRequest request,
+        CancellationToken ct = default)
+    {
+        if (!IdKeyHelper.TryDecode(personIdKey, out int personId))
+        {
+            throw new ArgumentException($"Invalid person IdKey: {personIdKey}", nameof(personIdKey));
+        }
+
+        if (!IdKeyHelper.TryDecode(noteIdKey, out int noteId))
+        {
+            throw new ArgumentException($"Invalid note IdKey: {noteIdKey}", nameof(noteIdKey));
+        }
+
+        var note = await context.PersonNotes
+            .FirstOrDefaultAsync(n => n.Id == noteId && n.PersonId == personId, ct);
+
+        if (note is null)
+        {
+            throw new KeyNotFoundException($"Note '{noteIdKey}' not found for person '{personIdKey}'");
+        }
+
+        // Resolve note type if provided
+        int? noteTypeDefinedValueId = null;
+        if (!string.IsNullOrWhiteSpace(request.NoteTypeDefinedValueIdKey))
+        {
+            if (IdKeyHelper.TryDecode(request.NoteTypeDefinedValueIdKey, out int noteTypeId))
+            {
+                noteTypeDefinedValueId = noteTypeId;
+            }
+        }
+
+        note.Text = request.Text;
+        note.NoteDate = request.NoteDate;
+        note.NoteTypeDefinedValueId = noteTypeDefinedValueId;
+        note.IsPrivate = request.IsPrivate;
+        note.IsAlert = request.IsAlert;
+        note.ModifiedDateTime = DateTime.UtcNow;
+
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation(
+            "Updated note {NoteId} for person {PersonId}",
+            noteId, personId);
+
+        // Fetch with includes for full DTO
+        var updated = await context.PersonNotes
+            .AsNoTracking()
+            .Include(n => n.NoteTypeDefinedValue)
+            .Include(n => n.CreatedByPersonAlias)
+                .ThenInclude(pa => pa!.Person)
+            .Where(n => n.Id == noteId)
+            .Select(n => new PersonNoteDto(
+                IdKeyHelper.Encode(n.Id),
+                n.Text,
+                n.NoteDate,
+                n.NoteTypeDefinedValue != null ? n.NoteTypeDefinedValue.Value : null,
+                n.CreatedByPersonAlias != null && n.CreatedByPersonAlias.Person != null
+                    ? n.CreatedByPersonAlias.Person.FullName
+                    : n.CreatedByPersonAlias != null
+                        ? n.CreatedByPersonAlias.Name
+                        : null,
+                n.IsPrivate,
+                n.IsAlert,
+                n.CreatedDateTime
+            ))
+            .FirstAsync(ct);
+
+        return updated;
+    }
+
+    public async Task DeleteNoteAsync(
+        string personIdKey,
+        string noteIdKey,
+        CancellationToken ct = default)
+    {
+        if (!IdKeyHelper.TryDecode(personIdKey, out int personId))
+        {
+            throw new ArgumentException($"Invalid person IdKey: {personIdKey}", nameof(personIdKey));
+        }
+
+        if (!IdKeyHelper.TryDecode(noteIdKey, out int noteId))
+        {
+            throw new ArgumentException($"Invalid note IdKey: {noteIdKey}", nameof(noteIdKey));
+        }
+
+        var note = await context.PersonNotes
+            .FirstOrDefaultAsync(n => n.Id == noteId && n.PersonId == personId, ct);
+
+        if (note is null)
+        {
+            throw new KeyNotFoundException($"Note '{noteIdKey}' not found for person '{personIdKey}'");
+        }
+
+        context.PersonNotes.Remove(note);
+        await context.SaveChangesAsync(ct);
+
+        logger.LogInformation(
+            "Deleted note {NoteId} for person {PersonId}",
+            noteId, personId);
     }
 
 }

--- a/src/Koinon.Application/Services/PersonService.cs
+++ b/src/Koinon.Application/Services/PersonService.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using AutoMapper;
 using AutoMapper.QueryableExtensions;
 using FluentValidation;
@@ -12,7 +13,6 @@ using Koinon.Domain.Entities;
 using Koinon.Domain.Enums;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
-using System.Collections.Generic;
 
 namespace Koinon.Application.Services;
 

--- a/src/Koinon.Application/Services/PersonService.cs
+++ b/src/Koinon.Application/Services/PersonService.cs
@@ -671,6 +671,8 @@ public class PersonService(
 
     public async Task<IEnumerable<PersonNoteDto>> GetNotesAsync(
         string personIdKey,
+        int page = 1,
+        int pageSize = 25,
         CancellationToken ct = default)
     {
         if (!IdKeyHelper.TryDecode(personIdKey, out int personId))
@@ -678,13 +680,39 @@ public class PersonService(
             return Enumerable.Empty<PersonNoteDto>();
         }
 
-        var notes = await context.PersonNotes
+        var isStaffOrAdmin = userContext.IsAuthenticated &&
+            (userContext.IsInRole(Roles.Staff) || userContext.IsInRole(Roles.Admin));
+
+        // Resolve current user's alias IDs for private note visibility
+        IReadOnlyList<int> currentUserAliasIds = Array.Empty<int>();
+        if (userContext.IsAuthenticated && userContext.CurrentPersonId.HasValue)
+        {
+            currentUserAliasIds = await context.PersonAliases
+                .AsNoTracking()
+                .Where(pa => pa.PersonId == userContext.CurrentPersonId.Value)
+                .Select(pa => pa.Id)
+                .ToListAsync(ct);
+        }
+
+        var query = context.PersonNotes
             .AsNoTracking()
             .Include(n => n.NoteTypeDefinedValue)
             .Include(n => n.CreatedByPersonAlias)
                 .ThenInclude(pa => pa!.Person)
-            .Where(n => n.PersonId == personId)
+            .Where(n => n.PersonId == personId);
+
+        // Filter private notes: only staff/admin or note author can see private notes
+        if (!isStaffOrAdmin)
+        {
+            query = query.Where(n =>
+                !n.IsPrivate ||
+                (n.CreatedByPersonAliasId != null && currentUserAliasIds.Contains(n.CreatedByPersonAliasId.Value)));
+        }
+
+        var notes = await query
             .OrderByDescending(n => n.NoteDate)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
             .Select(n => new PersonNoteDto(
                 IdKeyHelper.Encode(n.Id),
                 n.Text,
@@ -802,6 +830,22 @@ public class PersonService(
             throw new KeyNotFoundException($"Note '{noteIdKey}' not found for person '{personIdKey}'");
         }
 
+        // Authorization: only staff/admin or the note author can update
+        var isStaffOrAdmin = userContext.IsAuthenticated &&
+            (userContext.IsInRole(Roles.Staff) || userContext.IsInRole(Roles.Admin));
+        if (!isStaffOrAdmin)
+        {
+            var isAuthor = note.CreatedByPersonAliasId.HasValue &&
+                userContext.CurrentPersonId.HasValue &&
+                await context.PersonAliases
+                    .AnyAsync(pa => pa.Id == note.CreatedByPersonAliasId.Value
+                        && pa.PersonId == userContext.CurrentPersonId.Value, ct);
+            if (!isAuthor)
+            {
+                throw new UnauthorizedAccessException("You do not have permission to update this note.");
+            }
+        }
+
         // Resolve note type if provided
         int? noteTypeDefinedValueId = null;
         if (!string.IsNullOrWhiteSpace(request.NoteTypeDefinedValueIdKey))
@@ -872,6 +916,22 @@ public class PersonService(
         if (note is null)
         {
             throw new KeyNotFoundException($"Note '{noteIdKey}' not found for person '{personIdKey}'");
+        }
+
+        // Authorization: only staff/admin or the note author can delete
+        var isStaffOrAdmin = userContext.IsAuthenticated &&
+            (userContext.IsInRole(Roles.Staff) || userContext.IsInRole(Roles.Admin));
+        if (!isStaffOrAdmin)
+        {
+            var isAuthor = note.CreatedByPersonAliasId.HasValue &&
+                userContext.CurrentPersonId.HasValue &&
+                await context.PersonAliases
+                    .AnyAsync(pa => pa.Id == note.CreatedByPersonAliasId.Value
+                        && pa.PersonId == userContext.CurrentPersonId.Value, ct);
+            if (!isAuthor)
+            {
+                throw new UnauthorizedAccessException("You do not have permission to delete this note.");
+            }
         }
 
         context.PersonNotes.Remove(note);

--- a/src/Koinon.Domain/Entities/PersonNote.cs
+++ b/src/Koinon.Domain/Entities/PersonNote.cs
@@ -1,0 +1,30 @@
+namespace Koinon.Domain.Entities;
+
+/// <summary>
+/// A note or interaction log entry on a person record.
+/// </summary>
+public class PersonNote : Entity
+{
+    /// <summary>Person this note belongs to.</summary>
+    public int PersonId { get; set; }
+
+    /// <summary>Note text content.</summary>
+    public string Text { get; set; } = string.Empty;
+
+    /// <summary>Date of the interaction or note.</summary>
+    public DateTime NoteDate { get; set; }
+
+    /// <summary>Type of note — references DefinedValue (DefinedType: "Note Type").</summary>
+    public int? NoteTypeDefinedValueId { get; set; }
+
+    /// <summary>Whether this note is private and should only be visible to staff.</summary>
+    public bool IsPrivate { get; set; }
+
+    /// <summary>Whether this note is an alert that should be prominently displayed.</summary>
+    public bool IsAlert { get; set; }
+
+    // Navigation properties
+    public virtual Person Person { get; set; } = null!;
+    public virtual DefinedValue? NoteTypeDefinedValue { get; set; }
+    public virtual PersonAlias? CreatedByPersonAlias { get; set; }
+}

--- a/src/Koinon.Infrastructure/Configurations/PersonNoteConfiguration.cs
+++ b/src/Koinon.Infrastructure/Configurations/PersonNoteConfiguration.cs
@@ -1,0 +1,102 @@
+using Koinon.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Koinon.Infrastructure.Configurations;
+
+/// <summary>
+/// Entity Framework Core configuration for the PersonNote entity.
+/// </summary>
+public class PersonNoteConfiguration : IEntityTypeConfiguration<PersonNote>
+{
+    public void Configure(EntityTypeBuilder<PersonNote> builder)
+    {
+        // Table name
+        builder.ToTable("person_note");
+
+        // Primary key
+        builder.HasKey(n => n.Id);
+        builder.Property(n => n.Id)
+            .HasColumnName("id")
+            .ValueGeneratedOnAdd();
+
+        // Guid with unique index
+        builder.Property(n => n.Guid)
+            .HasColumnName("guid")
+            .IsRequired();
+        builder.HasIndex(n => n.Guid)
+            .IsUnique()
+            .HasDatabaseName("uix_person_note_guid");
+
+        // Required fields
+        builder.Property(n => n.PersonId)
+            .HasColumnName("person_id")
+            .IsRequired();
+
+        builder.Property(n => n.Text)
+            .HasColumnName("text")
+            .HasMaxLength(4000)
+            .IsRequired();
+
+        builder.Property(n => n.NoteDate)
+            .HasColumnName("note_date")
+            .IsRequired();
+
+        builder.Property(n => n.NoteTypeDefinedValueId)
+            .HasColumnName("note_type_defined_value_id");
+
+        builder.Property(n => n.IsPrivate)
+            .HasColumnName("is_private")
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(n => n.IsAlert)
+            .HasColumnName("is_alert")
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        // Audit fields (inherited from Entity)
+        builder.Property(n => n.CreatedDateTime)
+            .HasColumnName("created_date_time")
+            .IsRequired();
+
+        builder.Property(n => n.ModifiedDateTime)
+            .HasColumnName("modified_date_time");
+
+        builder.Property(n => n.CreatedByPersonAliasId)
+            .HasColumnName("created_by_person_alias_id");
+
+        builder.Property(n => n.ModifiedByPersonAliasId)
+            .HasColumnName("modified_by_person_alias_id");
+
+        // Indexes for performance
+        builder.HasIndex(n => n.PersonId)
+            .HasDatabaseName("ix_person_note_person_id");
+
+        builder.HasIndex(n => n.NoteDate)
+            .HasDatabaseName("ix_person_note_note_date");
+
+        builder.HasIndex(n => n.NoteTypeDefinedValueId)
+            .HasDatabaseName("ix_person_note_note_type_defined_value_id")
+            .HasFilter("note_type_defined_value_id IS NOT NULL");
+
+        // Foreign keys
+        builder.HasOne(n => n.Person)
+            .WithMany()
+            .HasForeignKey(n => n.PersonId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(n => n.NoteTypeDefinedValue)
+            .WithMany()
+            .HasForeignKey(n => n.NoteTypeDefinedValueId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasOne(n => n.CreatedByPersonAlias)
+            .WithMany()
+            .HasForeignKey(n => n.CreatedByPersonAliasId)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        // Ignore computed properties
+        builder.Ignore(n => n.IdKey);
+    }
+}

--- a/src/Koinon.Infrastructure/Data/KoinonDbContext.cs
+++ b/src/Koinon.Infrastructure/Data/KoinonDbContext.cs
@@ -20,6 +20,7 @@ public class KoinonDbContext : DbContext, IApplicationDbContext
     public DbSet<Person> People { get; set; } = null!;
     public DbSet<PersonAlias> PersonAliases { get; set; } = null!;
     public DbSet<PhoneNumber> PhoneNumbers { get; set; } = null!;
+    public DbSet<PersonNote> PersonNotes { get; set; } = null!;
 
     // Security entities
     public DbSet<SecurityRole> SecurityRoles { get; set; } = null!;

--- a/src/Koinon.Infrastructure/Migrations/20260327204303_AddPersonNote.Designer.cs
+++ b/src/Koinon.Infrastructure/Migrations/20260327204303_AddPersonNote.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Koinon.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -12,9 +13,11 @@ using NpgsqlTypes;
 namespace Koinon.Infrastructure.Migrations
 {
     [DbContext(typeof(KoinonDbContext))]
-    partial class KoinonDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260327204303_AddPersonNote")]
+    partial class AddPersonNote
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1783,8 +1786,7 @@ namespace Koinon.Infrastructure.Migrations
                         .HasColumnName("campus_id");
 
                     b.Property<int?>("CreatedByPersonAliasId")
-                        .HasColumnType("integer")
-                        .HasColumnName("created_by_person_alias_id");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime>("CreatedDateTime")
                         .HasColumnType("timestamp with time zone")
@@ -1801,8 +1803,7 @@ namespace Koinon.Infrastructure.Migrations
                         .HasColumnName("is_active");
 
                     b.Property<int?>("ModifiedByPersonAliasId")
-                        .HasColumnType("integer")
-                        .HasColumnName("modified_by_person_alias_id");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime?>("ModifiedDateTime")
                         .HasColumnType("timestamp with time zone")
@@ -1839,8 +1840,7 @@ namespace Koinon.Infrastructure.Migrations
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
                     b.Property<int?>("CreatedByPersonAliasId")
-                        .HasColumnType("integer")
-                        .HasColumnName("created_by_person_alias_id");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime>("CreatedDateTime")
                         .HasColumnType("timestamp with time zone")
@@ -1869,8 +1869,7 @@ namespace Koinon.Infrastructure.Migrations
                         .HasColumnName("is_primary");
 
                     b.Property<int?>("ModifiedByPersonAliasId")
-                        .HasColumnType("integer")
-                        .HasColumnName("modified_by_person_alias_id");
+                        .HasColumnType("integer");
 
                     b.Property<DateTime?>("ModifiedDateTime")
                         .HasColumnType("timestamp with time zone")

--- a/src/Koinon.Infrastructure/Migrations/20260327204303_AddPersonNote.cs
+++ b/src/Koinon.Infrastructure/Migrations/20260327204303_AddPersonNote.cs
@@ -1,91 +1,89 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 #nullable disable
 
-namespace Koinon.Infrastructure.Migrations
+namespace Koinon.Infrastructure.Migrations;
+/// <inheritdoc />
+public partial class AddPersonNote : Migration
 {
     /// <inheritdoc />
-    public partial class AddPersonNote : Migration
+    protected override void Up(MigrationBuilder migrationBuilder)
     {
-        /// <inheritdoc />
-        protected override void Up(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.CreateTable(
-                name: "person_note",
-                columns: table => new
-                {
-                    id = table.Column<int>(type: "integer", nullable: false)
-                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
-                    person_id = table.Column<int>(type: "integer", nullable: false),
-                    text = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
-                    note_date = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
-                    note_type_defined_value_id = table.Column<int>(type: "integer", nullable: true),
-                    is_private = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
-                    is_alert = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
-                    guid = table.Column<Guid>(type: "uuid", nullable: false),
-                    created_date_time = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
-                    modified_date_time = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
-                    created_by_person_alias_id = table.Column<int>(type: "integer", nullable: true),
-                    modified_by_person_alias_id = table.Column<int>(type: "integer", nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_person_note", x => x.id);
-                    table.ForeignKey(
-                        name: "FK_person_note_defined_value_note_type_defined_value_id",
-                        column: x => x.note_type_defined_value_id,
-                        principalTable: "defined_value",
-                        principalColumn: "id",
-                        onDelete: ReferentialAction.Restrict);
-                    table.ForeignKey(
-                        name: "FK_person_note_person_alias_created_by_person_alias_id",
-                        column: x => x.created_by_person_alias_id,
-                        principalTable: "person_alias",
-                        principalColumn: "id",
-                        onDelete: ReferentialAction.SetNull);
-                    table.ForeignKey(
-                        name: "FK_person_note_person_person_id",
-                        column: x => x.person_id,
-                        principalTable: "person",
-                        principalColumn: "id",
-                        onDelete: ReferentialAction.Cascade);
-                });
+        migrationBuilder.CreateTable(
+            name: "person_note",
+            columns: table => new
+            {
+                id = table.Column<int>(type: "integer", nullable: false)
+                    .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                person_id = table.Column<int>(type: "integer", nullable: false),
+                text = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
+                note_date = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                note_type_defined_value_id = table.Column<int>(type: "integer", nullable: true),
+                is_private = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                is_alert = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                guid = table.Column<Guid>(type: "uuid", nullable: false),
+                created_date_time = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                modified_date_time = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                created_by_person_alias_id = table.Column<int>(type: "integer", nullable: true),
+                modified_by_person_alias_id = table.Column<int>(type: "integer", nullable: true)
+            },
+            constraints: table =>
+            {
+                table.PrimaryKey("PK_person_note", x => x.id);
+                table.ForeignKey(
+                    name: "FK_person_note_defined_value_note_type_defined_value_id",
+                    column: x => x.note_type_defined_value_id,
+                    principalTable: "defined_value",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Restrict);
+                table.ForeignKey(
+                    name: "FK_person_note_person_alias_created_by_person_alias_id",
+                    column: x => x.created_by_person_alias_id,
+                    principalTable: "person_alias",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.SetNull);
+                table.ForeignKey(
+                    name: "FK_person_note_person_person_id",
+                    column: x => x.person_id,
+                    principalTable: "person",
+                    principalColumn: "id",
+                    onDelete: ReferentialAction.Cascade);
+            });
 
-            migrationBuilder.CreateIndex(
-                name: "IX_person_note_created_by_person_alias_id",
-                table: "person_note",
-                column: "created_by_person_alias_id");
+        migrationBuilder.CreateIndex(
+            name: "IX_person_note_created_by_person_alias_id",
+            table: "person_note",
+            column: "created_by_person_alias_id");
 
-            migrationBuilder.CreateIndex(
-                name: "ix_person_note_note_date",
-                table: "person_note",
-                column: "note_date");
+        migrationBuilder.CreateIndex(
+            name: "ix_person_note_note_date",
+            table: "person_note",
+            column: "note_date");
 
-            migrationBuilder.CreateIndex(
-                name: "ix_person_note_note_type_defined_value_id",
-                table: "person_note",
-                column: "note_type_defined_value_id",
-                filter: "note_type_defined_value_id IS NOT NULL");
+        migrationBuilder.CreateIndex(
+            name: "ix_person_note_note_type_defined_value_id",
+            table: "person_note",
+            column: "note_type_defined_value_id",
+            filter: "note_type_defined_value_id IS NOT NULL");
 
-            migrationBuilder.CreateIndex(
-                name: "ix_person_note_person_id",
-                table: "person_note",
-                column: "person_id");
+        migrationBuilder.CreateIndex(
+            name: "ix_person_note_person_id",
+            table: "person_note",
+            column: "person_id");
 
-            migrationBuilder.CreateIndex(
-                name: "uix_person_note_guid",
-                table: "person_note",
-                column: "guid",
-                unique: true);
-        }
+        migrationBuilder.CreateIndex(
+            name: "uix_person_note_guid",
+            table: "person_note",
+            column: "guid",
+            unique: true);
+    }
 
-        /// <inheritdoc />
-        protected override void Down(MigrationBuilder migrationBuilder)
-        {
-            migrationBuilder.DropTable(
-                name: "person_note");
-        }
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropTable(
+            name: "person_note");
     }
 }

--- a/src/Koinon.Infrastructure/Migrations/20260327204303_AddPersonNote.cs
+++ b/src/Koinon.Infrastructure/Migrations/20260327204303_AddPersonNote.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Koinon.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPersonNote : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "person_note",
+                columns: table => new
+                {
+                    id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    person_id = table.Column<int>(type: "integer", nullable: false),
+                    text = table.Column<string>(type: "character varying(4000)", maxLength: 4000, nullable: false),
+                    note_date = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    note_type_defined_value_id = table.Column<int>(type: "integer", nullable: true),
+                    is_private = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    is_alert = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    guid = table.Column<Guid>(type: "uuid", nullable: false),
+                    created_date_time = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    modified_date_time = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    created_by_person_alias_id = table.Column<int>(type: "integer", nullable: true),
+                    modified_by_person_alias_id = table.Column<int>(type: "integer", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_person_note", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_person_note_defined_value_note_type_defined_value_id",
+                        column: x => x.note_type_defined_value_id,
+                        principalTable: "defined_value",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_person_note_person_alias_created_by_person_alias_id",
+                        column: x => x.created_by_person_alias_id,
+                        principalTable: "person_alias",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.SetNull);
+                    table.ForeignKey(
+                        name: "FK_person_note_person_person_id",
+                        column: x => x.person_id,
+                        principalTable: "person",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_person_note_created_by_person_alias_id",
+                table: "person_note",
+                column: "created_by_person_alias_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_person_note_note_date",
+                table: "person_note",
+                column: "note_date");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_person_note_note_type_defined_value_id",
+                table: "person_note",
+                column: "note_type_defined_value_id",
+                filter: "note_type_defined_value_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_person_note_person_id",
+                table: "person_note",
+                column: "person_id");
+
+            migrationBuilder.CreateIndex(
+                name: "uix_person_note_guid",
+                table: "person_note",
+                column: "guid",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "person_note");
+        }
+    }
+}

--- a/src/web/e2e/tests/admin/people/person-notes.spec.ts
+++ b/src/web/e2e/tests/admin/people/person-notes.spec.ts
@@ -1,0 +1,304 @@
+/**
+ * E2E Smoke Tests: Person Notes Section
+ * Branch: feature/issue-486-notes-interaction-log
+ *
+ * Verifies that the NotesSection component renders on the person detail page.
+ * Uses API mocking to avoid auth setup and ensure deterministic state.
+ *
+ * What is tested:
+ *   - Person detail page loads with Notes section present
+ *   - Empty-state message "No notes yet" renders when no notes exist
+ *   - "Add Note" button is visible in the Notes section header
+ *   - Notes section renders note cards when notes data is returned
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+// IdKey for person ID 1 (little-endian Base64 URL-safe encoding)
+const PERSON_ID_KEY = 'AQAAAA';
+const PERSON_DETAIL_URL = `/admin/people/${PERSON_ID_KEY}`;
+const API_BASE = 'http://localhost:5000/api/v1';
+
+// ---------------------------------------------------------------------------
+// Minimal mock response payloads with correct shape for each API consumer
+// ---------------------------------------------------------------------------
+
+// getPersonById: get<{ data: PersonDetailDto }> → component uses response.data
+const MOCK_PERSON = {
+  data: {
+    idKey: PERSON_ID_KEY,
+    guid: '33333333-3333-3333-3333-333333333333',
+    firstName: 'John',
+    nickName: 'John',
+    middleName: null,
+    lastName: 'Smith',
+    fullName: 'John Smith',
+    birthDate: '1985-06-15',
+    age: 40,
+    gender: 'Male',
+    email: 'john.smith@example.com',
+    isEmailActive: true,
+    emailPreference: 'EmailAllowed',
+    phoneNumbers: [],
+    recordStatus: null,
+    connectionStatus: null,
+    title: null,
+    suffix: null,
+    maritalStatus: null,
+    anniversaryDate: null,
+    isDeceased: false,
+    primaryFamily: { idKey: 'AQAAAA', name: 'Smith', memberCount: 4 },
+    primaryCampus: null,
+    photoId: null,
+    photoUrl: null,
+    createdDateTime: '2026-03-26T21:57:12.326Z',
+    modifiedDateTime: null,
+  },
+};
+
+// getPersonFamily: get<{ data: PersonFamilyResponse }> → returns response.data
+// Outer envelope: { data: PersonFamilyResponse }
+const MOCK_FAMILY = {
+  data: {
+    family: { idKey: 'AQAAAA', name: 'Smith', memberCount: 1 },
+    members: [],
+  },
+};
+
+// getPersonGroups: get<PagedResult<PersonGroupMembershipDto>> → returns result directly (no .data)
+const MOCK_GROUPS_EMPTY = {
+  data: [],
+  meta: { page: 1, pageSize: 25, totalCount: 0, totalPages: 0 },
+};
+
+// getPersonNotes: get<{ data: PagedResult<NoteDto> }> → returns response.data
+// Outer envelope: { data: PagedResult }
+const makeNotesPayload = (notes: object[]) => ({
+  data: {
+    data: notes,
+    meta: { page: 1, pageSize: 25, totalCount: notes.length, totalPages: notes.length > 0 ? 1 : 0 },
+  },
+});
+
+const MOCK_NOTES_EMPTY = makeNotesPayload([]);
+
+const MOCK_NOTE = {
+  idKey: 'AQAAAA',
+  noteTypeName: 'General',
+  noteTypeValueIdKey: 'general',
+  text: 'Attended the newcomers lunch on Sunday.',
+  isPrivate: false,
+  isAlert: false,
+  noteDateTime: '2026-03-20T14:30:00.000Z',
+  authorPersonName: 'Jane Doe',
+};
+
+const MOCK_NOTES_WITH_DATA = makeNotesPayload([MOCK_NOTE]);
+
+// getPersonAttendance: get<{ data: AttendanceSummaryDto[] }> → returns response.data
+// Outer envelope: { data: AttendanceSummaryDto[] }
+const MOCK_ATTENDANCE = { data: [] };
+
+// getPersonGivingSummary: get<{ data: PersonGivingSummaryDto }> → returns response.data
+// Outer envelope: { data: PersonGivingSummaryDto }
+const MOCK_GIVING_SUMMARY = {
+  data: {
+    yearToDateTotal: 0,
+    lastContributionDate: null,
+    recentContributions: [],
+  },
+};
+
+// getCommunicationPreferences: get<{ data: CommunicationPreferenceDto[] }> → returns response.data
+// Return empty array wrapped correctly
+const MOCK_COMMUNICATION_PREFS = { data: [] };
+
+// Auth refresh — called by AuthContext on mount. Shape: { accessToken, refreshToken, expiresAt }
+// The access token just needs to look like a JWT (header.payload.sig) so extractRolesFromJwt
+// can parse it without throwing. Payload is a valid base64 JSON object.
+//
+// Computed offline: base64url({ alg: "HS256", typ: "JWT" }) = eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+// Payload: base64url({ sub: "1", name: "John Smith", idKey: "AQAAAA", exp: 9999999999 })
+//          = eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gU21pdGgiLCJpZEtleSI6IkFRQUFBQSIsImV4cCI6OTk5OTk5OTk5OX0
+const FAKE_ACCESS_TOKEN =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' +
+  '.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gU21pdGgiLCJpZEtleSI6IkFRQUFBQSIsImV4cCI6OTk5OTk5OTk5OX0' +
+  '.dummy-signature';
+
+const MOCK_REFRESH_RESPONSE = {
+  data: {
+    accessToken: FAKE_ACCESS_TOKEN,
+    refreshToken: 'dummy-refresh-token',
+    expiresAt: '2099-01-01T00:00:00.000Z',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Setup helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Inject tokens into localStorage before the SPA loads so the API client
+ * includes an Authorization header and AuthContext finds a token on mount.
+ */
+async function injectAuthToken(page: Page) {
+  await page.addInitScript((token: string) => {
+    localStorage.setItem('koinon_access_token', token);
+    localStorage.setItem('koinon_refresh_token', 'dummy-refresh-token');
+  }, FAKE_ACCESS_TOKEN);
+}
+
+/**
+ * Register all route handlers needed by PersonDetailPage.
+ * Pass the desired notes payload (empty or with data) per test.
+ */
+async function mockPersonDetailRoutes(
+  page: Page,
+  notesPayload: ReturnType<typeof makeNotesPayload>,
+) {
+  // Auth refresh — must succeed so AuthContext marks session as authenticated
+  await page.route(`${API_BASE}/auth/refresh`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_REFRESH_RESPONSE),
+    }),
+  );
+
+  // Person detail
+  await page.route(`${API_BASE}/people/${PERSON_ID_KEY}`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_PERSON),
+    }),
+  );
+
+  // Family — must be before groups glob to avoid ambiguity
+  await page.route(`${API_BASE}/people/${PERSON_ID_KEY}/family`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_FAMILY),
+    }),
+  );
+
+  // Groups (with optional query params)
+  await page.route(`${API_BASE}/people/${PERSON_ID_KEY}/groups`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_GROUPS_EMPTY),
+    }),
+  );
+
+  // Notes (with page/pageSize query params)
+  await page.route(`**/people/${PERSON_ID_KEY}/notes*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(notesPayload),
+    }),
+  );
+
+  // Communication preferences
+  await page.route(`${API_BASE}/people/${PERSON_ID_KEY}/communication-preferences`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_COMMUNICATION_PREFS),
+    }),
+  );
+
+  // Attendance history
+  await page.route(`**/people/${PERSON_ID_KEY}/attendance*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_ATTENDANCE),
+    }),
+  );
+
+  // Giving summary
+  await page.route(`${API_BASE}/people/${PERSON_ID_KEY}/giving-summary`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_GIVING_SUMMARY),
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe('Person Notes Section', () => {
+  test('renders Notes heading and empty state when no notes exist', async ({ page }) => {
+    await injectAuthToken(page);
+    await mockPersonDetailRoutes(page, MOCK_NOTES_EMPTY);
+
+    await page.goto(PERSON_DETAIL_URL);
+
+    // Wait for person name — confirms the detail page rendered successfully
+    await expect(page.getByRole('heading', { name: 'John Smith' })).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Notes section heading must be present
+    await expect(page.getByRole('heading', { name: /^Notes/i, level: 2 })).toBeVisible();
+
+    // Empty state message
+    await expect(page.getByText('No notes yet')).toBeVisible();
+
+    // Add Note button
+    await expect(page.getByRole('button', { name: /Add Note/i })).toBeVisible();
+  });
+
+  test('renders note cards when notes are present', async ({ page }) => {
+    await injectAuthToken(page);
+    await mockPersonDetailRoutes(page, MOCK_NOTES_WITH_DATA);
+
+    await page.goto(PERSON_DETAIL_URL);
+
+    await expect(page.getByRole('heading', { name: 'John Smith' })).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Notes section heading (count badge appended with span, so partial match)
+    await expect(page.getByRole('heading', { name: /Notes/i, level: 2 })).toBeVisible();
+
+    // Note card content
+    await expect(page.getByText('Attended the newcomers lunch on Sunday.')).toBeVisible();
+
+    // Note type badge
+    await expect(page.getByText('General')).toBeVisible();
+
+    // Author attribution
+    await expect(page.getByText('Jane Doe')).toBeVisible();
+  });
+
+  test('Add Note button opens the inline note form', async ({ page }) => {
+    await injectAuthToken(page);
+    await mockPersonDetailRoutes(page, MOCK_NOTES_EMPTY);
+
+    await page.goto(PERSON_DETAIL_URL);
+
+    await expect(page.getByRole('heading', { name: 'John Smith' })).toBeVisible({
+      timeout: 10000,
+    });
+
+    // Click Add Note
+    await page.getByRole('button', { name: /Add Note/i }).click();
+
+    // The inline add form should appear with its own heading
+    await expect(page.getByRole('heading', { name: /Add Note/i })).toBeVisible();
+
+    // Note type dropdown — scoped to the add-note form to avoid strict mode ambiguity
+    await expect(page.locator('form').getByRole('combobox')).toBeVisible();
+
+    // Cancel button returns to empty state
+    await page.getByRole('button', { name: /Cancel/i }).click();
+    await expect(page.getByText('No notes yet')).toBeVisible();
+  });
+});

--- a/src/web/src/components/admin/people/GroupMembershipsSection.tsx
+++ b/src/web/src/components/admin/people/GroupMembershipsSection.tsx
@@ -72,7 +72,9 @@ export function GroupMembershipsSection({ memberships, isLoading }: GroupMembers
                   </td>
                   <td className="py-3 pr-4 text-gray-600">{membership.groupTypeName}</td>
                   <td className="py-3 pr-4 text-gray-600">{membership.roleName}</td>
-                  <td className="py-3 pr-4"><StatusBadge status={membership.memberStatus} /></td>
+                  <td className="py-3 pr-4">
+                    <StatusBadge status={membership.memberStatus} />
+                  </td>
                   <td className="py-3 text-gray-600">{formatJoinDate(membership.createdDateTime)}</td>
                 </tr>
               ))}

--- a/src/web/src/components/admin/people/NotesSection.tsx
+++ b/src/web/src/components/admin/people/NotesSection.tsx
@@ -1,0 +1,491 @@
+/**
+ * NotesSection Component
+ * Displays and manages notes/interaction log for a person.
+ */
+
+import { useState } from 'react';
+import { usePersonNotes, useCreatePersonNote, useUpdatePersonNote, useDeletePersonNote } from '@/hooks/usePeople';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+import { useToast } from '@/contexts/ToastContext';
+import type { PersonNoteDto, CreatePersonNoteRequest, UpdatePersonNoteRequest } from '@/services/api/types';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const NOTE_TYPES = ['General', 'Prayer Request', 'Pastoral Visit', 'Counseling'] as const;
+type NoteType = typeof NOTE_TYPES[number];
+
+const NOTE_TYPE_BADGE_STYLES: Record<NoteType, string> = {
+  General: 'bg-gray-100 text-gray-700',
+  'Prayer Request': 'bg-purple-100 text-purple-800',
+  'Pastoral Visit': 'bg-blue-100 text-blue-800',
+  Counseling: 'bg-orange-100 text-orange-800',
+};
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function formatDate(isoString: string): string {
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  }).format(new Date(isoString));
+}
+
+function toDateInputValue(isoString: string): string {
+  // Convert ISO datetime to YYYY-MM-DD for <input type="date">
+  return isoString.split('T')[0];
+}
+
+function toIsoDateTime(dateString: string): string {
+  // Convert YYYY-MM-DD from date input to ISO datetime
+  return `${dateString}T00:00:00.000Z`;
+}
+
+// ============================================================================
+// Note Type Badge
+// ============================================================================
+
+interface NoteTypeBadgeProps {
+  noteType: string | null;
+}
+
+function NoteTypeBadge({ noteType }: NoteTypeBadgeProps) {
+  if (!noteType) return null;
+
+  const styles = NOTE_TYPE_BADGE_STYLES[noteType as NoteType] ?? 'bg-gray-100 text-gray-700';
+
+  return (
+    <span className={`inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full ${styles}`}>
+      {noteType}
+    </span>
+  );
+}
+
+// ============================================================================
+// Note Form
+// ============================================================================
+
+interface NoteFormValues {
+  text: string;
+  noteDate: string;
+  noteType: string;
+  isPrivate: boolean;
+  isAlert: boolean;
+}
+
+interface NoteFormProps {
+  initial?: NoteFormValues;
+  isSubmitting: boolean;
+  onSubmit: (values: NoteFormValues) => void;
+  onCancel: () => void;
+  submitLabel: string;
+}
+
+function NoteForm({ initial, isSubmitting, onSubmit, onCancel, submitLabel }: NoteFormProps) {
+  const today = new Date().toISOString().split('T')[0];
+
+  const [text, setText] = useState(initial?.text ?? '');
+  const [noteDate, setNoteDate] = useState(initial?.noteDate ?? today);
+  const [noteType, setNoteType] = useState(initial?.noteType ?? '');
+  const [isPrivate, setIsPrivate] = useState(initial?.isPrivate ?? false);
+  const [isAlert, setIsAlert] = useState(initial?.isAlert ?? false);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ text, noteDate, noteType, isPrivate, isAlert });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4 bg-gray-50 rounded-lg p-4 border border-gray-200">
+      <div>
+        <label htmlFor="note-text" className="block text-sm font-medium text-gray-700 mb-1">
+          Note <span className="text-red-500">*</span>
+        </label>
+        <textarea
+          id="note-text"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={4}
+          required
+          className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 resize-y"
+          placeholder="Enter note text..."
+        />
+      </div>
+
+      <div className="flex flex-wrap gap-4">
+        <div className="flex-1 min-w-40">
+          <label htmlFor="note-date" className="block text-sm font-medium text-gray-700 mb-1">
+            Date <span className="text-red-500">*</span>
+          </label>
+          <input
+            id="note-date"
+            type="date"
+            value={noteDate}
+            onChange={(e) => setNoteDate(e.target.value)}
+            required
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          />
+        </div>
+
+        <div className="flex-1 min-w-40">
+          <label htmlFor="note-type" className="block text-sm font-medium text-gray-700 mb-1">
+            Type
+          </label>
+          <select
+            id="note-type"
+            value={noteType}
+            onChange={(e) => setNoteType(e.target.value)}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+          >
+            <option value="">Select type...</option>
+            {NOTE_TYPES.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-6">
+        <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={isPrivate}
+            onChange={(e) => setIsPrivate(e.target.checked)}
+            className="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+          />
+          Private
+        </label>
+        <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer">
+          <input
+            type="checkbox"
+            checked={isAlert}
+            onChange={(e) => setIsAlert(e.target.checked)}
+            className="rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+          />
+          Alert
+        </label>
+      </div>
+
+      <div className="flex justify-end gap-2 pt-1">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isSubmitting}
+          className="px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 transition-colors"
+        >
+          Cancel
+        </button>
+        <button
+          type="submit"
+          disabled={isSubmitting || !text.trim()}
+          className="px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 transition-colors"
+        >
+          {isSubmitting ? 'Saving...' : submitLabel}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ============================================================================
+// Note Item
+// ============================================================================
+
+interface NoteItemProps {
+  note: PersonNoteDto;
+  onEdit: (note: PersonNoteDto) => void;
+  onDelete: (note: PersonNoteDto) => void;
+}
+
+function NoteItem({ note, onEdit, onDelete }: NoteItemProps) {
+  return (
+    <div className="py-4 border-b border-gray-100 last:border-0">
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-2 text-sm text-gray-500">
+          <span className="font-medium text-gray-900">{formatDate(note.noteDate)}</span>
+          {note.noteType && <NoteTypeBadge noteType={note.noteType} />}
+          {note.isAlert && (
+            <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-red-100 text-red-700">
+              Alert
+            </span>
+          )}
+          {note.isPrivate && (
+            <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-yellow-100 text-yellow-700">
+              Private
+            </span>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1 shrink-0">
+          <button
+            type="button"
+            onClick={() => onEdit(note)}
+            className="p-1 text-gray-400 hover:text-primary-600 rounded transition-colors"
+            aria-label="Edit note"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
+              />
+            </svg>
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(note)}
+            className="p-1 text-gray-400 hover:text-red-600 rounded transition-colors"
+            aria-label="Delete note"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+
+      <p className="mt-2 text-sm text-gray-800 whitespace-pre-wrap">{note.text}</p>
+
+      {note.createdByName && (
+        <p className="mt-1 text-xs text-gray-500">Added by {note.createdByName}</p>
+      )}
+    </div>
+  );
+}
+
+// ============================================================================
+// Loading Skeleton
+// ============================================================================
+
+function NotesSkeleton() {
+  return (
+    <div className="space-y-4" role="status" aria-label="Loading notes">
+      {Array.from({ length: 3 }).map((_, i) => (
+        <div key={i} className="py-4 border-b border-gray-100 last:border-0 space-y-2">
+          <div className="flex gap-3">
+            <Skeleton variant="text" height={16} width={120} />
+            <Skeleton variant="text" height={16} width={80} />
+          </div>
+          <Skeleton variant="text" height={14} width="90%" />
+          <Skeleton variant="text" height={14} width="70%" />
+          <Skeleton variant="text" height={12} width={100} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ============================================================================
+// Main Component
+// ============================================================================
+
+type FormMode = 'add' | 'edit';
+
+interface ActiveForm {
+  mode: FormMode;
+  note?: PersonNoteDto;
+}
+
+interface NotesSectionProps {
+  personIdKey: string;
+}
+
+export function NotesSection({ personIdKey }: NotesSectionProps) {
+  const toast = useToast();
+  const [activeForm, setActiveForm] = useState<ActiveForm | null>(null);
+  const [noteToDelete, setNoteToDelete] = useState<PersonNoteDto | null>(null);
+
+  const { data: notes, isLoading, isError } = usePersonNotes(personIdKey);
+  const createMutation = useCreatePersonNote();
+  const updateMutation = useUpdatePersonNote();
+  const deleteMutation = useDeletePersonNote();
+
+  const sortedNotes = notes
+    ? [...notes].sort((a, b) => new Date(b.noteDate).getTime() - new Date(a.noteDate).getTime())
+    : [];
+
+  const handleAddClick = () => {
+    setActiveForm({ mode: 'add' });
+  };
+
+  const handleEditClick = (note: PersonNoteDto) => {
+    setActiveForm({ mode: 'edit', note });
+  };
+
+  const handleDeleteClick = (note: PersonNoteDto) => {
+    setNoteToDelete(note);
+  };
+
+  const handleCancel = () => {
+    setActiveForm(null);
+  };
+
+  const handleAddSubmit = async (values: NoteFormValues) => {
+    const request: CreatePersonNoteRequest = {
+      text: values.text,
+      noteDate: toIsoDateTime(values.noteDate),
+      noteTypeDefinedValueIdKey: null,
+      isPrivate: values.isPrivate,
+      isAlert: values.isAlert,
+    };
+
+    try {
+      await createMutation.mutateAsync({ personIdKey, request });
+      toast.success('Note added', 'The note has been saved successfully.');
+      setActiveForm(null);
+    } catch {
+      toast.error('Failed to add note', 'Please try again.');
+    }
+  };
+
+  const handleEditSubmit = async (values: NoteFormValues) => {
+    if (!activeForm?.note) return;
+
+    const request: UpdatePersonNoteRequest = {
+      text: values.text,
+      noteDate: toIsoDateTime(values.noteDate),
+      noteTypeDefinedValueIdKey: null,
+      isPrivate: values.isPrivate,
+      isAlert: values.isAlert,
+    };
+
+    try {
+      await updateMutation.mutateAsync({
+        personIdKey,
+        noteIdKey: activeForm.note.idKey,
+        request,
+      });
+      toast.success('Note updated', 'The note has been updated successfully.');
+      setActiveForm(null);
+    } catch {
+      toast.error('Failed to update note', 'Please try again.');
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (!noteToDelete) return;
+
+    try {
+      await deleteMutation.mutateAsync({ personIdKey, noteIdKey: noteToDelete.idKey });
+      toast.success('Note deleted', 'The note has been removed.');
+      setNoteToDelete(null);
+    } catch {
+      toast.error('Failed to delete note', 'Please try again.');
+    }
+  };
+
+  const isSubmitting =
+    createMutation.isPending || updateMutation.isPending;
+
+  const getEditInitialValues = (note: PersonNoteDto): NoteFormValues => ({
+    text: note.text,
+    noteDate: toDateInputValue(note.noteDate),
+    noteType: note.noteType ?? '',
+    isPrivate: note.isPrivate,
+    isAlert: note.isAlert,
+  });
+
+  return (
+    <section className="bg-white rounded-lg border border-gray-200 p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-900">Notes</h2>
+        {activeForm === null && (
+          <button
+            type="button"
+            onClick={handleAddClick}
+            className="px-3 py-1.5 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors"
+          >
+            Add Note
+          </button>
+        )}
+      </div>
+
+      {/* Add form */}
+      {activeForm?.mode === 'add' && (
+        <div className="mb-6">
+          <NoteForm
+            isSubmitting={isSubmitting}
+            onSubmit={handleAddSubmit}
+            onCancel={handleCancel}
+            submitLabel="Add Note"
+          />
+        </div>
+      )}
+
+      {/* Loading */}
+      {isLoading && <NotesSkeleton />}
+
+      {/* Error */}
+      {isError && (
+        <EmptyState
+          title="Failed to load notes"
+          description="There was a problem loading notes for this person. Please try again."
+        />
+      )}
+
+      {/* Notes list */}
+      {!isLoading && !isError && notes !== undefined && (
+        <>
+          {sortedNotes.length === 0 && activeForm?.mode !== 'add' && (
+            <EmptyState
+              title="No notes yet"
+              description="Add a note to start keeping track of interactions with this person."
+            />
+          )}
+
+          {sortedNotes.length > 0 && (
+            <div>
+              {sortedNotes.map((note) => (
+                <div key={note.idKey}>
+                  {activeForm?.mode === 'edit' && activeForm.note?.idKey === note.idKey ? (
+                    <div className="py-4 border-b border-gray-100 last:border-0">
+                      <NoteForm
+                        initial={getEditInitialValues(note)}
+                        isSubmitting={isSubmitting}
+                        onSubmit={handleEditSubmit}
+                        onCancel={handleCancel}
+                        submitLabel="Save Changes"
+                      />
+                    </div>
+                  ) : (
+                    <NoteItem
+                      note={note}
+                      onEdit={handleEditClick}
+                      onDelete={handleDeleteClick}
+                    />
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Delete confirmation dialog */}
+      <ConfirmDialog
+        isOpen={noteToDelete !== null}
+        onClose={() => setNoteToDelete(null)}
+        onConfirm={handleDeleteConfirm}
+        title="Delete Note"
+        description="Are you sure you want to delete this note? This action cannot be undone."
+        confirmLabel="Delete"
+        variant="danger"
+        isLoading={deleteMutation.isPending}
+      />
+    </section>
+  );
+}

--- a/src/web/src/hooks/usePeople.ts
+++ b/src/web/src/hooks/usePeople.ts
@@ -8,6 +8,8 @@ import type {
   PersonSearchParams,
   CreatePersonRequest,
   UpdatePersonRequest,
+  CreatePersonNoteRequest,
+  UpdatePersonNoteRequest,
 } from '@/services/api/types';
 
 /**
@@ -137,5 +139,76 @@ export function usePersonGivingSummary(idKey?: string) {
     queryFn: () => peopleApi.getPersonGivingSummary(idKey!),
     enabled: !!idKey,
     staleTime: 5 * 60 * 1000, // 5 minutes
+  });
+}
+
+/**
+ * Get notes for a person
+ */
+export function usePersonNotes(personIdKey?: string) {
+  return useQuery({
+    queryKey: ['people', personIdKey, 'notes'],
+    queryFn: () => peopleApi.getPersonNotes(personIdKey!),
+    enabled: !!personIdKey,
+    staleTime: 2 * 60 * 1000, // 2 minutes
+  });
+}
+
+/**
+ * Create a note for a person
+ */
+export function useCreatePersonNote() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      personIdKey,
+      request,
+    }: {
+      personIdKey: string;
+      request: CreatePersonNoteRequest;
+    }) => peopleApi.createPersonNote(personIdKey, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['people', variables.personIdKey, 'notes'] });
+    },
+  });
+}
+
+/**
+ * Update a note for a person
+ */
+export function useUpdatePersonNote() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      personIdKey,
+      noteIdKey,
+      request,
+    }: {
+      personIdKey: string;
+      noteIdKey: string;
+      request: UpdatePersonNoteRequest;
+    }) => peopleApi.updatePersonNote(personIdKey, noteIdKey, request),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['people', variables.personIdKey, 'notes'] });
+    },
+  });
+}
+
+/**
+ * Delete a note from a person
+ */
+export function useDeletePersonNote() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      personIdKey,
+      noteIdKey,
+    }: {
+      personIdKey: string;
+      noteIdKey: string;
+    }) => peopleApi.deletePersonNote(personIdKey, noteIdKey),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['people', variables.personIdKey, 'notes'] });
+    },
   });
 }

--- a/src/web/src/pages/admin/people/PersonDetailPage.tsx
+++ b/src/web/src/pages/admin/people/PersonDetailPage.tsx
@@ -10,6 +10,7 @@ import { CommunicationPreferences } from '@/components/admin/people/Communicatio
 import { AttendanceHistorySection } from '@/components/admin/people/AttendanceHistorySection';
 import { GroupMembershipsSection } from '@/components/admin/people/GroupMembershipsSection';
 import { GivingHistorySection } from '@/components/admin/people/GivingHistorySection';
+import { NotesSection } from '@/components/admin/people/NotesSection';
 import { useToast } from '@/contexts/ToastContext';
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 
@@ -279,6 +280,8 @@ export function PersonDetailPage() {
       <GivingHistorySection personIdKey={idKey!} />
 
       <AttendanceHistorySection personIdKey={idKey!} />
+
+      <NotesSection personIdKey={idKey!} />
 
       {/* Delete Confirmation Dialog */}
       <ConfirmDialog

--- a/src/web/src/services/api/people.ts
+++ b/src/web/src/services/api/people.ts
@@ -15,6 +15,9 @@ import type {
   PersonGroupsParams,
   AttendanceSummaryDto,
   PersonGivingSummaryDto,
+  PersonNoteDto,
+  CreatePersonNoteRequest,
+  UpdatePersonNoteRequest,
 } from './types';
 
 /**
@@ -130,6 +133,47 @@ export async function getPersonGivingSummary(
     `/people/${personIdKey}/giving-summary`
   );
   return response.data;
+}
+
+/**
+ * Get notes for a person
+ */
+export async function getPersonNotes(personIdKey: string): Promise<PersonNoteDto[]> {
+  const response = await get<{ data: PersonNoteDto[] }>(`/people/${personIdKey}/notes`);
+  return response.data;
+}
+
+/**
+ * Create a note for a person
+ */
+export async function createPersonNote(
+  personIdKey: string,
+  request: CreatePersonNoteRequest
+): Promise<PersonNoteDto> {
+  const response = await post<{ data: PersonNoteDto }>(`/people/${personIdKey}/notes`, request);
+  return response.data;
+}
+
+/**
+ * Update an existing note for a person
+ */
+export async function updatePersonNote(
+  personIdKey: string,
+  noteIdKey: string,
+  request: UpdatePersonNoteRequest
+): Promise<PersonNoteDto> {
+  const response = await put<{ data: PersonNoteDto }>(
+    `/people/${personIdKey}/notes/${noteIdKey}`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Delete a note from a person
+ */
+export async function deletePersonNote(personIdKey: string, noteIdKey: string): Promise<void> {
+  await del<void>(`/people/${personIdKey}/notes/${noteIdKey}`);
 }
 
 /**

--- a/src/web/src/services/api/types.ts
+++ b/src/web/src/services/api/types.ts
@@ -1502,6 +1502,37 @@ export interface RecentContributionDto {
 }
 
 // ============================================================================
+// Person Note Types
+// ============================================================================
+
+export interface PersonNoteDto {
+  idKey: IdKey;
+  text: string;
+  noteDate: DateTime;
+  noteType: string | null;
+  createdByName: string | null;
+  isPrivate: boolean;
+  isAlert: boolean;
+  createdDateTime: DateTime;
+}
+
+export interface CreatePersonNoteRequest {
+  text: string;
+  noteDate: DateTime;
+  noteTypeDefinedValueIdKey?: IdKey | null;
+  isPrivate?: boolean;
+  isAlert?: boolean;
+}
+
+export interface UpdatePersonNoteRequest {
+  text: string;
+  noteDate: DateTime;
+  noteTypeDefinedValueIdKey?: IdKey | null;
+  isPrivate?: boolean;
+  isAlert?: boolean;
+}
+
+// ============================================================================
 // Data Export Types
 // ============================================================================
 

--- a/src/web/src/services/api/types.ts
+++ b/src/web/src/services/api/types.ts
@@ -503,10 +503,10 @@ export interface GroupMembershipDto {
   dateAdded?: DateTime;
 }
 
-/** Flat DTO returned by GET /api/v1/people/:idKey/groups */
+/** Flat DTO returned by GET /people/:idKey/groups — mirrors PersonGroupMembershipDto on the backend. */
 export interface PersonGroupMembershipDto {
   idKey: IdKey;
-  guid: string;
+  guid: Guid;
   groupIdKey: IdKey;
   groupName: string;
   groupTypeIdKey: IdKey;

--- a/tests/Koinon.Application.Tests/Services/AuthServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/AuthServiceTests.cs
@@ -419,6 +419,7 @@ public class AuthServiceTests
         public DbSet<Person> People { get; set; } = null!;
         public DbSet<PersonAlias> PersonAliases { get; set; } = null!;
         public DbSet<PhoneNumber> PhoneNumbers { get; set; } = null!;
+        public DbSet<PersonNote> PersonNotes { get; set; } = null!;
         public DbSet<Group> Groups { get; set; } = null!;
         public DbSet<GroupType> GroupTypes { get; set; } = null!;
         public DbSet<GroupTypeRole> GroupTypeRoles { get; set; } = null!;

--- a/tests/Koinon.Application.Tests/Services/AuthorizedPickupServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/AuthorizedPickupServiceTests.cs
@@ -955,6 +955,7 @@ public class AuthorizedPickupServiceTests : IDisposable
         public DbSet<Person> People { get; set; } = null!;
         public DbSet<PersonAlias> PersonAliases { get; set; } = null!;
         public DbSet<PhoneNumber> PhoneNumbers { get; set; } = null!;
+        public DbSet<PersonNote> PersonNotes { get; set; } = null!;
         public DbSet<Group> Groups { get; set; } = null!;
         public DbSet<GroupType> GroupTypes { get; set; } = null!;
         public DbSet<GroupTypeRole> GroupTypeRoles { get; set; } = null!;

--- a/tests/Koinon.Application.Tests/Services/DataExportServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/DataExportServiceTests.cs
@@ -719,6 +719,7 @@ public class DataExportServiceTests
         public DbSet<Person> People { get; set; } = null!;
         public DbSet<PersonAlias> PersonAliases { get; set; } = null!;
         public DbSet<PhoneNumber> PhoneNumbers { get; set; } = null!;
+        public DbSet<PersonNote> PersonNotes { get; set; } = null!;
         public DbSet<Group> Groups { get; set; } = null!;
         public DbSet<GroupType> GroupTypes { get; set; } = null!;
         public DbSet<GroupTypeRole> GroupTypeRoles { get; set; } = null!;

--- a/tests/Koinon.Application.Tests/Services/DeviceValidationServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/DeviceValidationServiceTests.cs
@@ -249,6 +249,7 @@ public class DeviceValidationServiceTests : IDisposable
         public DbSet<Person> People { get; set; } = null!;
         public DbSet<PersonAlias> PersonAliases { get; set; } = null!;
         public DbSet<PhoneNumber> PhoneNumbers { get; set; } = null!;
+        public DbSet<PersonNote> PersonNotes { get; set; } = null!;
         public DbSet<Group> Groups { get; set; } = null!;
         public DbSet<GroupType> GroupTypes { get; set; } = null!;
         public DbSet<GroupTypeRole> GroupTypeRoles { get; set; } = null!;

--- a/tests/Koinon.Application.Tests/Services/Performance/DataExportPerformanceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/Performance/DataExportPerformanceTests.cs
@@ -649,6 +649,7 @@ public class DataExportPerformanceTests
         public DbSet<Person> People { get; set; } = null!;
         public DbSet<PersonAlias> PersonAliases { get; set; } = null!;
         public DbSet<PhoneNumber> PhoneNumbers { get; set; } = null!;
+        public DbSet<PersonNote> PersonNotes { get; set; } = null!;
         public DbSet<Group> Groups { get; set; } = null!;
         public DbSet<GroupType> GroupTypes { get; set; } = null!;
         public DbSet<GroupTypeRole> GroupTypeRoles { get; set; } = null!;

--- a/tests/Koinon.Application.Tests/Services/Performance/DataImportPerformanceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/Performance/DataImportPerformanceTests.cs
@@ -746,6 +746,7 @@ public class DataImportPerformanceTests
         public DbSet<Person> People { get; set; } = null!;
         public DbSet<PersonAlias> PersonAliases { get; set; } = null!;
         public DbSet<PhoneNumber> PhoneNumbers { get; set; } = null!;
+        public DbSet<PersonNote> PersonNotes { get; set; } = null!;
         public DbSet<Group> Groups { get; set; } = null!;
         public DbSet<GroupType> GroupTypes { get; set; } = null!;
         public DbSet<GroupTypeRole> GroupTypeRoles { get; set; } = null!;

--- a/tests/Koinon.Application.Tests/Services/ReportServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/ReportServiceTests.cs
@@ -636,6 +636,7 @@ public class ReportServiceTests
         public DbSet<Person> People { get; set; } = null!;
         public DbSet<PersonAlias> PersonAliases { get; set; } = null!;
         public DbSet<PhoneNumber> PhoneNumbers { get; set; } = null!;
+        public DbSet<PersonNote> PersonNotes { get; set; } = null!;
         public DbSet<Group> Groups { get; set; } = null!;
         public DbSet<GroupType> GroupTypes { get; set; } = null!;
         public DbSet<GroupTypeRole> GroupTypeRoles { get; set; } = null!;

--- a/tests/Koinon.Application.Tests/Services/Reporting/ReportGeneratorTests.cs
+++ b/tests/Koinon.Application.Tests/Services/Reporting/ReportGeneratorTests.cs
@@ -599,6 +599,7 @@ public class ReportGeneratorTests
         public DbSet<Person> People { get; set; } = null!;
         public DbSet<PersonAlias> PersonAliases { get; set; } = null!;
         public DbSet<PhoneNumber> PhoneNumbers { get; set; } = null!;
+        public DbSet<PersonNote> PersonNotes { get; set; } = null!;
         public DbSet<Group> Groups { get; set; } = null!;
         public DbSet<GroupType> GroupTypes { get; set; } = null!;
         public DbSet<GroupTypeRole> GroupTypeRoles { get; set; } = null!;

--- a/tests/Koinon.Application.Tests/Services/UserSettingsServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/UserSettingsServiceTests.cs
@@ -602,6 +602,7 @@ public class UserSettingsServiceTests
         public DbSet<Person> People { get; set; } = null!;
         public DbSet<PersonAlias> PersonAliases { get; set; } = null!;
         public DbSet<PhoneNumber> PhoneNumbers { get; set; } = null!;
+        public DbSet<PersonNote> PersonNotes { get; set; } = null!;
         public DbSet<Group> Groups { get; set; } = null!;
         public DbSet<GroupType> GroupTypes { get; set; } = null!;
         public DbSet<GroupTypeRole> GroupTypeRoles { get; set; } = null!;

--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-03-27T19:17:28-04:00",
+  "generated_at": "2026-03-27T16:12:10-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -1087,6 +1087,30 @@
         "MergedByPerson": "virtual Person?"
       },
       "navigations": []
+    },
+    "PersonNote": {
+      "name": "PersonNote",
+      "namespace": "Koinon.Domain.Entities",
+      "table": "person_note",
+      "properties": {
+        "Entity": "class PersonNote :",
+        "PersonId": "int",
+        "Text": "string",
+        "NoteDate": "DateTime",
+        "NoteTypeDefinedValueId": "int?",
+        "IsPrivate": "bool",
+        "IsAlert": "bool",
+        "Person": "virtual Person",
+        "NoteTypeDefinedValue": "virtual DefinedValue?",
+        "CreatedByPersonAlias": "virtual PersonAlias?"
+      },
+      "navigations": [
+        {
+          "name": "NoteDate",
+          "target_entity": "DateTime",
+          "type": "one"
+        }
+      ]
     },
     "PersonSecurityRole": {
       "name": "PersonSecurityRole",
@@ -3225,6 +3249,45 @@
         "MergedDateTime": "DateTime"
       },
       "linked_entity": "Person"
+    },
+    "PersonNoteDto": {
+      "name": "PersonNoteDto",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {
+        "IdKey": "string",
+        "Text": "string",
+        "NoteDate": "DateTime",
+        "NoteType": "string?",
+        "CreatedByName": "string?",
+        "IsPrivate": "bool",
+        "IsAlert": "bool",
+        "CreatedDateTime": "DateTime"
+      },
+      "linked_entity": "PersonNote"
+    },
+    "CreatePersonNoteRequest": {
+      "name": "CreatePersonNoteRequest",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {
+        "Text": "string",
+        "NoteDate": "DateTime",
+        "NoteTypeDefinedValueIdKey": "string?",
+        "IsPrivate": "bool",
+        "IsAlert": "bool"
+      },
+      "linked_entity": "PersonNote"
+    },
+    "UpdatePersonNoteRequest": {
+      "name": "UpdatePersonNoteRequest",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {
+        "Text": "string",
+        "NoteDate": "DateTime",
+        "NoteTypeDefinedValueIdKey": "string?",
+        "IsPrivate": "bool",
+        "IsAlert": "bool"
+      },
+      "linked_entity": "PersonNote"
     },
     "PickupLogDto": {
       "name": "PickupLogDto",
@@ -6109,6 +6172,26 @@
           "name": "GetGivingSummaryAsync",
           "return_type": "Task<Result<PersonGivingSummaryDto>>",
           "is_async": false
+        },
+        {
+          "name": "GetNotesAsync",
+          "return_type": "Task<IEnumerable<PersonNoteDto>>",
+          "is_async": false
+        },
+        {
+          "name": "CreateNoteAsync",
+          "return_type": "Task<PersonNoteDto>",
+          "is_async": false
+        },
+        {
+          "name": "UpdateNoteAsync",
+          "return_type": "Task<PersonNoteDto>",
+          "is_async": false
+        },
+        {
+          "name": "DeleteNoteAsync",
+          "return_type": "Task",
+          "is_async": false
         }
       ],
       "dependencies": [
@@ -8522,6 +8605,24 @@
           "required_roles": []
         },
         {
+          "name": "GetPersonNotes",
+          "method": "GET",
+          "route": "{idKey}/notes",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
+          "name": "CreatePersonNote",
+          "method": "POST",
+          "route": "{idKey}/notes",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
           "name": "UploadPhoto",
           "method": "POST",
           "route": "{idKey}/photo",
@@ -8540,9 +8641,27 @@
           "required_roles": []
         },
         {
+          "name": "UpdatePersonNote",
+          "method": "PUT",
+          "route": "{idKey}/notes/{noteIdKey}",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
           "name": "Delete",
           "method": "DELETE",
           "route": "{idKey}",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
+          "name": "DeletePersonNote",
+          "method": "DELETE",
+          "route": "{idKey}/notes/{noteIdKey}",
           "request_type": null,
           "response_type": null,
           "requires_auth": true,
@@ -9656,6 +9775,21 @@
     {
       "source": "PersonMergeResultDto",
       "target": "Person",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "PersonNoteDto",
+      "target": "PersonNote",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "CreatePersonNoteRequest",
+      "target": "PersonNote",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "UpdatePersonNoteRequest",
+      "target": "PersonNote",
       "relationship": "maps_to"
     },
     {
@@ -11104,6 +11238,21 @@
       "relationship": "returns"
     },
     {
+      "source": "PersonService",
+      "target": "PersonNoteDto",
+      "relationship": "returns"
+    },
+    {
+      "source": "PersonService",
+      "target": "PersonNoteDto",
+      "relationship": "returns"
+    },
+    {
+      "source": "PersonService",
+      "target": "PersonNoteDto",
+      "relationship": "returns"
+    },
+    {
       "source": "PublicGroupService",
       "target": "GroupDto",
       "relationship": "returns"
@@ -11525,10 +11674,10 @@
     }
   ],
   "summary": {
-    "total_entities": 59,
-    "total_dtos": 204,
+    "total_entities": 60,
+    "total_dtos": 207,
     "total_services": 109,
     "total_controllers": 35,
-    "total_relationships": 492
+    "total_relationships": 498
   }
 }

--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-03-27T18:22:17-04:00",
+  "generated_at": "2026-03-27T20:34:25-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",

--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-03-27T16:12:10-04:00",
+  "generated_at": "2026-03-27T18:22:17-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-03-28T00:33:04.695Z",
+  "generated_at": "2026-03-28T01:17:36.394Z",
   "types": {
     "AttendanceAnalyticsDto": {
       "name": "AttendanceAnalyticsDto",
@@ -2543,8 +2543,9 @@
         "idKey": "IdKey",
         "firstName": "string",
         "lastName": "string",
-        "email": "string",
-        "photoUrl": "string"
+        "email": "string | null",
+        "photoUrl": "string | null",
+        "roles": "string[]"
       },
       "path": "services/api/types.ts"
     },
@@ -2889,6 +2890,32 @@
       "properties": {
         "family": "FamilyDetailDto",
         "members": "FamilyMemberDto[]"
+      },
+      "path": "services/api/types.ts"
+    },
+    "GroupAttendanceOccurrenceDto": {
+      "name": "GroupAttendanceOccurrenceDto",
+      "kind": "interface",
+      "properties": {
+        "idKey": "IdKey",
+        "occurrenceDate": "DateOnly",
+        "attendeeCount": "number",
+        "anonymousCount": "number",
+        "didNotOccur": "boolean",
+        "locationName": "string | null",
+        "scheduleName": "string | null"
+      },
+      "path": "services/api/types.ts"
+    },
+    "GroupAttendanceDetailDto": {
+      "name": "GroupAttendanceDetailDto",
+      "kind": "interface",
+      "properties": {
+        "personIdKey": "IdKey",
+        "fullName": "string",
+        "photoUrl": "string | null",
+        "didAttend": "boolean",
+        "presentDateTime": "DateTime | null"
       },
       "path": "services/api/types.ts"
     },

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-03-27T20:43:15.529Z",
+  "generated_at": "2026-03-28T00:33:04.695Z",
   "types": {
     "AttendanceAnalyticsDto": {
       "name": "AttendanceAnalyticsDto",
@@ -2840,6 +2840,24 @@
         "PaginationParams"
       ]
     },
+    "PersonGroupMembershipDto": {
+      "name": "PersonGroupMembershipDto",
+      "kind": "interface",
+      "properties": {
+        "idKey": "IdKey",
+        "guid": "Guid",
+        "groupIdKey": "IdKey",
+        "groupName": "string",
+        "groupTypeIdKey": "IdKey",
+        "groupTypeName": "string",
+        "roleIdKey": "IdKey",
+        "roleName": "string",
+        "memberStatus": "string",
+        "createdDateTime": "DateTime",
+        "modifiedDateTime": "DateTime"
+      },
+      "path": "services/api/types.ts"
+    },
     "AddGroupMemberRequest": {
       "name": "AddGroupMemberRequest",
       "kind": "interface",
@@ -3781,6 +3799,45 @@
         "amount": "number",
         "fundName": "string",
         "transactionType": "string"
+      },
+      "path": "services/api/types.ts"
+    },
+    "PersonNoteDto": {
+      "name": "PersonNoteDto",
+      "kind": "interface",
+      "properties": {
+        "idKey": "IdKey",
+        "text": "string",
+        "noteDate": "DateTime",
+        "noteType": "string | null",
+        "createdByName": "string | null",
+        "isPrivate": "boolean",
+        "isAlert": "boolean",
+        "createdDateTime": "DateTime"
+      },
+      "path": "services/api/types.ts"
+    },
+    "CreatePersonNoteRequest": {
+      "name": "CreatePersonNoteRequest",
+      "kind": "interface",
+      "properties": {
+        "text": "string",
+        "noteDate": "DateTime",
+        "noteTypeDefinedValueIdKey": "IdKey | null",
+        "isPrivate": "boolean",
+        "isAlert": "boolean"
+      },
+      "path": "services/api/types.ts"
+    },
+    "UpdatePersonNoteRequest": {
+      "name": "UpdatePersonNoteRequest",
+      "kind": "interface",
+      "properties": {
+        "text": "string",
+        "noteDate": "DateTime",
+        "noteTypeDefinedValueIdKey": "IdKey | null",
+        "isPrivate": "boolean",
+        "isAlert": "boolean"
       },
       "path": "services/api/types.ts"
     },
@@ -4915,6 +4972,34 @@
       "endpoint": "/people/${personIdKey}/giving-summary",
       "method": "GET",
       "responseType": "PersonGivingSummaryDto"
+    },
+    "getPersonNotes": {
+      "name": "getPersonNotes",
+      "path": "services/api/people.ts",
+      "endpoint": "/people/${personIdKey}/notes",
+      "method": "GET",
+      "responseType": "PersonNoteDto[]"
+    },
+    "createPersonNote": {
+      "name": "createPersonNote",
+      "path": "services/api/people.ts",
+      "endpoint": "/people/${personIdKey}/notes",
+      "method": "POST",
+      "responseType": "PersonNoteDto"
+    },
+    "updatePersonNote": {
+      "name": "updatePersonNote",
+      "path": "services/api/people.ts",
+      "endpoint": "/people/${personIdKey}/notes/${noteIdKey}",
+      "method": "PUT",
+      "responseType": "PersonNoteDto"
+    },
+    "deletePersonNote": {
+      "name": "deletePersonNote",
+      "path": "services/api/people.ts",
+      "endpoint": "/people/${personIdKey}/notes/${noteIdKey}",
+      "method": "DELETE",
+      "responseType": "void"
     },
     "uploadPersonPhoto": {
       "name": "uploadPersonPhoto",
@@ -6631,6 +6716,58 @@
         "getPersonGivingSummary"
       ]
     },
+    "usePersonNotes": {
+      "name": "usePersonNotes",
+      "path": "hooks/usePeople.ts",
+      "apiBinding": "",
+      "queryKey": [
+        "people"
+      ],
+      "usesQuery": true,
+      "usesMutation": false,
+      "dependencies": [
+        "getPersonNotes"
+      ]
+    },
+    "useCreatePersonNote": {
+      "name": "useCreatePersonNote",
+      "path": "hooks/usePeople.ts",
+      "apiBinding": "",
+      "queryKey": [
+        "people"
+      ],
+      "usesQuery": false,
+      "usesMutation": true,
+      "dependencies": [
+        "createPersonNote"
+      ]
+    },
+    "useUpdatePersonNote": {
+      "name": "useUpdatePersonNote",
+      "path": "hooks/usePeople.ts",
+      "apiBinding": "",
+      "queryKey": [
+        "people"
+      ],
+      "usesQuery": false,
+      "usesMutation": true,
+      "dependencies": [
+        "updatePersonNote"
+      ]
+    },
+    "useDeletePersonNote": {
+      "name": "useDeletePersonNote",
+      "path": "hooks/usePeople.ts",
+      "apiBinding": "",
+      "queryKey": [
+        "people"
+      ],
+      "usesQuery": false,
+      "usesMutation": true,
+      "dependencies": [
+        "deletePersonNote"
+      ]
+    },
     "useDuplicates": {
       "name": "useDuplicates",
       "path": "hooks/usePersonMerge.ts",
@@ -7315,6 +7452,17 @@
       "name": "GroupMembershipsSection",
       "path": "components/admin/people/GroupMembershipsSection.tsx",
       "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "NotesSection": {
+      "name": "NotesSection",
+      "path": "components/admin/people/NotesSection.tsx",
+      "hooksUsed": [
+        "usePersonNotes",
+        "useCreatePersonNote",
+        "useUpdatePersonNote",
+        "useDeletePersonNote"
+      ],
       "apiCallsDirectly": false
     },
     "PersonCard": {
@@ -8084,6 +8232,26 @@
     {
       "from": "GivingHistorySection",
       "to": "usePersonGivingSummary",
+      "type": "uses_hook"
+    },
+    {
+      "from": "NotesSection",
+      "to": "usePersonNotes",
+      "type": "uses_hook"
+    },
+    {
+      "from": "NotesSection",
+      "to": "useCreatePersonNote",
+      "type": "uses_hook"
+    },
+    {
+      "from": "NotesSection",
+      "to": "useUpdatePersonNote",
+      "type": "uses_hook"
+    },
+    {
+      "from": "NotesSection",
+      "to": "useDeletePersonNote",
       "type": "uses_hook"
     },
     {

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-03-27T23:29:15.716Z",
+  "generated_at": "2026-03-27T20:43:15.529Z",
   "types": {
     "AttendanceAnalyticsDto": {
       "name": "AttendanceAnalyticsDto",
@@ -2543,9 +2543,8 @@
         "idKey": "IdKey",
         "firstName": "string",
         "lastName": "string",
-        "email": "string | null",
-        "photoUrl": "string | null",
-        "roles": "string[]"
+        "email": "string",
+        "photoUrl": "string"
       },
       "path": "services/api/types.ts"
     },
@@ -2841,24 +2840,6 @@
         "PaginationParams"
       ]
     },
-    "PersonGroupMembershipDto": {
-      "name": "PersonGroupMembershipDto",
-      "kind": "interface",
-      "properties": {
-        "idKey": "IdKey",
-        "guid": "string",
-        "groupIdKey": "IdKey",
-        "groupName": "string",
-        "groupTypeIdKey": "IdKey",
-        "groupTypeName": "string",
-        "roleIdKey": "IdKey",
-        "roleName": "string",
-        "memberStatus": "string",
-        "createdDateTime": "DateTime",
-        "modifiedDateTime": "DateTime"
-      },
-      "path": "services/api/types.ts"
-    },
     "AddGroupMemberRequest": {
       "name": "AddGroupMemberRequest",
       "kind": "interface",
@@ -2890,32 +2871,6 @@
       "properties": {
         "family": "FamilyDetailDto",
         "members": "FamilyMemberDto[]"
-      },
-      "path": "services/api/types.ts"
-    },
-    "GroupAttendanceOccurrenceDto": {
-      "name": "GroupAttendanceOccurrenceDto",
-      "kind": "interface",
-      "properties": {
-        "idKey": "IdKey",
-        "occurrenceDate": "DateOnly",
-        "attendeeCount": "number",
-        "anonymousCount": "number",
-        "didNotOccur": "boolean",
-        "locationName": "string | null",
-        "scheduleName": "string | null"
-      },
-      "path": "services/api/types.ts"
-    },
-    "GroupAttendanceDetailDto": {
-      "name": "GroupAttendanceDetailDto",
-      "kind": "interface",
-      "properties": {
-        "personIdKey": "IdKey",
-        "fullName": "string",
-        "photoUrl": "string | null",
-        "didAttend": "boolean",
-        "presentDateTime": "DateTime | null"
       },
       "path": "services/api/types.ts"
     },

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-03-27T19:29:28-04:00",
+  "generated_at": "2026-03-27T16:12:10-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -1087,6 +1087,30 @@
         "MergedByPerson": "virtual Person?"
       },
       "navigations": []
+    },
+    "PersonNote": {
+      "name": "PersonNote",
+      "namespace": "Koinon.Domain.Entities",
+      "table": "person_note",
+      "properties": {
+        "Entity": "class PersonNote :",
+        "PersonId": "int",
+        "Text": "string",
+        "NoteDate": "DateTime",
+        "NoteTypeDefinedValueId": "int?",
+        "IsPrivate": "bool",
+        "IsAlert": "bool",
+        "Person": "virtual Person",
+        "NoteTypeDefinedValue": "virtual DefinedValue?",
+        "CreatedByPersonAlias": "virtual PersonAlias?"
+      },
+      "navigations": [
+        {
+          "name": "NoteDate",
+          "target_entity": "DateTime",
+          "type": "one"
+        }
+      ]
     },
     "PersonSecurityRole": {
       "name": "PersonSecurityRole",
@@ -3225,6 +3249,45 @@
         "MergedDateTime": "DateTime"
       },
       "linked_entity": "Person"
+    },
+    "PersonNoteDto": {
+      "name": "PersonNoteDto",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {
+        "IdKey": "string",
+        "Text": "string",
+        "NoteDate": "DateTime",
+        "NoteType": "string?",
+        "CreatedByName": "string?",
+        "IsPrivate": "bool",
+        "IsAlert": "bool",
+        "CreatedDateTime": "DateTime"
+      },
+      "linked_entity": "PersonNote"
+    },
+    "CreatePersonNoteRequest": {
+      "name": "CreatePersonNoteRequest",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {
+        "Text": "string",
+        "NoteDate": "DateTime",
+        "NoteTypeDefinedValueIdKey": "string?",
+        "IsPrivate": "bool",
+        "IsAlert": "bool"
+      },
+      "linked_entity": "PersonNote"
+    },
+    "UpdatePersonNoteRequest": {
+      "name": "UpdatePersonNoteRequest",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {
+        "Text": "string",
+        "NoteDate": "DateTime",
+        "NoteTypeDefinedValueIdKey": "string?",
+        "IsPrivate": "bool",
+        "IsAlert": "bool"
+      },
+      "linked_entity": "PersonNote"
     },
     "PickupLogDto": {
       "name": "PickupLogDto",
@@ -6109,6 +6172,26 @@
           "name": "GetGivingSummaryAsync",
           "return_type": "Task<Result<PersonGivingSummaryDto>>",
           "is_async": false
+        },
+        {
+          "name": "GetNotesAsync",
+          "return_type": "Task<IEnumerable<PersonNoteDto>>",
+          "is_async": false
+        },
+        {
+          "name": "CreateNoteAsync",
+          "return_type": "Task<PersonNoteDto>",
+          "is_async": false
+        },
+        {
+          "name": "UpdateNoteAsync",
+          "return_type": "Task<PersonNoteDto>",
+          "is_async": false
+        },
+        {
+          "name": "DeleteNoteAsync",
+          "return_type": "Task",
+          "is_async": false
         }
       ],
       "dependencies": [
@@ -8522,6 +8605,24 @@
           "required_roles": []
         },
         {
+          "name": "GetPersonNotes",
+          "method": "GET",
+          "route": "{idKey}/notes",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
+          "name": "CreatePersonNote",
+          "method": "POST",
+          "route": "{idKey}/notes",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
           "name": "UploadPhoto",
           "method": "POST",
           "route": "{idKey}/photo",
@@ -8540,9 +8641,27 @@
           "required_roles": []
         },
         {
+          "name": "UpdatePersonNote",
+          "method": "PUT",
+          "route": "{idKey}/notes/{noteIdKey}",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
           "name": "Delete",
           "method": "DELETE",
           "route": "{idKey}",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
+          "name": "DeletePersonNote",
+          "method": "DELETE",
+          "route": "{idKey}/notes/{noteIdKey}",
           "request_type": null,
           "response_type": null,
           "requires_auth": true,
@@ -11604,9 +11723,8 @@
         "idKey": "IdKey",
         "firstName": "string",
         "lastName": "string",
-        "email": "string | null",
-        "photoUrl": "string | null",
-        "roles": "string[]"
+        "email": "string",
+        "photoUrl": "string"
       },
       "path": "services/api/types.ts"
     },
@@ -11902,24 +12020,6 @@
         "PaginationParams"
       ]
     },
-    "PersonGroupMembershipDto": {
-      "name": "PersonGroupMembershipDto",
-      "kind": "interface",
-      "properties": {
-        "idKey": "IdKey",
-        "guid": "string",
-        "groupIdKey": "IdKey",
-        "groupName": "string",
-        "groupTypeIdKey": "IdKey",
-        "groupTypeName": "string",
-        "roleIdKey": "IdKey",
-        "roleName": "string",
-        "memberStatus": "string",
-        "createdDateTime": "DateTime",
-        "modifiedDateTime": "DateTime"
-      },
-      "path": "services/api/types.ts"
-    },
     "AddGroupMemberRequest": {
       "name": "AddGroupMemberRequest",
       "kind": "interface",
@@ -11951,32 +12051,6 @@
       "properties": {
         "family": "FamilyDetailDto",
         "members": "FamilyMemberDto[]"
-      },
-      "path": "services/api/types.ts"
-    },
-    "GroupAttendanceOccurrenceDto": {
-      "name": "GroupAttendanceOccurrenceDto",
-      "kind": "interface",
-      "properties": {
-        "idKey": "IdKey",
-        "occurrenceDate": "DateOnly",
-        "attendeeCount": "number",
-        "anonymousCount": "number",
-        "didNotOccur": "boolean",
-        "locationName": "string | null",
-        "scheduleName": "string | null"
-      },
-      "path": "services/api/types.ts"
-    },
-    "GroupAttendanceDetailDto": {
-      "name": "GroupAttendanceDetailDto",
-      "kind": "interface",
-      "properties": {
-        "personIdKey": "IdKey",
-        "fullName": "string",
-        "photoUrl": "string | null",
-        "didAttend": "boolean",
-        "presentDateTime": "DateTime | null"
       },
       "path": "services/api/types.ts"
     },
@@ -17648,6 +17722,21 @@
       "relationship": "maps_to"
     },
     {
+      "source": "PersonNoteDto",
+      "target": "PersonNote",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "CreatePersonNoteRequest",
+      "target": "PersonNote",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "UpdatePersonNoteRequest",
+      "target": "PersonNote",
+      "relationship": "maps_to"
+    },
+    {
       "source": "PickupLogDto",
       "target": "PickupLog",
       "relationship": "maps_to"
@@ -19093,6 +19182,21 @@
       "relationship": "returns"
     },
     {
+      "source": "PersonService",
+      "target": "PersonNoteDto",
+      "relationship": "returns"
+    },
+    {
+      "source": "PersonService",
+      "target": "PersonNoteDto",
+      "relationship": "returns"
+    },
+    {
+      "source": "PersonService",
+      "target": "PersonNoteDto",
+      "relationship": "returns"
+    },
+    {
       "source": "PublicGroupService",
       "target": "GroupDto",
       "relationship": "returns"
@@ -19964,7 +20068,6 @@
     "dto:DefinedValueDto": "type:DefinedValueDto",
     "dto:FamilySummaryDto": "type:FamilySummaryDto",
     "dto:CampusSummaryDto": "type:CampusSummaryDto",
-    "dto:PersonGroupMembershipDto": "type:PersonGroupMembershipDto",
     "dto:DuplicateMatchDto": "type:DuplicateMatchDto",
     "dto:IgnoreDuplicateRequestDto": "type:IgnoreDuplicateRequestDto",
     "dto:PersonComparisonDto": "type:PersonComparisonDto",
@@ -20038,14 +20141,14 @@
     "dto:UserSessionDto": "type:UserSessionDto"
   },
   "stats": {
-    "entities": 59,
-    "dtos": 204,
+    "entities": 60,
+    "dtos": 207,
     "services": 109,
     "controllers": 35,
-    "types": 307,
+    "types": 304,
     "api_functions": 173,
     "hooks": 151,
     "components": 133,
-    "total_edges": 561
+    "total_edges": 567
   }
 }

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-03-27T18:22:17-04:00",
+  "generated_at": "2026-03-27T20:34:25-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -11723,8 +11723,9 @@
         "idKey": "IdKey",
         "firstName": "string",
         "lastName": "string",
-        "email": "string",
-        "photoUrl": "string"
+        "email": "string | null",
+        "photoUrl": "string | null",
+        "roles": "string[]"
       },
       "path": "services/api/types.ts"
     },
@@ -12069,6 +12070,32 @@
       "properties": {
         "family": "FamilyDetailDto",
         "members": "FamilyMemberDto[]"
+      },
+      "path": "services/api/types.ts"
+    },
+    "GroupAttendanceOccurrenceDto": {
+      "name": "GroupAttendanceOccurrenceDto",
+      "kind": "interface",
+      "properties": {
+        "idKey": "IdKey",
+        "occurrenceDate": "DateOnly",
+        "attendeeCount": "number",
+        "anonymousCount": "number",
+        "didNotOccur": "boolean",
+        "locationName": "string | null",
+        "scheduleName": "string | null"
+      },
+      "path": "services/api/types.ts"
+    },
+    "GroupAttendanceDetailDto": {
+      "name": "GroupAttendanceDetailDto",
+      "kind": "interface",
+      "properties": {
+        "personIdKey": "IdKey",
+        "fullName": "string",
+        "photoUrl": "string | null",
+        "didAttend": "boolean",
+        "presentDateTime": "DateTime | null"
       },
       "path": "services/api/types.ts"
     },
@@ -20317,7 +20344,7 @@
     "dtos": 207,
     "services": 109,
     "controllers": 35,
-    "types": 308,
+    "types": 310,
     "api_functions": 177,
     "hooks": 155,
     "components": 134,

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-03-27T16:12:10-04:00",
+  "generated_at": "2026-03-27T18:22:17-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -12020,6 +12020,24 @@
         "PaginationParams"
       ]
     },
+    "PersonGroupMembershipDto": {
+      "name": "PersonGroupMembershipDto",
+      "kind": "interface",
+      "properties": {
+        "idKey": "IdKey",
+        "guid": "Guid",
+        "groupIdKey": "IdKey",
+        "groupName": "string",
+        "groupTypeIdKey": "IdKey",
+        "groupTypeName": "string",
+        "roleIdKey": "IdKey",
+        "roleName": "string",
+        "memberStatus": "string",
+        "createdDateTime": "DateTime",
+        "modifiedDateTime": "DateTime"
+      },
+      "path": "services/api/types.ts"
+    },
     "AddGroupMemberRequest": {
       "name": "AddGroupMemberRequest",
       "kind": "interface",
@@ -12961,6 +12979,45 @@
         "amount": "number",
         "fundName": "string",
         "transactionType": "string"
+      },
+      "path": "services/api/types.ts"
+    },
+    "PersonNoteDto": {
+      "name": "PersonNoteDto",
+      "kind": "interface",
+      "properties": {
+        "idKey": "IdKey",
+        "text": "string",
+        "noteDate": "DateTime",
+        "noteType": "string | null",
+        "createdByName": "string | null",
+        "isPrivate": "boolean",
+        "isAlert": "boolean",
+        "createdDateTime": "DateTime"
+      },
+      "path": "services/api/types.ts"
+    },
+    "CreatePersonNoteRequest": {
+      "name": "CreatePersonNoteRequest",
+      "kind": "interface",
+      "properties": {
+        "text": "string",
+        "noteDate": "DateTime",
+        "noteTypeDefinedValueIdKey": "IdKey | null",
+        "isPrivate": "boolean",
+        "isAlert": "boolean"
+      },
+      "path": "services/api/types.ts"
+    },
+    "UpdatePersonNoteRequest": {
+      "name": "UpdatePersonNoteRequest",
+      "kind": "interface",
+      "properties": {
+        "text": "string",
+        "noteDate": "DateTime",
+        "noteTypeDefinedValueIdKey": "IdKey | null",
+        "isPrivate": "boolean",
+        "isAlert": "boolean"
       },
       "path": "services/api/types.ts"
     },
@@ -14598,6 +14655,58 @@
         "getPersonGivingSummary"
       ]
     },
+    "usePersonNotes": {
+      "name": "usePersonNotes",
+      "path": "hooks/usePeople.ts",
+      "apiBinding": "",
+      "queryKey": [
+        "people"
+      ],
+      "usesQuery": true,
+      "usesMutation": false,
+      "dependencies": [
+        "getPersonNotes"
+      ]
+    },
+    "useCreatePersonNote": {
+      "name": "useCreatePersonNote",
+      "path": "hooks/usePeople.ts",
+      "apiBinding": "",
+      "queryKey": [
+        "people"
+      ],
+      "usesQuery": false,
+      "usesMutation": true,
+      "dependencies": [
+        "createPersonNote"
+      ]
+    },
+    "useUpdatePersonNote": {
+      "name": "useUpdatePersonNote",
+      "path": "hooks/usePeople.ts",
+      "apiBinding": "",
+      "queryKey": [
+        "people"
+      ],
+      "usesQuery": false,
+      "usesMutation": true,
+      "dependencies": [
+        "updatePersonNote"
+      ]
+    },
+    "useDeletePersonNote": {
+      "name": "useDeletePersonNote",
+      "path": "hooks/usePeople.ts",
+      "apiBinding": "",
+      "queryKey": [
+        "people"
+      ],
+      "usesQuery": false,
+      "usesMutation": true,
+      "dependencies": [
+        "deletePersonNote"
+      ]
+    },
     "useDuplicates": {
       "name": "useDuplicates",
       "path": "hooks/usePersonMerge.ts",
@@ -16009,6 +16118,34 @@
       "method": "GET",
       "responseType": "PersonGivingSummaryDto"
     },
+    "getPersonNotes": {
+      "name": "getPersonNotes",
+      "path": "services/api/people.ts",
+      "endpoint": "/people/${personIdKey}/notes",
+      "method": "GET",
+      "responseType": "PersonNoteDto[]"
+    },
+    "createPersonNote": {
+      "name": "createPersonNote",
+      "path": "services/api/people.ts",
+      "endpoint": "/people/${personIdKey}/notes",
+      "method": "POST",
+      "responseType": "PersonNoteDto"
+    },
+    "updatePersonNote": {
+      "name": "updatePersonNote",
+      "path": "services/api/people.ts",
+      "endpoint": "/people/${personIdKey}/notes/${noteIdKey}",
+      "method": "PUT",
+      "responseType": "PersonNoteDto"
+    },
+    "deletePersonNote": {
+      "name": "deletePersonNote",
+      "path": "services/api/people.ts",
+      "endpoint": "/people/${personIdKey}/notes/${noteIdKey}",
+      "method": "DELETE",
+      "responseType": "void"
+    },
     "uploadPersonPhoto": {
       "name": "uploadPersonPhoto",
       "path": "services/api/people.ts",
@@ -16495,6 +16632,17 @@
       "name": "GroupMembershipsSection",
       "path": "components/admin/people/GroupMembershipsSection.tsx",
       "hooksUsed": [],
+      "apiCallsDirectly": false
+    },
+    "NotesSection": {
+      "name": "NotesSection",
+      "path": "components/admin/people/NotesSection.tsx",
+      "hooksUsed": [
+        "usePersonNotes",
+        "useCreatePersonNote",
+        "useUpdatePersonNote",
+        "useDeletePersonNote"
+      ],
       "apiCallsDirectly": false
     },
     "PersonCard": {
@@ -19757,6 +19905,26 @@
       "type": "uses_hook"
     },
     {
+      "from": "NotesSection",
+      "to": "usePersonNotes",
+      "type": "uses_hook"
+    },
+    {
+      "from": "NotesSection",
+      "to": "useCreatePersonNote",
+      "type": "uses_hook"
+    },
+    {
+      "from": "NotesSection",
+      "to": "useUpdatePersonNote",
+      "type": "uses_hook"
+    },
+    {
+      "from": "NotesSection",
+      "to": "useDeletePersonNote",
+      "type": "uses_hook"
+    },
+    {
       "from": "PersonComparisonView",
       "to": "usePersonComparison",
       "type": "uses_hook"
@@ -20068,12 +20236,16 @@
     "dto:DefinedValueDto": "type:DefinedValueDto",
     "dto:FamilySummaryDto": "type:FamilySummaryDto",
     "dto:CampusSummaryDto": "type:CampusSummaryDto",
+    "dto:PersonGroupMembershipDto": "type:PersonGroupMembershipDto",
     "dto:DuplicateMatchDto": "type:DuplicateMatchDto",
     "dto:IgnoreDuplicateRequestDto": "type:IgnoreDuplicateRequestDto",
     "dto:PersonComparisonDto": "type:PersonComparisonDto",
     "dto:PersonMergeHistoryDto": "type:PersonMergeHistoryDto",
     "dto:PersonMergeRequestDto": "type:PersonMergeRequestDto",
     "dto:PersonMergeResultDto": "type:PersonMergeResultDto",
+    "dto:PersonNoteDto": "type:PersonNoteDto",
+    "dto:CreatePersonNoteRequest": "type:CreatePersonNoteRequest",
+    "dto:UpdatePersonNoteRequest": "type:UpdatePersonNoteRequest",
     "dto:PickupLogDto": "type:PickupLogDto",
     "dto:PickupVerificationResultDto": "type:PickupVerificationResultDto",
     "dto:PublicGroupDto": "type:PublicGroupDto",
@@ -20145,10 +20317,10 @@
     "dtos": 207,
     "services": 109,
     "controllers": 35,
-    "types": 304,
-    "api_functions": 173,
-    "hooks": 151,
-    "components": 133,
-    "total_edges": 567
+    "types": 308,
+    "api_functions": 177,
+    "hooks": 155,
+    "components": 134,
+    "total_edges": 571
   }
 }


### PR DESCRIPTION
## Summary
- Add PersonNote entity, EF Core configuration, and database migration
- Implement CRUD endpoints on PeopleController for notes (`GET/POST/PUT/DELETE {idKey}/notes`)
- Add privacy filtering (non-staff users only see public notes + their own private notes)
- Add authorization checks on update/delete (staff/admin or note author)
- Map `UnauthorizedAccessException`/`KeyNotFoundException` to proper HTTP status codes in `GlobalExceptionHandler`
- Add pagination with input validation (page clamping, pageSize 1-100)
- Add frontend `NotesSection` component with inline add/edit form, note type badges, delete confirmation
- Add TanStack Query hooks (`usePersonNotes`, `useCreatePersonNote`, `useUpdatePersonNote`, `useDeletePersonNote`)
- Fix `GroupMembershipsSection` to use correct `PersonGroupMembershipDto` type

## Test Coverage
- E2E: 3 Playwright tests — notes section rendering, note cards with API mocking, inline form interaction
- Unit: 1406 backend tests passing (218 Domain + 312 Api + 55 Contract + 687 Application + 134 Infrastructure)
- TypeScript: Zero errors, zero lint warnings

## Review
- Junior reviewer: PASS
- Senior reviewer: APPROVED (4 security findings addressed — privacy filtering, authorization, exception mapping, input validation)

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)