### PR TITLE
fix(e2e): set workers=1 to prevent Argon2id memory exhaustion

### DIFF
--- a/src/web/playwright.config.ts
+++ b/src/web/playwright.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  workers: 1,
 
   reporter: [
     ['html', { outputFolder: 'playwright-report' }],


### PR DESCRIPTION
## Summary
- Root cause: Argon2id password hashing allocates 128MB per login attempt. With Playwright's default workers (half CPU cores = 8 on this 16-core system), multiple concurrent login attempts exhaust the 3.3GB system RAM, causing API timeouts
- Fix: Set `workers: 1` in playwright.config.ts to serialize test execution

## Tests Fixed
- All 7 login tests (login.spec.ts) — previously 4/7 failing
- All 16 admin navigation tests (admin-navigation.spec.ts) — previously 8/16 failing  
- Unblocks all test suites using `loginAsAdmin` fixture (family-members, groups-tree, group-members, person-notes, etc.)

## Verification
- 53 tests run across 4 test suites: 53 passed, 0 failed
- Backend: 1406 tests passing
- Frontend unit: 189 tests passing

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)