### PR TITLE
fix(groups): fix group CRUD - update, delete, form, and seed data

### DIFF
--- a/src/Koinon.Application/DTOs/Requests/CreateGroupRequest.cs
+++ b/src/Koinon.Application/DTOs/Requests/CreateGroupRequest.cs
@@ -20,16 +20,16 @@ public record CreateGroupRequest
 /// <summary>
 /// Request to update an existing group.
 /// </summary>
-public record UpdateGroupRequest
+public class UpdateGroupRequest
 {
-    public string? Name { get; init; }
-    public string? Description { get; init; }
-    public string? CampusId { get; init; }
-    public bool? IsActive { get; init; }
-    public bool? IsPublic { get; init; }
-    public bool? AllowGuests { get; init; }
-    public int? GroupCapacity { get; init; }
-    public int? Order { get; init; }
+    public string? Name { get; set; }
+    public string? Description { get; set; }
+    public string? CampusId { get; set; }
+    public bool? IsActive { get; set; }
+    public bool? IsPublic { get; set; }
+    public bool? AllowGuests { get; set; }
+    public int? GroupCapacity { get; set; }
+    public int? Order { get; set; }
 }
 
 /// <summary>

--- a/src/Koinon.Application/Services/GroupService.cs
+++ b/src/Koinon.Application/Services/GroupService.cs
@@ -269,13 +269,14 @@ public class GroupService(
             return Result<GroupDto>.Failure(Error.FromFluentValidation(validation));
         }
 
-        // Get group
+        // Get group (must use AsTracking since DbContext defaults to NoTracking)
         if (!IdKeyHelper.TryDecode(idKey, out int id))
         {
             return Result<GroupDto>.Failure(Error.NotFound("Group", idKey));
         }
 
         var group = await context.Groups
+            .AsTracking()
             .Include(g => g.GroupType)
             .FirstOrDefaultAsync(g => g.Id == id, ct);
 
@@ -357,6 +358,7 @@ public class GroupService(
         }
 
         var group = await context.Groups
+            .AsTracking()
             .Include(g => g.GroupType)
             .FirstOrDefaultAsync(g => g.Id == id, ct);
 

--- a/src/web/src/pages/admin/groups/GroupDetailPage.tsx
+++ b/src/web/src/pages/admin/groups/GroupDetailPage.tsx
@@ -101,7 +101,7 @@ export function GroupDetailPage() {
             onClick={() => setShowDeleteConfirm(true)}
             className="px-4 py-2 text-red-600 bg-white border border-red-300 rounded-lg hover:bg-red-50 transition-colors"
           >
-            Delete
+            Delete Group
           </button>
         </div>
       </div>
@@ -160,10 +160,10 @@ export function GroupDetailPage() {
                 )}
               </div>
 
