### PR TITLE
fix(api): resolve API base URL mismatch for person detail pages

### DIFF
--- a/src/web/src/services/api/client.ts
+++ b/src/web/src/services/api/client.ts
@@ -16,7 +16,11 @@ import { isNetworkError } from '../../lib/networkUtils';
 // Configuration
 // ============================================================================
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || '/api/v1';
+const API_BASE_URL =
+  import.meta.env.VITE_API_URL ||
+  (import.meta.env.VITE_API_BASE_URL
+    ? `${import.meta.env.VITE_API_BASE_URL}/api/v1`
+    : '/api/v1');
 const DEFAULT_TIMEOUT_MS = 10000; // 10 seconds
 const UPLOAD_TIMEOUT_MS = 60000; // 60 seconds for uploads
 

--- a/src/web/vite.config.ts
+++ b/src/web/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig(({ mode }) => ({
     VitePWA({
       registerType: 'autoUpdate',
       devOptions: {
-        enabled: true,
+        enabled: false,
       },
       includeAssets: ['icons/icon-192x192.png', 'icons/icon-512x512.png'],
       manifest: {


### PR DESCRIPTION
## Summary
- Add `VITE_API_BASE_URL` environment variable support to API client, allowing Playwright E2E tests to intercept API calls via absolute URLs
- Disable VitePWA dev service worker to prevent missing `dev-dist/sw.js` error overlay from blocking E2E interactions

Fixes #634

## Test plan
- [x] Person-notes E2E tests (3/3) pass
- [x] Regression check: 57 passed, 0 failed
- [x] Pre-push hooks: all backend tests + frontend typecheck + lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)