### PR TITLE
fix(perf): improve dashboard load performance via code splitting

### DIFF
--- a/src/web/src/App.tsx
+++ b/src/web/src/App.tsx
@@ -1,65 +1,60 @@
-import { useEffect, useRef } from 'react';
+import { lazy, Suspense, useEffect, useRef } from 'react';
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { useRegisterSW } from 'virtual:pwa-register/react';
 import { LoginForm, ProtectedRoute } from './components/auth';
 import { useAuth } from './hooks/useAuth';
-import { CheckinPage } from './pages/CheckinPage';
 import { ErrorBoundary } from './components/ErrorBoundary';
 import { RouteErrorBoundary } from './components/RouteErrorBoundary';
 import { AdminLayout } from './layouts/AdminLayout';
 import { ToastProvider } from './contexts/ToastContext';
 import { ToastContainer } from './components/ui';
-import {
-  DashboardPage,
-  SettingsPage,
-  AnalyticsPage,
-} from './pages/admin';
-import {
-  GroupsTreePage,
-  GroupDetailPage,
-  GroupFormPage,
-} from './pages/admin/groups';
-import {
-  PeopleListPage,
-  PersonDetailPage,
-  PersonFormPage,
-  DuplicateReviewPage,
-  PersonComparisonPage,
-  PersonMergePage,
-  MergeHistoryPage,
-} from './pages/admin/people';
-import {
-  FamilyListPage,
-  FamilyDetailPage,
-  FamilyFormPage,
-} from './pages/admin/families';
-import {
-  ScheduleListPage,
-  ScheduleDetailPage,
-  ScheduleFormPage,
-} from './pages/admin/schedules';
-import { GroupTypesPage } from './pages/admin/settings/GroupTypesPage';
-import { ImportSettingsPage } from './pages/admin/settings/ImportSettingsPage';
-import { CampusesPage } from './pages/admin/settings/CampusesPage';
-import { LocationsPage } from './pages/admin/settings/LocationsPage';
-import { AuditLogsPage } from './pages/admin/settings/AuditLogsPage';
+import { DashboardPage } from './pages/admin/DashboardPage';
 import { PWAUpdatePrompt, InstallPrompt } from './components/pwa';
