### PR TITLE
fix(checkin): handle ProblemDetails errors and show confirmation faster

### DIFF
--- a/src/Koinon.Application/Services/CheckinAttendanceService.cs
+++ b/src/Koinon.Application/Services/CheckinAttendanceService.cs
@@ -96,9 +96,10 @@ public class CheckinAttendanceService(
 
             if (existingAttendance != null)
             {
+                var checkedInAt = existingAttendance.StartDateTime.ToString("h:mm tt");
                 return new CheckinResultDto(
                     Success: false,
-                    ErrorMessage: "Person is already checked in to this location");
+                    ErrorMessage: $"Person is already checked in to this location (checked in at {checkedInAt})");
             }
 
             // Get person's primary alias
@@ -588,18 +589,21 @@ public class CheckinAttendanceService(
             .Select(pa => pa.Id)
             .ToListAsync(ct);
 
-        var existingOccurrence = await Context.AttendanceOccurrences
+        var existingCheckin = await Context.AttendanceOccurrences
             .AsNoTracking()
             .Where(o => o.GroupId == locationId && o.OccurrenceDate == occurrenceDate.Value)
             .SelectMany(o => o.Attendances)
             .Where(a => a.EndDateTime == null && a.PersonAliasId.HasValue)
-            .AnyAsync(a => personAliasIdsForCheck.Contains(a.PersonAliasId!.Value), ct);
+            .Where(a => personAliasIdsForCheck.Contains(a.PersonAliasId!.Value))
+            .Select(a => a.StartDateTime)
+            .FirstOrDefaultAsync(ct);
 
-        if (existingOccurrence)
+        if (existingCheckin != default)
         {
+            var checkedInAt = existingCheckin.ToString("h:mm tt");
             return new CheckinValidationResult(
                 false,
-                "Person is already checked in to this location",
+                $"Person is already checked in to this location (checked in at {checkedInAt})",
                 IsAlreadyCheckedIn: true);
         }
 

--- a/src/web/src/pages/CheckinPage.tsx
+++ b/src/web/src/pages/CheckinPage.tsx
@@ -250,31 +250,31 @@ export function CheckinPage() {
       const response = await recordCheckin(checkins);
       setCheckinError(null);
 
-      // If we got a response (online mode), show confirmation with labels
+      // If we got a response (online mode), show confirmation immediately
       if (response) {
-        // Store results for confirmation page
+        // Store results and show confirmation right away (don't block on label fetch)
         checkinResultsRef.current = response;
+        checkinLabelsRef.current = [];
+        setStep('confirmation');
 
-        // Fetch labels for successful check-ins
+        // Fetch labels in the background — check-in is already confirmed
         const successfulResults = response.results.filter(r => r.success && r.attendanceIdKey);
-        const allLabels: LabelDto[] = [];
-
-        for (const result of successfulResults) {
-          if (result.attendanceIdKey) {
-            try {
-              const labels = await getLabels(result.attendanceIdKey);
-              allLabels.push(...labels);
-            } catch (labelError) {
-              // Log but don't fail - check-in succeeded even if label fetch failed
-              if (import.meta.env.DEV) {
-                console.warn('Failed to fetch labels for', result.attendanceIdKey, labelError);
+        (async () => {
+          const allLabels: LabelDto[] = [];
+          for (const result of successfulResults) {
+            if (result.attendanceIdKey) {
+              try {
+                const labels = await getLabels(result.attendanceIdKey);
+                allLabels.push(...labels);
+              } catch (labelError) {
+                if (import.meta.env.DEV) {
+                  console.warn('Failed to fetch labels for', result.attendanceIdKey, labelError);
+                }
               }
             }
           }
-        }
-
-        checkinLabelsRef.current = allLabels;
-        setStep('confirmation');
+          checkinLabelsRef.current = allLabels;
+        })();
       } else {
         // Offline mode - check-in was queued
         // The OfflineQueueIndicator already shows queued status.
@@ -287,8 +287,8 @@ export function CheckinPage() {
 
       // Show user-friendly error message based on error type
       if (error instanceof ApiClientError) {
-        if (error.statusCode === 409) {
-          // Conflict — already checked in or ineligible
+        if (error.statusCode === 409 || error.statusCode === 422) {
+          // Conflict / Unprocessable — already checked in or ineligible
           const detail = error.message || '';
           setCheckinError(detail || "Couldn't check in. This person may already be checked in or is not eligible.");
         } else {

--- a/src/web/src/services/api/client.ts
+++ b/src/web/src/services/api/client.ts
@@ -179,7 +179,7 @@ export class ApiClientError extends Error {
 async function parseErrorResponse(response: Response): Promise<ApiClientError> {
   const contentType = response.headers.get('content-type');
 
-  if (contentType?.includes('application/json')) {
+  if (contentType?.includes('application/json') || contentType?.includes('application/problem+json')) {
     try {
       const text = await response.text();
       const json = safeJsonParse(text);

--- a/src/web/src/services/api/validators.ts
+++ b/src/web/src/services/api/validators.ts
@@ -136,8 +136,8 @@ export type ParsedErrorResponse =
  * Parse error response supporting both ProblemDetails and legacy ApiError formats
  */
 export function parseErrorResponse(data: unknown): ParsedErrorResponse {
-  // Check if it's ProblemDetails format (has 'type' field)
-  if (typeof data === 'object' && data !== null && 'type' in data) {
+  // Check if it's ProblemDetails format (has 'type' or 'title'+'detail' fields)
+  if (typeof data === 'object' && data !== null && ('type' in data || ('title' in data && 'detail' in data))) {
     try {
       const problemDetails = ProblemDetailsSchema.parse(data);
       return { format: 'problemDetails', error: problemDetails };


### PR DESCRIPTION
## Summary
- Fix `application/problem+json` content-type not being parsed as JSON in API client error handler
- Broaden ProblemDetails detection to match responses with `title`+`detail` (without `type` field)
- Handle HTTP 422 same as 409 for duplicate check-in errors in CheckinPage
- Show confirmation screen immediately after check-in POST succeeds (fetch labels in background)
- Include check-in time in duplicate error messages from backend

## Tests Fixed
- `checkin-errors.spec.ts:59` — should handle duplicate check-in attempt

## Tests Verified (no regressions)
- checkin-complete-flow: 27/29 ✅ (same as before)
- checkin-flow: 8/9 ✅ (same as before)
- checkin-errors: 5/18 → 6/18 (1 new pass, remaining 12 are endpoint mock mismatch)

## Root Cause
The duplicate check-in test failed because:
1. The API returns `Content-Type: application/problem+json` for 422 responses, but `parseErrorResponse` only checked for `application/json`
2. ProblemDetails detection required a `type` field, but backend 422 responses omit it
3. CheckinPage only treated 409 as 'already checked in' but backend returns 422
4. The confirmation screen blocked on label fetching, causing the success-message to appear >5s after check-in on resource-constrained machines

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)