### PR TITLE
fix(analytics): change page heading to match nav label

### DIFF
--- a/src/web/src/pages/admin/AnalyticsPage.tsx
+++ b/src/web/src/pages/admin/AnalyticsPage.tsx
@@ -66,7 +66,7 @@ export function AnalyticsPage() {
     <div className="space-y-6">
       {/* Page header */}
       <div>
-        <h1 className="text-3xl font-bold text-gray-900">Attendance Analytics</h1>
+        <h1 className="text-3xl font-bold text-gray-900">Analytics</h1>
         <p className="mt-2 text-gray-600">
           View attendance metrics, trends, and group breakdowns
         </p>


### PR DESCRIPTION
## Summary
- Change Analytics page heading from "Attendance Analytics" to "Analytics" to match sidebar nav label and test expectations

## Tests Fixed
- `navigation/breadcrumb.spec.ts` → "should display correct page heading for Analytics"
- `navigation/breadcrumb.spec.ts` → "@smoke should verify all page headings"

## Verification
- [x] Analytics heading test passes
- [x] TypeScript compiles clean

Closes #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)