### PR TITLE
fix(groups): add attendance history section to group detail page

### DIFF
--- a/src/web/src/components/admin/groups/GroupAttendanceHistorySection.tsx
+++ b/src/web/src/components/admin/groups/GroupAttendanceHistorySection.tsx
@@ -1,0 +1,175 @@
+/**
+ * Group Attendance History Section
+ * Displays past attendance occurrences with expandable attendee details
+ */
+
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useGroupAttendanceHistory, useGroupAttendanceDetail } from '@/hooks/useGroups';
+import type { GroupAttendanceOccurrenceDto } from '@/services/api/types';
+
+interface GroupAttendanceHistorySectionProps {
+  groupIdKey: string;
+}
+
+function formatOccurrenceDate(dateStr: string): string {
+  const date = new Date(dateStr + 'T00:00:00');
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+}
+
+function TrendIndicator({
+  current,
+  previous,
+}: {
+  current: GroupAttendanceOccurrenceDto;
+  previous: GroupAttendanceOccurrenceDto | undefined;
+}) {
+  if (!previous || current.didNotOccur || previous.didNotOccur) return null;
+
+  const diff = current.attendeeCount - previous.attendeeCount;
+  if (diff === 0) return null;
+
+  if (diff > 0) {
+    return (
+      <span
+        className="text-green-600 font-semibold ml-2"
+        title={`Up from ${previous.attendeeCount}`}
+      >
+        ↑
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className="text-red-600 font-semibold ml-2"
+      title={`Down from ${previous.attendeeCount}`}
+    >
+      ↓
+    </span>
+  );
+}
+
+function OccurrenceRow({
+  occurrence,
+  previousOccurrence,
+  groupIdKey,
+}: {
+  occurrence: GroupAttendanceOccurrenceDto;
+  previousOccurrence: GroupAttendanceOccurrenceDto | undefined;
+  groupIdKey: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const { data: attendees } = useGroupAttendanceDetail(
+    expanded ? groupIdKey : undefined,
+    expanded ? occurrence.idKey : undefined
+  );
+
+  const presentAttendees = (attendees || []).filter((a) => a.didAttend);
+
+  return (
+    <div className="border border-gray-200 rounded-lg">
+      <button
+        onClick={() => setExpanded(!expanded)}
+        className="w-full text-left px-4 py-3 flex items-center justify-between hover:bg-gray-50"
+        aria-label={formatOccurrenceDate(occurrence.occurrenceDate)}
+      >
+        <div className="flex items-center gap-3">
+          <span className="font-medium text-gray-900">
+            {formatOccurrenceDate(occurrence.occurrenceDate)}
+          </span>
+          {occurrence.locationName && (
+            <span className="text-sm text-gray-500">{occurrence.locationName}</span>
+          )}
+          {occurrence.scheduleName && (
+            <span className="text-sm text-gray-400">({occurrence.scheduleName})</span>
+          )}
+        </div>
+        <div className="flex items-center">
+          {occurrence.didNotOccur ? (
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
+              Did not occur
+            </span>
+          ) : (
+            <span className="text-sm text-gray-600">
+              {occurrence.attendeeCount} attended
+              <TrendIndicator current={occurrence} previous={previousOccurrence} />
+            </span>
+          )}
+          <svg
+            className={`w-4 h-4 ml-2 text-gray-400 transition-transform ${expanded ? 'rotate-180' : ''}`}
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </div>
+      </button>
+
+      {expanded && presentAttendees.length > 0 && (
+        <div className="border-t border-gray-200 px-4 py-3 space-y-2">
+          {presentAttendees.map((attendee) => (
+            <div key={attendee.personIdKey} className="flex items-center gap-3">
+              {attendee.photoUrl ? (
+                <img
+                  src={attendee.photoUrl}
+                  alt={attendee.fullName}
+                  className="w-8 h-8 rounded-full object-cover"
+                />
+              ) : (
+                <div className="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center text-xs font-medium text-gray-600">
+                  {attendee.fullName.charAt(0)}
+                </div>
+              )}
+              <Link
+                to={`/admin/people/${attendee.personIdKey}`}
+                className="text-sm text-blue-600 hover:text-blue-800 hover:underline"
+              >
+                {attendee.fullName}
+              </Link>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function GroupAttendanceHistorySection({ groupIdKey }: GroupAttendanceHistorySectionProps) {
+  const { data: historyData, isLoading } = useGroupAttendanceHistory(groupIdKey);
+
+  const occurrences = historyData?.data || [];
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-6">
+      <h2 className="text-lg font-semibold text-gray-900 mb-4">Attendance History</h2>
+
+      {isLoading && (
+        <div className="text-center py-8 text-gray-500">Loading attendance history...</div>
+      )}
+
+      {!isLoading && occurrences.length === 0 && (
+        <div className="text-center py-8 text-gray-500">No attendance records yet</div>
+      )}
+
+      {!isLoading && occurrences.length > 0 && (
+        <div className="space-y-2">
+          {occurrences.map((occ, index) => (
+            <OccurrenceRow
+              key={occ.idKey}
+              occurrence={occ}
+              previousOccurrence={occurrences[index + 1]}
+              groupIdKey={groupIdKey}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/web/src/components/admin/groups/index.ts
+++ b/src/web/src/components/admin/groups/index.ts
@@ -1,1 +1,2 @@
 export { GroupSchedulesSection } from './GroupSchedulesSection';
+export { GroupAttendanceHistorySection } from './GroupAttendanceHistorySection';

--- a/src/web/src/hooks/useGroups.ts
+++ b/src/web/src/hooks/useGroups.ts
@@ -134,3 +134,27 @@ export function useRemoveGroupSchedule() {
     },
   });
 }
+
+/**
+ * Fetch attendance history for a group
+ */
+export function useGroupAttendanceHistory(groupIdKey?: string) {
+  return useQuery({
+    queryKey: ['groups', groupIdKey, 'attendance'],
+    queryFn: () => groupsApi.getGroupAttendanceHistory(groupIdKey!),
+    enabled: !!groupIdKey,
+    staleTime: 2 * 60 * 1000,
+  });
+}
+
+/**
+ * Fetch attendance detail for a specific occurrence
+ */
+export function useGroupAttendanceDetail(groupIdKey?: string, occurrenceIdKey?: string) {
+  return useQuery({
+    queryKey: ['groups', groupIdKey, 'attendance', occurrenceIdKey],
+    queryFn: () => groupsApi.getGroupAttendanceDetail(groupIdKey!, occurrenceIdKey!),
+    enabled: !!groupIdKey && !!occurrenceIdKey,
+    staleTime: 5 * 60 * 1000,
+  });
+}

--- a/src/web/src/pages/admin/groups/GroupDetailPage.tsx
+++ b/src/web/src/pages/admin/groups/GroupDetailPage.tsx
@@ -6,7 +6,7 @@
 import { useState } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useGroup, useChildGroups, useDeleteGroup } from '@/hooks/useGroups';
-import { GroupSchedulesSection } from '@/components/admin/groups';
+import { GroupSchedulesSection, GroupAttendanceHistorySection } from '@/components/admin/groups';
 
 export function GroupDetailPage() {
   const { idKey } = useParams<{ idKey: string }>();
@@ -266,6 +266,9 @@ export function GroupDetailPage() {
 
           {/* Schedules */}
           <GroupSchedulesSection groupIdKey={idKey!} />
+
+          {/* Attendance History */}
+          <GroupAttendanceHistorySection groupIdKey={idKey!} />
         </div>
 
         {/* Sidebar */}

--- a/src/web/src/services/api/groups.ts
+++ b/src/web/src/services/api/groups.ts
@@ -15,6 +15,8 @@ import type {
   UpdateGroupRequest,
   GroupScheduleDto,
   AddGroupScheduleRequest,
+  GroupAttendanceOccurrenceDto,
+  GroupAttendanceDetailDto,
 } from './types';
 
 /**
@@ -153,4 +155,26 @@ export async function removeGroupSchedule(
   scheduleIdKey: string
 ): Promise<void> {
   await del<void>(`/groups/${groupIdKey}/schedules/${scheduleIdKey}`);
+}
+
+/**
+ * Get attendance history for a group (paginated list of occurrences)
+ */
+export async function getGroupAttendanceHistory(
+  groupIdKey: string
+): Promise<PagedResult<GroupAttendanceOccurrenceDto>> {
+  return get<PagedResult<GroupAttendanceOccurrenceDto>>(`/groups/${groupIdKey}/attendance`);
+}
+
+/**
+ * Get attendance detail for a specific occurrence
+ */
+export async function getGroupAttendanceDetail(
+  groupIdKey: string,
+  occurrenceIdKey: string
+): Promise<GroupAttendanceDetailDto[]> {
+  const response = await get<{ data: GroupAttendanceDetailDto[] }>(
+    `/groups/${groupIdKey}/attendance/${occurrenceIdKey}`
+  );
+  return response.data;
 }


### PR DESCRIPTION
## Summary
- Created `GroupAttendanceHistorySection` component with expandable occurrence rows
- Added API functions and TanStack Query hooks for group attendance endpoints
- Integrated into GroupDetailPage below schedules section

## Tests Fixed
- All 8 tests in `e2e/tests/admin/groups/attendance-history.spec.ts` now passing

## Verification
- [x] Specific E2E tests pass (8/8)
- [x] Frontend unit tests pass (189/189)
- [x] Backend tests pass (1406/1406)
- [x] TypeScript compiles
- [x] Lint passes

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)