### PR TITLE
fix(people): add phone number management to person update flow

### DIFF
--- a/src/Koinon.Application/DTOs/Requests/UpdatePersonRequest.cs
+++ b/src/Koinon.Application/DTOs/Requests/UpdatePersonRequest.cs
@@ -21,4 +21,5 @@ public record UpdatePersonRequest
     public string? ConnectionStatusValueId { get; init; }
     public string? RecordStatusValueId { get; init; }
     public string? PrimaryCampusId { get; init; }
+    public IList<CreatePhoneNumberRequest>? PhoneNumbers { get; init; }
 }

--- a/src/Koinon.Application/Services/PersonService.cs
+++ b/src/Koinon.Application/Services/PersonService.cs
@@ -306,6 +306,7 @@ public class PersonService(
         }
 
         var person = await context.People
+            .AsTracking()
             .Include(p => p.PhoneNumbers)
             .FirstOrDefaultAsync(p => p.Id == id, ct);
 
@@ -421,6 +422,29 @@ public class PersonService(
         if (request.AnniversaryDate.HasValue)
         {
             person.AnniversaryDate = request.AnniversaryDate.Value;
+        }
+
+        // Update phone numbers (replace all if provided)
+        if (request.PhoneNumbers != null)
+        {
+            // Remove existing phone numbers
+            person.PhoneNumbers.Clear();
+
+            // Add new phone numbers
+            foreach (var phoneRequest in request.PhoneNumbers)
+            {
+                var phone = mapper.Map<PhoneNumber>(phoneRequest);
+
+                if (!string.IsNullOrWhiteSpace(phoneRequest.PhoneTypeValueId))
+                {
+                    if (IdKeyHelper.TryDecode(phoneRequest.PhoneTypeValueId, out int phoneTypeId))
+                    {
+                        phone.NumberTypeValueId = phoneTypeId;
+                    }
+                }
+
+                person.PhoneNumbers.Add(phone);
+            }
         }
 
         person.ModifiedDateTime = DateTime.UtcNow;

--- a/src/web/src/pages/admin/people/PersonFormPage.tsx
+++ b/src/web/src/pages/admin/people/PersonFormPage.tsx
@@ -112,6 +112,9 @@ export function PersonFormPage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    // Filter out empty phone numbers before validation
+    const filledPhoneNumbers = phoneNumbers.filter((p) => p.number.trim());
+
     // Validate all fields before submit
     const formData = {
       firstName,
@@ -122,7 +125,7 @@ export function PersonFormPage() {
       gender,
       birthDate,
       campusId,
-      phoneNumbers,
+      phoneNumbers: filledPhoneNumbers,
     };
 
     const result = personFormSchema.safeParse(formData);
@@ -158,6 +161,9 @@ export function PersonFormPage() {
         if (gender !== person?.gender) request.gender = gender;
         if (birthDate !== person?.birthDate) request.birthDate = birthDate || null;
         if (campusId !== person?.primaryCampus?.idKey) request.primaryCampusId = campusId || null;
+
+        // Always send phone numbers on update (replace strategy)
+        request.phoneNumbers = phoneNumbersData.length > 0 ? phoneNumbersData : [];
 
         const result = await updateMutation.mutateAsync({ idKey: idKey!, request });
         navigate(`/admin/people/${result.idKey}`);

--- a/src/web/src/services/api/types.ts
+++ b/src/web/src/services/api/types.ts
@@ -315,6 +315,7 @@ export interface UpdatePersonRequest {
   recordStatusValueId?: IdKey;
 
   primaryCampusId?: IdKey | null;
+  phoneNumbers?: CreatePhoneNumberRequest[];
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Added `PhoneNumbers` to `UpdatePersonRequest` (backend + frontend types)
- Added phone number replace logic in `PersonService.UpdateAsync`
- Added `AsTracking()` to `PersonService.UpdateAsync` (same global NoTracking fix as groups)
- Filter empty phone inputs before form validation to prevent blocking submit

## Tests Fixed
- `should filter out empty phone numbers on submit`
- `should add phone number in edit mode`
- `should update existing phone number`
- `should add multiple phones to existing person`
- `should handle removing all phones from person with multiple`
- All 26 person-phone-editor.spec.ts tests pass

## Verification
- [x] All 26 tests pass
- [x] Backend tests pass
- [x] TypeScript compiles
- [x] Lint passes

Closes #544

🤖 Generated with [Claude Code](https://claude.com/claude-code)