### PR TITLE
fix(checkin): update not-found text to satisfy both test regexes

### DIFF
--- a/src/web/src/pages/CheckinPage.tsx
+++ b/src/web/src/pages/CheckinPage.tsx
@@ -565,7 +565,7 @@ export function CheckinPage() {
             <div className="max-w-2xl mx-auto mt-4 space-y-4" role="alert" aria-live="polite">
               <Card className="bg-yellow-50 border border-yellow-200">
                 <p id="search-no-results" className="text-yellow-900 text-center font-medium">
-                  No families found. Please check the number and try again.
+                  No families found. Phone number not found in our records.
                 </p>
               </Card>
               <Button


### PR DESCRIPTION
## Summary
- Changed "No families found. Please check the number and try again." to "No families found. Phone number not found in our records."
- This text matches both `/no families found/i` and `/no family found|not found/i`

## Tests Fixed
- `checkin-flow.spec.ts` — "should show error for non-existent phone"

## Verification
- Both regex-dependent tests pass
- No regressions in checkin-complete-flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)