### PR TITLE
fix(notes): align PersonNoteDto field names with API contract

### DIFF
--- a/src/Koinon.Application/DTOs/PersonNoteDto.cs
+++ b/src/Koinon.Application/DTOs/PersonNoteDto.cs
@@ -4,12 +4,13 @@ namespace Koinon.Application.DTOs;
 public record PersonNoteDto(
     string IdKey,
     string Text,
-    DateTime NoteDate,
-    string? NoteType,
-    string? CreatedByName,
+    DateTime NoteDateTime,
+    string? NoteTypeName,
+    string? NoteTypeValueIdKey,
+    string? AuthorPersonName,
     bool IsPrivate,
     bool IsAlert,
-    DateTime CreatedDateTime
+    DateTime? CreatedDateTime = null
 );
 
 /// <summary>Request to create a person note.</summary>

--- a/src/Koinon.Application/Services/PersonService.cs
+++ b/src/Koinon.Application/Services/PersonService.cs
@@ -770,6 +770,7 @@ public class PersonService(
                 n.Text,
                 n.NoteDate,
                 n.NoteTypeDefinedValue != null ? n.NoteTypeDefinedValue.Value : null,
+                n.NoteTypeDefinedValueId != null ? IdKeyHelper.Encode(n.NoteTypeDefinedValueId.Value) : null,
                 n.CreatedByPersonAlias != null && n.CreatedByPersonAlias.Person != null
                     ? n.CreatedByPersonAlias.Person.FullName
                     : n.CreatedByPersonAlias != null
@@ -844,6 +845,7 @@ public class PersonService(
                 n.Text,
                 n.NoteDate,
                 n.NoteTypeDefinedValue != null ? n.NoteTypeDefinedValue.Value : null,
+                n.NoteTypeDefinedValueId != null ? IdKeyHelper.Encode(n.NoteTypeDefinedValueId.Value) : null,
                 n.CreatedByPersonAlias != null && n.CreatedByPersonAlias.Person != null
                     ? n.CreatedByPersonAlias.Person.FullName
                     : n.CreatedByPersonAlias != null
@@ -933,6 +935,7 @@ public class PersonService(
                 n.Text,
                 n.NoteDate,
                 n.NoteTypeDefinedValue != null ? n.NoteTypeDefinedValue.Value : null,
+                n.NoteTypeDefinedValueId != null ? IdKeyHelper.Encode(n.NoteTypeDefinedValueId.Value) : null,
                 n.CreatedByPersonAlias != null && n.CreatedByPersonAlias.Person != null
                     ? n.CreatedByPersonAlias.Person.FullName
                     : n.CreatedByPersonAlias != null

--- a/src/web/src/components/admin/people/NotesSection.tsx
+++ b/src/web/src/components/admin/people/NotesSection.tsx
@@ -210,8 +210,8 @@ function NoteItem({ note, onEdit, onDelete }: NoteItemProps) {
     <div className="py-4 border-b border-gray-100 last:border-0">
       <div className="flex items-start justify-between gap-2">
         <div className="flex flex-wrap items-center gap-2 text-sm text-gray-500">
-          <span className="font-medium text-gray-900">{formatDate(note.noteDate)}</span>
-          {note.noteType && <NoteTypeBadge noteType={note.noteType} />}
+          <span className="font-medium text-gray-900">{formatDate(note.noteDateTime)}</span>
+          {note.noteTypeName && <NoteTypeBadge noteType={note.noteTypeName} />}
           {note.isAlert && (
             <span className="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded-full bg-red-100 text-red-700">
               Alert
@@ -260,8 +260,8 @@ function NoteItem({ note, onEdit, onDelete }: NoteItemProps) {
 
       <p className="mt-2 text-sm text-gray-800 whitespace-pre-wrap">{note.text}</p>
 
-      {note.createdByName && (
-        <p className="mt-1 text-xs text-gray-500">Added by {note.createdByName}</p>
+      {note.authorPersonName && (
+        <p className="mt-1 text-xs text-gray-500">Added by {note.authorPersonName}</p>
       )}
     </div>
   );
@@ -315,7 +315,7 @@ export function NotesSection({ personIdKey }: NotesSectionProps) {
   const deleteMutation = useDeletePersonNote();
 
   const sortedNotes = notes
-    ? [...notes].sort((a, b) => new Date(b.noteDate).getTime() - new Date(a.noteDate).getTime())
+    ? [...notes].sort((a, b) => new Date(b.noteDateTime).getTime() - new Date(a.noteDateTime).getTime())
     : [];
 
   const handleAddClick = () => {
@@ -393,8 +393,8 @@ export function NotesSection({ personIdKey }: NotesSectionProps) {
 
   const getEditInitialValues = (note: PersonNoteDto): NoteFormValues => ({
     text: note.text,
-    noteDate: toDateInputValue(note.noteDate),
-    noteType: note.noteType ?? '',
+    noteDate: toDateInputValue(note.noteDateTime),
+    noteType: note.noteTypeName ?? '',
     isPrivate: note.isPrivate,
     isAlert: note.isAlert,
   });
@@ -417,6 +417,7 @@ export function NotesSection({ personIdKey }: NotesSectionProps) {
       {/* Add form */}
       {activeForm?.mode === 'add' && (
         <div className="mb-6">
+          <h3 className="text-md font-semibold text-gray-900 mb-3">Add Note</h3>
           <NoteForm
             isSubmitting={isSubmitting}
             onSubmit={handleAddSubmit}

--- a/src/web/src/services/api/people.ts
+++ b/src/web/src/services/api/people.ts
@@ -139,8 +139,17 @@ export async function getPersonGivingSummary(
  * Get notes for a person
  */
 export async function getPersonNotes(personIdKey: string): Promise<PersonNoteDto[]> {
-  const response = await get<{ data: PersonNoteDto[] }>(`/people/${personIdKey}/notes`);
-  return response.data;
+  const response = await get<{ data: PersonNoteDto[] | { data: PersonNoteDto[] } }>(`/people/${personIdKey}/notes`);
+  // Handle both flat array and paginated (PagedResult) response formats
+  const data = response.data;
+  if (Array.isArray(data)) {
+    return data;
+  }
+  // PagedResult format: { data: [...], meta: { ... } }
+  if (data && typeof data === 'object' && 'data' in data && Array.isArray((data as { data: PersonNoteDto[] }).data)) {
+    return (data as { data: PersonNoteDto[] }).data;
+  }
+  return [];
 }
 
 /**

--- a/src/web/src/services/api/types.ts
+++ b/src/web/src/services/api/types.ts
@@ -1510,12 +1510,13 @@ export interface RecentContributionDto {
 export interface PersonNoteDto {
   idKey: IdKey;
   text: string;
-  noteDate: DateTime;
-  noteType: string | null;
-  createdByName: string | null;
+  noteDateTime: DateTime;
+  noteTypeName: string | null;
+  noteTypeValueIdKey: IdKey | null;
+  authorPersonName: string | null;
   isPrivate: boolean;
   isAlert: boolean;
-  createdDateTime: DateTime;
+  createdDateTime?: DateTime;
 }
 
 export interface CreatePersonNoteRequest {


### PR DESCRIPTION
## Summary
- Renamed PersonNoteDto fields to match API contract: noteDate→noteDateTime, noteType→noteTypeName, createdByName→authorPersonName
- Added noteTypeValueIdKey field to DTO
- Fixed getPersonNotes to handle PagedResult response envelope format
- Added "Add Note" heading to inline note form

## Tests Fixed
- renders Notes heading and empty state when no notes exist
- renders note cards when notes are present
- Add Note button opens the inline note form

## Verification
- [x] 3/3 specific tests pass
- [x] TypeScript compiles clean
- [x] Backend builds + all 1406 backend tests pass
- [x] Lint passes

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)