### PR TITLE
fix(families): add data-testid, role=dialog, age format for member E2E

### DIFF
--- a/src/web/src/components/admin/families/AddMemberModal.tsx
+++ b/src/web/src/components/admin/families/AddMemberModal.tsx
@@ -68,7 +68,7 @@ export function AddMemberModal({
         />
 
         {/* Modal */}
-        <div className="relative inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
+        <div role="dialog" aria-modal="true" aria-label="Add Family Member" className="relative inline-block align-bottom bg-white rounded-lg text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-lg sm:w-full">
           <div className="bg-white px-4 pt-5 pb-4 sm:p-6 sm:pb-4">
             <div className="flex items-start justify-between mb-4">
               <h3 className="text-lg font-medium text-gray-900">Add Family Member</h3>
@@ -102,7 +102,7 @@ export function AddMemberModal({
               <div className="relative">
                 <input
                   type="text"
-                  placeholder="Search by name, email, or phone..."
+                  placeholder="Search for a person by name or email..."
                   value={searchQuery}
                   onChange={(e) => setSearchQuery(e.target.value)}
                   className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"

--- a/src/web/src/components/admin/families/FamilyMemberCard.tsx
+++ b/src/web/src/components/admin/families/FamilyMemberCard.tsx
@@ -17,7 +17,7 @@ export function FamilyMemberCard({ member, onRemove, readOnly = false }: FamilyM
   const isAdult = role.name === 'Adult';
 
   return (
-    <div className="flex items-center gap-4 p-4 bg-white border border-gray-200 rounded-lg hover:shadow-sm transition-shadow">
+    <div data-testid="family-member-card" className="flex items-center gap-4 p-4 bg-white border border-gray-200 rounded-lg hover:shadow-sm transition-shadow">
       {/* Avatar */}
       <Link to={`/admin/people/${person.idKey}`} className="flex-shrink-0">
         {person.photoUrl ? (
@@ -57,7 +57,7 @@ export function FamilyMemberCard({ member, onRemove, readOnly = false }: FamilyM
               {person.fullName}
             </h3>
             {person.age !== undefined && (
-              <span className="text-xs text-gray-500">({person.age})</span>
+              <span className="text-xs text-gray-500">({person.age}y)</span>
             )}
           </div>
         </Link>


### PR DESCRIPTION
## Summary
- Added `data-testid="family-member-card"` to FamilyMemberCard component
- Added `role="dialog" aria-modal="true"` to AddMemberModal
- Changed age display from `(40)` to `(40y)` to match test regex `/\d+\s*y|age/i`
- Updated search placeholder to include "person" for `/search.*person/i` match

## Tests Fixed
- Family members: 11/13 pass (was 5/13, +6)
- Family detail: 14/16 pass (was 11/16, +3)

## Known Remaining (strict mode violations in tests)
- `getByText(/adult|child/i)` matches 4 elements
- `getByText(/adult/i)` matches 2 elements

Closes #579

🤖 Generated with [Claude Code](https://claude.com/claude-code)