### PR TITLE
fix(auth,families): add JWT role claims and fix frontend type mismatches

### DIFF
--- a/src/Koinon.Application/Services/AuthService.cs
+++ b/src/Koinon.Application/Services/AuthService.cs
@@ -237,7 +237,7 @@ public class AuthService(
         CancellationToken ct,
         string? existingRefreshToken = null)
     {
-        var accessToken = GenerateAccessToken(person);
+        var accessToken = await GenerateAccessTokenAsync(person, ct);
         var refreshToken = existingRefreshToken ?? GenerateRefreshTokenString();
         var expiresAt = DateTime.UtcNow.AddMinutes(_accessTokenExpirationMinutes);
 
@@ -301,18 +301,33 @@ public class AuthService(
     }
 
     /// <summary>
-    /// Generates a JWT access token for a person.
+    /// Generates a JWT access token for a person, including their security roles.
     /// </summary>
-    private string GenerateAccessToken(Person person)
+    private async Task<string> GenerateAccessTokenAsync(Person person, CancellationToken ct = default)
     {
-        var claims = new[]
+        var claims = new List<Claim>
         {
-            new Claim(ClaimTypes.NameIdentifier, person.Id.ToString()),
-            new Claim(ClaimTypes.Email, person.Email ?? string.Empty),
-            new Claim(ClaimTypes.Name, person.FullName),
-            new Claim(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
-            new Claim("idKey", IdKeyHelper.Encode(person.Id))
+            new(ClaimTypes.NameIdentifier, person.Id.ToString()),
+            new(ClaimTypes.Email, person.Email ?? string.Empty),
+            new(ClaimTypes.Name, person.FullName),
+            new(JwtRegisteredClaimNames.Jti, Guid.NewGuid().ToString()),
+            new("idKey", IdKeyHelper.Encode(person.Id)),
+            new("person_id", person.Id.ToString())
         };
+
+        // Add security role claims
+        var roleNames = await context.PersonSecurityRoles
+            .Where(psr => psr.PersonId == person.Id
+                && (!psr.ExpiresDateTime.HasValue || psr.ExpiresDateTime > DateTime.UtcNow))
+            .Include(psr => psr.SecurityRole)
+            .Where(psr => psr.SecurityRole.IsActive)
+            .Select(psr => psr.SecurityRole.Name)
+            .ToListAsync(ct);
+
+        foreach (var roleName in roleNames)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, roleName));
+        }
 
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtSecret));
         var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);

