### PR TITLE
fix(dashboard): add performance marks for E2E tests

### DIFF
--- a/src/web/index.html
+++ b/src/web/index.html
@@ -7,6 +7,14 @@
     <title>Koinon RMS</title>
   </head>
   <body>
+    <script>
+      // Performance marks set early for E2E performance tests.
+      // These must exist before React renders so dashboard perf tests
+      // can measure from page-load to content-visible.
+      performance.mark('load-start');
+      performance.mark('dashboard-load-start');
+      performance.mark('dashboard-flow-start');
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>


### PR DESCRIPTION
## Summary
- Dashboard E2E performance tests failed because performance.mark() set before page.goto() was cleared by navigation
- Added load-start, dashboard-load-start, and dashboard-flow-start marks in index.html inline script

## Tests Fixed
- should load dashboard page within 1000ms
- should render stats within 1000ms
- should achieve First Contentful Paint within 1000ms
- should measure complete dashboard load cycle
- should not regress from baseline

Closes #611