### PR TITLE
feat(offline): add family search cache and align IndexedDB schema

### DIFF
--- a/src/web/src/services/api/checkin.ts
+++ b/src/web/src/services/api/checkin.ts
@@ -3,6 +3,7 @@
  */
 
 import { get, post } from './client';
+import { offlineFamilyCache } from '@/services/offline/OfflineFamilyCache';
 import type {
   CheckinConfigDto,
   CheckinConfigParams,
@@ -55,40 +56,59 @@ export async function getCheckinConfiguration(
 export async function searchFamiliesForCheckin(
   request: CheckinSearchRequest
 ): Promise<CheckinFamilyDto[]> {
-  // Use a shorter timeout for kiosk search — users expect fast feedback
-  const response = await get<Record<string, unknown>>(
-    `/families/search?query=${encodeURIComponent(request.searchValue)}`,
-    { timeout: 5000 }
-  );
+  try {
+    // Use a shorter timeout for kiosk search — users expect fast feedback
+    const response = await get<Record<string, unknown>>(
+      `/families/search?query=${encodeURIComponent(request.searchValue)}`,
+      { timeout: 5000 }
+    );
 
-  // Handle { data: [...] } format (backend & most mocks)
-  const dataArray = response.data as Array<CheckinFamilySearchResultDto & Partial<CheckinFamilyDto>> | undefined;
-  if (Array.isArray(dataArray)) {
-    return dataArray.map((item) => {
-      // Backend format has familyIdKey; mock/frontend format has idKey directly
-      if (item.familyIdKey) {
-        return mapSearchResultToFamily(item as CheckinFamilySearchResultDto);
+    // Handle { data: [...] } format (backend & most mocks)
+    const dataArray = response.data as Array<CheckinFamilySearchResultDto & Partial<CheckinFamilyDto>> | undefined;
+    let results: CheckinFamilyDto[];
+
+    if (Array.isArray(dataArray)) {
+      results = dataArray.map((item) => {
+        // Backend format has familyIdKey; mock/frontend format has idKey directly
+        if (item.familyIdKey) {
+          return mapSearchResultToFamily(item as CheckinFamilySearchResultDto);
+        }
+        // Already in frontend DTO shape (from mocked responses)
+        return item as unknown as CheckinFamilyDto;
+      });
+    } else {
+      // Handle single-family format: { family: { idKey, name }, members: [...] }
+      const family = response.family as { idKey?: string; name?: string } | undefined;
+      const members = response.members as CheckinFamilyMemberDto[] | undefined;
+      if (family && family.idKey) {
+        results = [{
+          idKey: family.idKey,
+          name: family.name ?? '',
+          members: Array.isArray(members)
+            ? members.map(mapMemberToPersonDto)
+            : [],
+        }];
+      } else {
+        results = [];
       }
-      // Already in frontend DTO shape (from mocked responses)
-      return item as unknown as CheckinFamilyDto;
-    });
-  }
+    }
 
-  // Handle single-family format: { family: { idKey, name }, members: [...] }
-  const family = response.family as { idKey?: string; name?: string } | undefined;
-  const members = response.members as CheckinFamilyMemberDto[] | undefined;
-  if (family && family.idKey) {
-    return [{
-      idKey: family.idKey,
-      name: family.name ?? '',
-      members: Array.isArray(members)
-        ? members.map(mapMemberToPersonDto)
-        : [],
-    }];
-  }
+    // Cache results for offline use
+    if (results.length > 0) {
+      offlineFamilyCache.cacheResults(request.searchValue, results).catch(() => {
+        // Silently ignore cache write failures
+      });
+    }
 
-  // Fallback: return empty array
-  return [];
+    return results;
+  } catch (error) {
+    // When offline, fall back to cached results
+    if (!navigator.onLine) {
+      const cached = await offlineFamilyCache.getCachedResults(request.searchValue);
+      if (cached) return cached;
+    }
+    throw error;
+  }
 }
 
 /**

--- a/src/web/src/services/offline/OfflineCheckinQueue.ts
+++ b/src/web/src/services/offline/OfflineCheckinQueue.ts
@@ -8,8 +8,8 @@ import type { CheckinRequestItem, BatchCheckinResultDto } from '@/services/api/t
 import { recordAttendance } from '@/services/api/checkin';
 import { ApiClientError } from '@/services/api/client';
 
-const DB_NAME = 'koinon-checkin-offline';
-const STORE_NAME = 'queue';
+const DB_NAME = 'checkin-queue';
+const STORE_NAME = 'pending';
 const DB_VERSION = 1;
 
 export type QueueStatus = 'pending' | 'syncing' | 'failed' | 'success';

--- a/src/web/src/services/offline/OfflineFamilyCache.ts
+++ b/src/web/src/services/offline/OfflineFamilyCache.ts
@@ -1,0 +1,82 @@
+/**
+ * Offline Family Cache Service
+ * Caches family search results in IndexedDB for offline use
+ */
+
+import { openDB, type IDBPDatabase } from 'idb';
+import type { CheckinFamilyDto } from '@/services/api/types';
+
+const DB_NAME = 'checkin-cache';
+const STORE_NAME = 'families';
+const DB_VERSION = 1;
+
+interface CachedFamily {
+  /** Phone number or search query used to find this family */
+  query: string;
+  families: CheckinFamilyDto[];
+  timestamp: number;
+}
+
+class OfflineFamilyCache {
+  private db: IDBPDatabase | null = null;
+
+  private async getDB(): Promise<IDBPDatabase> {
+    if (this.db) {
+      return this.db;
+    }
+
+    this.db = await openDB(DB_NAME, DB_VERSION, {
+      upgrade(db) {
+        if (!db.objectStoreNames.contains(STORE_NAME)) {
+          db.createObjectStore(STORE_NAME, { keyPath: 'query' });
+        }
+      },
+    });
+
+    return this.db;
+  }
+
+  /**
+   * Cache family search results for a query
+   */
+  async cacheResults(query: string, families: CheckinFamilyDto[]): Promise<void> {
+    const db = await this.getDB();
+    const entry: CachedFamily = {
+      query,
+      families,
+      timestamp: Date.now(),
+    };
+    await db.put(STORE_NAME, entry);
+  }
+
+  /**
+   * Get cached family results for a query
+   * Returns null if not found
+   */
+  async getCachedResults(query: string): Promise<CheckinFamilyDto[] | null> {
+    const db = await this.getDB();
+    const entry = await db.get(STORE_NAME, query);
+    if (!entry) return null;
+    return (entry as CachedFamily).families;
+  }
+
+  /**
+   * Clear all cached data
+   */
+  async clearCache(): Promise<void> {
+    const db = await this.getDB();
+    await db.clear(STORE_NAME);
+  }
+
+  /**
+   * Get cache timestamp for staleness checks
+   */
+  async getCacheTimestamp(query: string): Promise<number | null> {
+    const db = await this.getDB();
+    const entry = await db.get(STORE_NAME, query);
+    if (!entry) return null;
+    return (entry as CachedFamily).timestamp;
+  }
+}
+
+export const offlineFamilyCache = new OfflineFamilyCache();


### PR DESCRIPTION
## Summary
- Create `OfflineFamilyCache` service — caches family search results in IndexedDB (`checkin-cache`/`families`) for offline use
- `searchFamiliesForCheckin()` now caches results after online search and falls back to cache when offline
- Rename `OfflineCheckinQueue` DB from `koinon-checkin-offline` to `checkin-queue`, store from `queue` to `pending` (aligning with E2E test expectations)

Partially fixes #639 (3 of 11 offline tests now pass; remaining 8 have distinct root causes filed in issue comments)

## Test plan
- [x] 3 offline tests now pass (lines 24, 51, 247)
- [x] Full checkin regression: 50 passed, 4 pre-existing failures, 0 new regressions
- [x] Pre-push hooks: all backend tests + frontend typecheck + lint pass
- [x] Independent agent verification confirmed results

🤖 Generated with [Claude Code](https://claude.com/claude-code)