### PR TITLE
fix(roster): forward data-testid prop in LocationPicker

### DIFF
--- a/src/web/src/components/LocationPicker.tsx
+++ b/src/web/src/components/LocationPicker.tsx
@@ -9,6 +9,7 @@ export interface LocationPickerProps {
   campusIdKey?: string;
   className?: string;
   disabled?: boolean;
+  'data-testid'?: string;
 }
 
 /**
@@ -28,6 +29,7 @@ export function LocationPicker({
   campusIdKey,
   className = '',
   disabled = false,
+  'data-testid': dataTestId,
 }: LocationPickerProps) {
   const [locations, setLocations] = useState<CheckinLocationDto[]>([]);
 
@@ -66,7 +68,7 @@ export function LocationPicker({
   }
 
   return (
-    <div className={className}>
+    <div className={className} data-testid={dataTestId}>
       <label htmlFor="location-picker" className="block text-sm font-medium text-gray-700 mb-2">
         Select Room
       </label>


### PR DESCRIPTION
## Summary
- LocationPicker component was not forwarding `data-testid` attribute to the DOM
- Added `data-testid` prop support so E2E tests can find the location picker element

## Tests Fixed
- All 8 tests in `e2e/tests/admin/roster/room-roster.spec.ts` now passing

## Verification
- [x] Specific E2E tests pass (8/8)
- [x] Frontend unit tests pass (189/189)
- [x] TypeScript compiles
- [x] Lint passes

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)