### PR TITLE
fix(e2e): correct mock route in checkin-complete-flow tests

### DIFF
--- a/src/web/e2e/tests/checkin/checkin-complete-flow.spec.ts
+++ b/src/web/e2e/tests/checkin/checkin-complete-flow.spec.ts
@@ -295,7 +295,7 @@ async function setupCheckinMocks(
   );
 
   // Search (POST /checkin/search)
-  await page.route('**/api/v1/checkin/search', (route) =>
+  await page.route('**/api/v1/families/search*', (route) =>
     route.fulfill({
       status: 200,
       contentType: 'application/json',
@@ -487,7 +487,7 @@ test.describe('Complete Check-in Flow', () => {
 
   test('multiple families — select-family step shown, user picks one', async ({ page }) => {
     // Override search to return two families
-    await page.route('**/api/v1/checkin/search', (route) =>
+    await page.route('**/api/v1/families/search*', (route) =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -514,7 +514,7 @@ test.describe('Complete Check-in Flow', () => {
   });
 
   test('no results — shows not-found message', async ({ page }) => {
-    await page.route('**/api/v1/checkin/search', (route) =>
+    await page.route('**/api/v1/families/search*', (route) =>
       route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -530,7 +530,7 @@ test.describe('Complete Check-in Flow', () => {
   });
 
   test('API error during search — error message shown', async ({ page }) => {
-    await page.route('**/api/v1/checkin/search', (route) =>
+    await page.route('**/api/v1/families/search*', (route) =>
       route.fulfill({ status: 500, contentType: 'application/json', body: '{}' })
     );
 


### PR DESCRIPTION
## Summary
- Fix 3 failing tests that mocked `/api/v1/checkin/search` — the app actually uses `/api/v1/families/search`
- Mocks never intercepted, so tests timed out waiting for expected responses

Fixes #633

## Test plan
- [x] 3 previously failing tests now pass (lines 488, 532, 544)
- [x] Full file regression: 27 passed, 2 pre-existing known failures, 0 new regressions
- [x] Pre-push hooks: all backend tests + frontend typecheck + lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)