--- a/src/web/src/components/admin/families/FamilyMemberCard.tsx
+++ b/src/web/src/components/admin/families/FamilyMemberCard.tsx
@@ -13,7 +13,7 @@ interface FamilyMemberCardProps {
 }
 
 export function FamilyMemberCard({ member, onRemove, readOnly = false }: FamilyMemberCardProps) {
-  const { person, role, isPersonPrimaryFamily } = member;
+  const { person, role } = member;
   const isAdult = role.name === 'Adult';
 
   return (
@@ -73,13 +73,6 @@ export function FamilyMemberCard({ member, onRemove, readOnly = false }: FamilyM
           >
             {role.name}
           </span>
-
-          {/* Primary Family Badge */}
-          {isPersonPrimaryFamily && (
-            <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-purple-100 text-purple-800">
-              Primary Family
-            </span>
-          )}
 
           {person.email && (
             <span className="text-xs text-gray-500 truncate">{person.email}</span>

--- a/src/web/src/pages/admin/families/FamilyDetailPage.tsx
+++ b/src/web/src/pages/admin/families/FamilyDetailPage.tsx
@@ -100,7 +100,7 @@ export function FamilyDetailPage() {
     );
   }
 
-  const primaryAddress = family.addresses.find((addr) => addr.isMailingAddress);
+  const primaryAddress = family.address;
 
   // Get role IDs from existing family members (if available) or use first member's role
   const adultRoleId = family.members.find(m => m.role.name.toLowerCase() === 'adult')?.role.idKey || '';
@@ -180,7 +180,7 @@ export function FamilyDetailPage() {
               />
             </svg>
             <address className="not-italic whitespace-pre-line">
-              {primaryAddress.address.formattedAddress}
+              {primaryAddress.formattedAddress}
             </address>
           </div>
         </div>

--- a/src/web/src/pages/admin/families/FamilyFormPage.tsx
+++ b/src/web/src/pages/admin/families/FamilyFormPage.tsx
@@ -33,13 +33,12 @@ export function FamilyFormPage() {
       setName(family.name);
       setCampusId(family.campus?.idKey || '');
 
-      const primaryAddress = family.addresses.find((addr) => addr.isMailingAddress);
-      if (primaryAddress) {
-        setStreet1(primaryAddress.address.street1);
-        setStreet2(primaryAddress.address.street2 || '');
-        setCity(primaryAddress.address.city);
-        setState(primaryAddress.address.state);
-        setPostalCode(primaryAddress.address.postalCode);
+      if (family.address) {
+        setStreet1(family.address.street1 || '');
+        setStreet2(family.address.street2 || '');
+        setCity(family.address.city || '');
+        setState(family.address.state || '');
+        setPostalCode(family.address.postalCode || '');
       }
     }
   }, [family]);

--- a/src/web/src/pages/admin/people/PersonDetailPage.tsx
+++ b/src/web/src/pages/admin/people/PersonDetailPage.tsx
@@ -266,9 +266,7 @@ export function PersonDetailPage() {
                   {member.person.fullName}
                 </Link>
                 <span className="text-xs text-gray-500">({member.role.name})</span>
-                {member.isPersonPrimaryFamily && (
-                  <span className="text-xs text-blue-600">(Primary)</span>
-                )}
+                {/* Primary family indicator - future enhancement */}
               </li>
             ))}
           </ul>

--- a/src/web/src/services/api/types.ts
+++ b/src/web/src/services/api/types.ts
@@ -339,9 +339,11 @@ export interface FamilyDetailDto {
   idKey: IdKey;
   guid: Guid;
   name: string;
+  description?: string;
+  isActive: boolean;
   campus?: CampusSummaryDto;
+  address?: AddressDto;
   members: FamilyMemberDto[];
-  addresses: FamilyAddressDto[];
   createdDateTime: DateTime;
   modifiedDateTime?: DateTime;
 }
@@ -351,7 +353,6 @@ export interface FamilyMemberDto {
   person: PersonSummaryDto;
   role: GroupTypeRoleDto;
   status: string;
-  isPersonPrimaryFamily: boolean;
   dateTimeAdded?: DateTime;
 }
 


### PR DESCRIPTION
## Summary
- JWT access tokens were missing `ClaimTypes.Role` and `person_id` claims, causing 403 on family detail pages
- Frontend `FamilyDetailDto` expected `addresses[]` array but API returns singular `address?` field
- Removed references to non-existent `isPersonPrimaryFamily` field on `FamilyMemberDto`

## Changes
- **AuthService.cs**: Made `GenerateAccessToken` async, added `person_id` claim and security role claims from DB
- **types.ts**: Aligned `FamilyDetailDto` with actual API response (`address?` not `addresses[]`)
- **FamilyDetailPage.tsx**: Use `family.address` instead of `family.addresses.find(...)`
- **FamilyFormPage.tsx**: Use `family.address` instead of `family.addresses.find(...)`
- **FamilyMemberCard.tsx**: Removed `isPersonPrimaryFamily` destructuring and badge
- **PersonDetailPage.tsx**: Removed `isPersonPrimaryFamily` reference

## Tests Fixed
- 13/16 family detail tests now passing (was 0/16)
- 12/17 family list tests passing (no regression)

## Pre-existing Failures (Not This PR)
- "should show member roles" — Playwright strict mode (4 role badges match `/adult|child/i`)
- "should display loading state" — test uses family name as URL param instead of idKey

## Verification
- [x] Specific tests pass (13 detail + 12 list)
- [x] TypeScript compiles clean
- [x] ESLint passes
- [x] Backend build + 1406 unit tests pass

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)