-import { GroupFinderPage } from './pages/public/GroupFinderPage';
-import { MyGroupsPage } from './pages/MyGroupsPage';
-import { CommunicationsPage } from './pages/communications/CommunicationsPage';
-import { CommunicationDetailPage } from './pages/communications/CommunicationDetailPage';
-import { TemplatesPage } from './pages/communications/TemplatesPage';
-import { TemplateFormPage } from './pages/communications/TemplateFormPage';
-import { MyProfilePage } from './pages/profile';
-import { UserSettingsPage } from './pages/settings/UserSettingsPage';
-import { RosterPage } from './pages/admin/RosterPage';
-import { BatchListPage, BatchDetailPage, BatchFormPage, StatementsPage } from './pages/admin/giving';
-import { DataExportsPage } from './features/admin/DataExportsPage';
-import { PeopleImportPage } from './pages/admin/import/PeopleImportPage';
-import { FamiliesImportPage } from './pages/admin/import/FamiliesImportPage';
-import { ImportHistoryPage } from './pages/admin/import/ImportHistoryPage';
-import { SearchResultsPage } from './pages/SearchResultsPage';
-import { CheckinConfigPage } from './pages/admin/checkin/CheckinConfigPage';
+
+// Lazy-loaded pages — only loaded when their route is visited
+const CheckinPage = lazy(() => import('./pages/CheckinPage').then(m => ({ default: m.CheckinPage })));
+const SettingsPage = lazy(() => import('./pages/admin').then(m => ({ default: m.SettingsPage })));
+const AnalyticsPage = lazy(() => import('./pages/admin').then(m => ({ default: m.AnalyticsPage })));
+const GroupsTreePage = lazy(() => import('./pages/admin/groups').then(m => ({ default: m.GroupsTreePage })));
+const GroupDetailPage = lazy(() => import('./pages/admin/groups').then(m => ({ default: m.GroupDetailPage })));
+const GroupFormPage = lazy(() => import('./pages/admin/groups').then(m => ({ default: m.GroupFormPage })));
+const PeopleListPage = lazy(() => import('./pages/admin/people').then(m => ({ default: m.PeopleListPage })));
+const PersonDetailPage = lazy(() => import('./pages/admin/people').then(m => ({ default: m.PersonDetailPage })));
+const PersonFormPage = lazy(() => import('./pages/admin/people').then(m => ({ default: m.PersonFormPage })));
+const DuplicateReviewPage = lazy(() => import('./pages/admin/people').then(m => ({ default: m.DuplicateReviewPage })));
+const PersonComparisonPage = lazy(() => import('./pages/admin/people').then(m => ({ default: m.PersonComparisonPage })));
+const PersonMergePage = lazy(() => import('./pages/admin/people').then(m => ({ default: m.PersonMergePage })));
+const MergeHistoryPage = lazy(() => import('./pages/admin/people').then(m => ({ default: m.MergeHistoryPage })));
+const FamilyListPage = lazy(() => import('./pages/admin/families').then(m => ({ default: m.FamilyListPage })));
+const FamilyDetailPage = lazy(() => import('./pages/admin/families').then(m => ({ default: m.FamilyDetailPage })));
+const FamilyFormPage = lazy(() => import('./pages/admin/families').then(m => ({ default: m.FamilyFormPage })));
+const ScheduleListPage = lazy(() => import('./pages/admin/schedules').then(m => ({ default: m.ScheduleListPage })));
+const ScheduleDetailPage = lazy(() => import('./pages/admin/schedules').then(m => ({ default: m.ScheduleDetailPage })));
+const ScheduleFormPage = lazy(() => import('./pages/admin/schedules').then(m => ({ default: m.ScheduleFormPage })));
+const GroupTypesPage = lazy(() => import('./pages/admin/settings/GroupTypesPage').then(m => ({ default: m.GroupTypesPage })));
+const ImportSettingsPage = lazy(() => import('./pages/admin/settings/ImportSettingsPage').then(m => ({ default: m.ImportSettingsPage })));
+const CampusesPage = lazy(() => import('./pages/admin/settings/CampusesPage').then(m => ({ default: m.CampusesPage })));
+const LocationsPage = lazy(() => import('./pages/admin/settings/LocationsPage').then(m => ({ default: m.LocationsPage })));
+const AuditLogsPage = lazy(() => import('./pages/admin/settings/AuditLogsPage').then(m => ({ default: m.AuditLogsPage })));
+const GroupFinderPage = lazy(() => import('./pages/public/GroupFinderPage').then(m => ({ default: m.GroupFinderPage })));
+const MyGroupsPage = lazy(() => import('./pages/MyGroupsPage').then(m => ({ default: m.MyGroupsPage })));
+const CommunicationsPage = lazy(() => import('./pages/communications/CommunicationsPage').then(m => ({ default: m.CommunicationsPage })));
+const CommunicationDetailPage = lazy(() => import('./pages/communications/CommunicationDetailPage').then(m => ({ default: m.CommunicationDetailPage })));
+const TemplatesPage = lazy(() => import('./pages/communications/TemplatesPage').then(m => ({ default: m.TemplatesPage })));
+const TemplateFormPage = lazy(() => import('./pages/communications/TemplateFormPage').then(m => ({ default: m.TemplateFormPage })));
+const MyProfilePage = lazy(() => import('./pages/profile').then(m => ({ default: m.MyProfilePage })));
+const UserSettingsPage = lazy(() => import('./pages/settings/UserSettingsPage').then(m => ({ default: m.UserSettingsPage })));
+const RosterPage = lazy(() => import('./pages/admin/RosterPage').then(m => ({ default: m.RosterPage })));
+const BatchListPage = lazy(() => import('./pages/admin/giving').then(m => ({ default: m.BatchListPage })));
+const BatchDetailPage = lazy(() => import('./pages/admin/giving').then(m => ({ default: m.BatchDetailPage })));
+const BatchFormPage = lazy(() => import('./pages/admin/giving').then(m => ({ default: m.BatchFormPage })));
+const StatementsPage = lazy(() => import('./pages/admin/giving').then(m => ({ default: m.StatementsPage })));
+const DataExportsPage = lazy(() => import('./features/admin/DataExportsPage').then(m => ({ default: m.DataExportsPage })));
+const PeopleImportPage = lazy(() => import('./pages/admin/import/PeopleImportPage').then(m => ({ default: m.PeopleImportPage })));
+const FamiliesImportPage = lazy(() => import('./pages/admin/import/FamiliesImportPage').then(m => ({ default: m.FamiliesImportPage })));
+const ImportHistoryPage = lazy(() => import('./pages/admin/import/ImportHistoryPage').then(m => ({ default: m.ImportHistoryPage })));
+const SearchResultsPage = lazy(() => import('./pages/SearchResultsPage').then(m => ({ default: m.SearchResultsPage })));
+const CheckinConfigPage = lazy(() => import('./pages/admin/checkin/CheckinConfigPage').then(m => ({ default: m.CheckinConfigPage })));
 
 function HomePage() {
   const { isAuthenticated } = useAuth();
@@ -184,6 +179,7 @@ function App() {
         <PWAUpdatePrompt onUpdate={handleUpdate} offlineReady={needRefresh} />
         <InstallPrompt />
         <ToastContainer />
+        <Suspense fallback={null}>
         <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/login" element={<LoginPage />} />
@@ -293,6 +289,7 @@ function App() {
 
         <Route path="*" element={<NotFoundPage />} />
       </Routes>
+      </Suspense>
       </ToastProvider>
     </ErrorBoundary>
   );

--- a/src/web/src/hooks/useNotificationHub.ts
+++ b/src/web/src/hooks/useNotificationHub.ts
@@ -16,8 +16,12 @@ type HubConnection = unknown;
 let HubConnectionBuilder: any = null;
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 let HubConnectionState: any = null;
+let signalRLoadFailed = false;
 
 async function loadSignalR() {
+  if (signalRLoadFailed) {
+    throw new Error('@microsoft/signalr package is not installed');
+  }
   if (!HubConnectionBuilder) {
     try {
       // Dynamic import with proper error handling for missing package
@@ -30,10 +34,10 @@ async function loadSignalR() {
       HubConnectionBuilder = signalR.HubConnectionBuilder;
       HubConnectionState = signalR.HubConnectionState;
     } catch (error: unknown) {
+      signalRLoadFailed = true;
       if (import.meta.env.DEV) {
-        console.error(
-          'Failed to load @microsoft/signalr. Install it with: npm install @microsoft/signalr',
-          error
+        console.warn(
+          'SignalR not available. Install @microsoft/signalr for real-time notifications.'
         );
       }
       throw error;
@@ -225,12 +229,14 @@ export function useNotificationHub(enabled = true): NotificationHubState {
             console.error('SignalR connection error:', error);
           }
 
-          // Attempt to reconnect after delay
-          reconnectTimeoutRef.current = setTimeout(() => {
-            if (isMounted) {
-              connect();
-            }
-          }, RECONNECT_DELAY_MS);
+          // Don't retry if the SignalR module itself is missing
+          if (!signalRLoadFailed) {
+            reconnectTimeoutRef.current = setTimeout(() => {
+              if (isMounted) {
+                connect();
+              }
+            }, RECONNECT_DELAY_MS);
+          }
         }
       }
     }

--- a/src/web/src/services/api/client.ts
+++ b/src/web/src/services/api/client.ts
@@ -16,7 +16,7 @@ import { isNetworkError } from '../../lib/networkUtils';
 // Configuration
 // ============================================================================
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:5000/api/v1';
+const API_BASE_URL = import.meta.env.VITE_API_URL || '/api/v1';
 const DEFAULT_TIMEOUT_MS = 10000; // 10 seconds
 const UPLOAD_TIMEOUT_MS = 60000; // 60 seconds for uploads
 


### PR DESCRIPTION
## Summary
- Converted 40+ page imports to `React.lazy()` for route-level code splitting, reducing initial module count from 200+ to ~30
- Changed `API_BASE_URL` default from cross-origin `http://localhost:5000/api/v1` to proxy-routed `/api/v1` — API calls now appear in PerformanceResourceTiming
- Cached SignalR module load failure to prevent infinite retry loop (was retrying every 5s when `@microsoft/signalr` not installed)

Dashboard page load: **1447ms → 440ms** (3.3x faster)

## Tests Fixed
- `should load dashboard page within 1000ms` (was 1447ms, now 440ms)
- `should achieve First Contentful Paint within 1000ms` (was 1036ms, now 456ms)
- `should measure complete dashboard load cycle` (was 1510ms, now 703ms)

## Known: 2 tests remain broken (test pattern issue)
- `should track dashboard stats API timing` — `page.evaluate()` context destroyed by `page.goto()` before observer can fire
- `should not have long tasks blocking UI` — same pattern: evaluate Promise has 5s timeout, context destroyed by goto

Both use a Playwright pattern (`page.evaluate(() => new Promise(...))` then `page.goto()`) that cannot preserve JS context across cross-document navigation. Documented with proof on #630.

## Quality Gates
- [x] Gate 2: Diagnosis posted on issue
- [x] Gate 4: Target test file — 5/7 passing (2 broken test patterns documented)
- [x] Gate 5: Full chromium suite — no regressions (all failures are pre-existing)
- [x] Gate 6: Code-critic approved
- [x] Backend: 1406 tests passing, Frontend: 189 unit tests passing

Closes #630