### PR TITLE
fix(checkin): align server error message with test expectations

### DIFF
--- a/src/web/src/pages/CheckinPage.tsx
+++ b/src/web/src/pages/CheckinPage.tsx
@@ -507,7 +507,7 @@ export function CheckinPage() {
 
             // For 400 errors, extract validation details from error body
             let errorText = isServerError
-              ? 'Something went wrong. Please try again later.'
+              ? 'Search failed. Please try again later.'
               : friendly.message;
             if (is400 && error instanceof ApiClientError) {
               // Check for validation details in legacy error format


### PR DESCRIPTION
## Summary
- Changed server error message from 'Something went wrong. Please try again later.' to 'Search failed. Please try again later.'
- This message matches both test file regex patterns:
  - `checkin-errors.spec.ts`: `/something went wrong|server error|try again later/i` (matches "try again later")
  - `checkin-complete-flow.spec.ts`: `/search failed/i` (matches "Search failed")

## Tests Fixed
- No net-new test passes, but improves compatibility with both test file expectations

## Verification
- checkin-errors server error, validation, empty family, malformed, clear, retry: all pass
- No regressions in login, checkin-flow, supervisor-mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)