### PR TITLE
fix(forms): check window.confirm return value in handleCancel

### DIFF
--- a/src/web/src/pages/admin/families/FamilyFormPage.tsx
+++ b/src/web/src/pages/admin/families/FamilyFormPage.tsx
@@ -150,9 +150,10 @@ export function FamilyFormPage() {
 
   const handleCancel = () => {
     if (isFormDirty()) {
-      window.confirm(
+      const confirmed = window.confirm(
         'You have unsaved changes. Are you sure you want to leave?'
       );
+      if (!confirmed) return;
     }
     if (isEdit && idKey) {
       navigate(`/admin/families/${idKey}`);

--- a/src/web/src/pages/admin/people/PersonFormPage.tsx
+++ b/src/web/src/pages/admin/people/PersonFormPage.tsx
@@ -202,9 +202,10 @@ export function PersonFormPage() {
 
   const handleCancel = () => {
     if (isFormDirty()) {
-      window.confirm(
+      const confirmed = window.confirm(
         'You have unsaved changes. Are you sure you want to leave?'
       );
+      if (!confirmed) return;
     }
     navigate(isEdit ? `/admin/people/${idKey}` : '/admin/people');
   };


### PR DESCRIPTION
## Summary
- **Root cause:** `handleCancel` in PersonFormPage and FamilyFormPage called `window.confirm()` but ignored its return value, so navigation always proceeded regardless of the user's choice
- **Fix:** Capture the return value and return early if the user dismisses the dialog (clicks Cancel)

## Tests Fixed
- `person-crud.spec.ts:261` — should show unsaved changes warning on cancel
- `family-crud.spec.ts:281` — should show unsaved changes warning on cancel

## Quality Gates
- [x] Gate 2: Diagnosis posted on issue
- [x] Gate 4: Target test file passing
- [x] Gate 5: Full chromium suite passing (no new failures)
- [x] Gate 6: Code-critic approved
- [x] QA evidence recorded

Closes #623