### PR TITLE
fix(pwa): add data-testid to OfflineIndicator

### DIFF
--- a/src/web/src/components/pwa/OfflineIndicator.tsx
+++ b/src/web/src/components/pwa/OfflineIndicator.tsx
@@ -40,6 +40,7 @@ export function OfflineIndicator() {
 
   return (
     <div
+      data-testid="offline-indicator"
       className={`fixed top-0 left-0 right-0 z-50 px-4 py-3 text-center font-medium transition-colors ${
         isOnline
           ? 'bg-green-600 text-white'


### PR DESCRIPTION
## Summary
- Add `data-testid="offline-indicator"` to the OfflineIndicator component's outer div
- Component had `role="status"` but E2E tests locate it via `getByTestId('offline-indicator')`

Fixes #637

## Test plan
- [x] Offline smoke test (line 247) now passes — verified by independent agent
- [x] Pre-push hooks: all backend tests + frontend typecheck + lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)