### PR TITLE
fix(search): fix people/families query param and search placeholder

### DIFF
--- a/src/web/src/pages/admin/people/PeopleListPage.tsx
+++ b/src/web/src/pages/admin/people/PeopleListPage.tsx
@@ -86,7 +86,7 @@ export function PeopleListPage() {
             <PersonSearchBar
               value={searchQuery}
               onChange={handleSearchChange}
-              placeholder="Search by name, email, or phone..."
+              placeholder="Search people by name, email, or phone..."
             />
           </div>
 

--- a/src/web/src/services/api/families.ts
+++ b/src/web/src/services/api/families.ts
@@ -25,7 +25,7 @@ export async function searchFamilies(
 ): Promise<PagedResult<FamilySummaryDto>> {
   const queryParams = new URLSearchParams();
 
-  if (params.q) queryParams.set('q', params.q);
+  if (params.q) queryParams.set('query', params.q);
   if (params.campusId) queryParams.set('campusId', params.campusId);
   if (params.includeInactive) queryParams.set('includeInactive', String(params.includeInactive));
   if (params.page) queryParams.set('page', String(params.page));

--- a/src/web/src/services/api/people.ts
+++ b/src/web/src/services/api/people.ts
@@ -28,7 +28,7 @@ export async function searchPeople(
 ): Promise<PagedResult<PersonSummaryDto>> {
   const queryParams = new URLSearchParams();
 
-  if (params.q) queryParams.set('q', params.q);
+  if (params.q) queryParams.set('query', params.q);
   if (params.firstName) queryParams.set('firstName', params.firstName);
   if (params.lastName) queryParams.set('lastName', params.lastName);
   if (params.email) queryParams.set('email', params.email);


### PR DESCRIPTION
## Summary
- Fix `q` → `query` search parameter in people.ts and families.ts to match backend `[FromQuery]` binding
- Fix search placeholder in PeopleListPage to include "people" so tests matching `/search.*people/i` pass

## Tests Fixed
- People search tests (query param fix)
- Families search tests (query param fix)
- People list placeholder match

## Verification
- [x] Specific tests pass
- [x] TypeScript compiles
- [x] Lint passes

Closes #539

🤖 Generated with [Claude Code](https://claude.com/claude-code)