-              {group.capacity && (
+              {group.groupCapacity && (
                 <div>
                   <dt className="text-sm font-medium text-gray-500">Capacity</dt>
-                  <dd className="mt-1 text-sm text-gray-900">{group.capacity} people</dd>
+                  <dd className="mt-1 text-sm text-gray-900">{group.groupCapacity} people</dd>
                 </div>
               )}
 

--- a/src/web/src/pages/admin/groups/GroupFormPage.tsx
+++ b/src/web/src/pages/admin/groups/GroupFormPage.tsx
@@ -6,6 +6,7 @@
 import { useEffect, useState } from 'react';
 import { useParams, useNavigate, useSearchParams, Link } from 'react-router-dom';
 import { useGroup, useCreateGroup, useUpdateGroup } from '@/hooks/useGroups';
+import { useGroupTypes } from '@/hooks/useGroupTypes';
 import type { CreateGroupRequest, UpdateGroupRequest } from '@/services/api/types';
 import { groupFormSchema, groupFormSchemaForEdit } from '@/schemas/group.schema';
 
@@ -16,6 +17,7 @@ export function GroupFormPage() {
   const isEditMode = !!idKey;
 
   const { data: group, isLoading } = useGroup(idKey);
+  const { data: groupTypes } = useGroupTypes();
   const createGroup = useCreateGroup();
   const updateGroup = useUpdateGroup();
 
@@ -45,7 +47,7 @@ export function GroupFormPage() {
       setGroupTypeId(group.groupType.idKey);
       setParentGroupId(group.parentGroup?.idKey || '');
       setCampusId(group.campus?.idKey || '');
-      setCapacity(group.capacity?.toString() || '');
+      setCapacity(group.groupCapacity?.toString() || '');
       setIsActive(group.isActive);
     }
   }, [group]);
@@ -238,9 +240,11 @@ export function GroupFormPage() {
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
               >
                 <option value="">Select a group type...</option>
-                <option value="checkin-area">Check-in Area</option>
-                <option value="age-group">Age Group</option>
-                <option value="general">General</option>
+                {groupTypes?.map((gt) => (
+                  <option key={gt.idKey} value={gt.idKey}>
+                    {gt.name}
+                  </option>
+                ))}
               </select>
               {validationErrors.groupTypeId && (
                 <p className="text-sm text-red-600 mt-1">{validationErrors.groupTypeId}</p>

--- a/src/web/src/services/api/groupTypes.ts
+++ b/src/web/src/services/api/groupTypes.ts
@@ -25,21 +25,24 @@ export async function getGroupTypes(includeArchived = false): Promise<GroupTypeA
   const query = queryParams.toString();
   const endpoint = `${BASE_URL}${query ? `?${query}` : ''}`;
 
-  return get<GroupTypeAdminDto[]>(endpoint);
+  const response = await get<{ data: GroupTypeAdminDto[] }>(endpoint);
+  return response.data;
 }
 
 /**
  * Get group type details by IdKey
  */
 export async function getGroupType(idKey: string): Promise<GroupTypeDetailAdminDto> {
-  return get<GroupTypeDetailAdminDto>(`${BASE_URL}/${idKey}`);
+  const response = await get<{ data: GroupTypeDetailAdminDto }>(`${BASE_URL}/${idKey}`);
+  return response.data;
 }
 
 /**
  * Create a new group type
  */
 export async function createGroupType(request: CreateGroupTypeRequest): Promise<GroupTypeAdminDto> {
-  return post<GroupTypeAdminDto>(BASE_URL, request);
+  const response = await post<{ data: GroupTypeAdminDto }>(BASE_URL, request);
+  return response.data;
 }
 
 /**
@@ -49,7 +52,8 @@ export async function updateGroupType(
   idKey: string,
   request: UpdateGroupTypeRequest
 ): Promise<GroupTypeAdminDto> {
-  return put<GroupTypeAdminDto>(`${BASE_URL}/${idKey}`, request);
+  const response = await put<{ data: GroupTypeAdminDto }>(`${BASE_URL}/${idKey}`, request);
+  return response.data;
 }
 
 /**
@@ -63,5 +67,6 @@ export async function archiveGroupType(idKey: string): Promise<void> {
  * Get groups of a specific type
  */
 export async function getGroupsByType(idKey: string): Promise<GroupTypeGroupDto[]> {
-  return get<GroupTypeGroupDto[]>(`${BASE_URL}/${idKey}/groups`);
+  const response = await get<{ data: GroupTypeGroupDto[] }>(`${BASE_URL}/${idKey}/groups`);
+  return response.data;
 }

--- a/src/web/src/services/api/groups.ts
+++ b/src/web/src/services/api/groups.ts
@@ -130,7 +130,8 @@ export async function getChildGroups(idKey: string): Promise<PagedResult<GroupSu
  * Get schedules for a group
  */
 export async function getGroupSchedules(groupIdKey: string): Promise<GroupScheduleDto[]> {
-  return get<GroupScheduleDto[]>(`/groups/${groupIdKey}/schedules`);
+  const response = await get<{ data: GroupScheduleDto[] }>(`/groups/${groupIdKey}/schedules`);
+  return response.data;
 }
 
 /**
@@ -140,7 +141,8 @@ export async function addGroupSchedule(
   groupIdKey: string,
   request: AddGroupScheduleRequest
 ): Promise<GroupScheduleDto> {
-  return post<GroupScheduleDto>(`/groups/${groupIdKey}/schedules`, request);
+  const response = await post<{ data: GroupScheduleDto }>(`/groups/${groupIdKey}/schedules`, request);
+  return response.data;
 }
 
 /**

--- a/src/web/src/services/api/types.ts
+++ b/src/web/src/services/api/types.ts
@@ -464,7 +464,7 @@ export interface GroupDetailDto {
   groupType: GroupTypeSummaryDto;
   parentGroup?: GroupSummaryDto;
   campus?: CampusSummaryDto;
-  capacity?: number;
+  groupCapacity?: number;
   isActive: boolean;
   isArchived: boolean;
   schedule?: ScheduleDto;

--- a/tools/Koinon.TestDataSeeder/DataSeeder.cs
+++ b/tools/Koinon.TestDataSeeder/DataSeeder.cs
@@ -35,9 +35,11 @@ public class DataSeeder
     private static readonly Guid _wednesday7pmScheduleGuid = new("ffffffff-ffff-ffff-ffff-ffffffffffff");
     private static readonly Guid _familyGroupTypeGuid = new("10101010-1010-1010-1010-101010101010");
     private static readonly Guid _checkinGroupTypeGuid = new("20202020-2020-2020-2020-202020202020");
+    private static readonly Guid _generalGroupTypeGuid = new("60606060-6060-6060-6060-606060606060");
     private static readonly Guid _adultRoleGuid = new("30303030-3030-3030-3030-303030303030");
     private static readonly Guid _childRoleGuid = new("40404040-4040-4040-4040-404040404040");
     private static readonly Guid _memberRoleGuid = new("50505050-5050-5050-5050-505050505050");
+    private static readonly Guid _adminSecurityRoleGuid = new("70707070-7070-7070-7070-707070707070");
 
     public DataSeeder(KoinonDbContext context, ILogger<DataSeeder> logger, IAuthService authService)
     {
@@ -109,6 +111,10 @@ public class DataSeeder
         // Final save for all check-in groups
         await _context.SaveChangesAsync(cancellationToken);
 
+        // Seed security roles and assign Admin to John Smith
+        _logger.LogInformation("Seeding security roles...");
+        await SeedSecurityRolesAsync(people, now, cancellationToken);
+
         _logger.LogInformation("✅ Successfully seeded all test data");
     }
 
@@ -144,8 +150,24 @@ public class DataSeeder
             CreatedDateTime = now
         };
 
+        // General group type (for generic groups created in E2E tests)
+        var generalGroupType = new GroupType
+        {
+            Guid = _generalGroupTypeGuid,
+            Name = "General",
+            Description = "General purpose groups",
+            GroupTerm = "Group",
+            GroupMemberTerm = "Member",
+            IsSystem = false,
+            ShowInGroupList = true,
+            ShowInNavigation = true,
+            TakesAttendance = false,
+            CreatedDateTime = now
+        };
+
         _context.GroupTypes.Add(familyGroupType);
         _context.GroupTypes.Add(checkinGroupType);
+        _context.GroupTypes.Add(generalGroupType);
         // Save group types first so we have their IDs for roles
         await _context.SaveChangesAsync(cancellationToken);
 
@@ -431,6 +453,34 @@ public class DataSeeder
         await _context.SaveChangesAsync(cancellationToken);
 
         return people;
+    }
+
+    private async Task SeedSecurityRolesAsync(List<Person> people, DateTime now, CancellationToken cancellationToken = default)
+    {
+        var adminRole = new SecurityRole
+        {
+            Guid = _adminSecurityRoleGuid,
+            Name = "Admin",
+            Description = "Full administrative access",
+            IsSystemRole = true,
+            IsActive = true,
+            CreatedDateTime = now
+        };
+
+        _context.SecurityRoles.Add(adminRole);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        // Assign Admin role to John Smith (first person, the E2E test admin user)
+        var johnSmith = people.First(p => p.Email == "john.smith@example.com");
+        var adminAssignment = new PersonSecurityRole
+        {
+            PersonId = johnSmith.Id,
+            SecurityRoleId = adminRole.Id,
+            CreatedDateTime = now
+        };
+
+        _context.PersonSecurityRoles.Add(adminAssignment);
+        await _context.SaveChangesAsync(cancellationToken);
     }
 
     private Task SeedCheckinGroupsAsync(int checkinGroupTypeId, int memberRoleId, int scheduleId, DateTime now, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary
- Added `AsTracking()` to GroupService Update/Delete queries (global NoTracking default prevented mutations from persisting)
- Fixed API response envelope unwrapping in groupTypes and schedules frontend services
- Aligned frontend `GroupDetailDto.capacity` → `groupCapacity` to match backend DTO
- Disambiguated delete confirmation button (page button → "Delete Group")
- Group form now dynamically fetches group types from API
- Seeder now creates Admin security role + General group type for E2E tests

## Tests Fixed
- `should update group details` — update now persists via AsTracking
- `should delete a group with confirmation` — button no longer ambiguous
- `@smoke should complete full CRUD cycle` — full flow works end-to-end
- All 15 group-crud.spec.ts tests pass (1 skipped)

## Verification
- [x] Specific tests pass (15/15 + 1 skipped)
- [x] Backend tests pass (1406 passed)
- [x] TypeScript compiles
- [x] Lint passes

Closes #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)