### PR TITLE
fix(perf): kiosk INP + search regressions (#649, #650)

### DIFF
--- a/src/web/src/components/checkin/FamilyMemberList.tsx
+++ b/src/web/src/components/checkin/FamilyMemberList.tsx
@@ -1,3 +1,4 @@
+import { memo, useCallback } from 'react';
 import { Card } from '@/components/ui/Card';
 import type {
   CheckinPersonDto,
@@ -35,7 +36,7 @@ export interface FamilyMemberListProps {
 /**
  * Display family members with checkboxes to check in
  */
-export function FamilyMemberList({
+function FamilyMemberListImpl({
   opportunities,
   selectedCheckins,
   onToggleCheckin,
@@ -45,42 +46,59 @@ export function FamilyMemberList({
       {opportunities.map((opp) => (
         <PersonCard
           key={opp.person.idKey}
+          personIdKey={opp.person.idKey}
           person={opp.person}
           availableOptions={opp.availableOptions}
           currentAttendance={opp.currentAttendance}
           selectedOptions={selectedCheckins.get(opp.person.idKey) || []}
-          onSelect={(groupId, locationId, scheduleId, groupName, locationName, scheduleName, startTime) =>
-            onToggleCheckin(opp.person.idKey, groupId, locationId, scheduleId, groupName, locationName, scheduleName, startTime)
-          }
+          onToggleCheckin={onToggleCheckin}
         />
       ))}
     </div>
   );
 }
 
+export const FamilyMemberList = memo(FamilyMemberListImpl);
+
 interface PersonCardProps {
+  personIdKey: string;
   person: CheckinPersonDto;
   availableOptions: CheckinOptionDto[];
   currentAttendance: CurrentAttendanceDto[];
   selectedOptions: OpportunitySelection[];
-  onSelect: (
-    groupId: string,
-    locationId: string,
-    scheduleId: string,
-    groupName: string,
-    locationName: string,
-    scheduleName: string,
-    startTime: string
-  ) => void;
+  onToggleCheckin: FamilyMemberListProps['onToggleCheckin'];
 }
 
-function PersonCard({
+const PersonCard = memo(function PersonCard({
+  personIdKey,
   person,
   availableOptions,
   currentAttendance,
   selectedOptions,
-  onSelect,
+  onToggleCheckin,
 }: PersonCardProps) {
+  const onSelect = useCallback(
+    (
+      groupId: string,
+      locationId: string,
+      scheduleId: string,
+      groupName: string,
+      locationName: string,
+      scheduleName: string,
+      startTime: string
+    ) =>
+      onToggleCheckin(
+        personIdKey,
+        groupId,
+        locationId,
+        scheduleId,
+        groupName,
+        locationName,
+        scheduleName,
+        startTime
+      ),
+    [onToggleCheckin, personIdKey]
+  );
   // If already checked in, show current attendance
   if (currentAttendance.length > 0) {
     return (
@@ -266,4 +284,4 @@ function PersonCard({
       </div>
     </Card>
   );
-}
+});

--- a/src/web/src/main.tsx
+++ b/src/web/src/main.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AuthProvider } from './contexts/AuthContext';
 import App from './App.tsx';
 import './index.css';
@@ -22,6 +21,15 @@ const queryClient = new QueryClient({
   },
 });
 
+const DevtoolsPortal =
+  import.meta.env.DEV && !import.meta.env.VITE_E2E
+    ? React.lazy(() =>
+        import('@tanstack/react-query-devtools').then((m) => ({
+          default: m.ReactQueryDevtools,
+        })),
+      )
+    : null;
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
@@ -30,7 +38,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
           <App />
         </AuthProvider>
       </BrowserRouter>
-      <ReactQueryDevtools initialIsOpen={false} />
+      {DevtoolsPortal ? (
+        <React.Suspense fallback={null}>
+          <DevtoolsPortal initialIsOpen={false} />
+        </React.Suspense>
+      ) : null}
     </QueryClientProvider>
   </React.StrictMode>
 );

--- a/src/web/src/pages/CheckinPage.tsx
+++ b/src/web/src/pages/CheckinPage.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
-import { flushSync } from 'react-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   KioskLayout,
@@ -185,7 +184,7 @@ export function CheckinPage() {
     setStep('select-members');
   };
 
-  const handleToggleCheckin = (
+  const handleToggleCheckin = useCallback((
     personId: string,
     groupId: string,
     locationId: string,
@@ -195,48 +194,46 @@ export function CheckinPage() {
     scheduleName: string,
     startTime: string
   ) => {
-    const newSelected = new Map(selectedCheckins);
-    const existingSelections = newSelected.get(personId) || [];
+    setSelectedCheckins((prev) => {
+      const newSelected = new Map(prev);
+      const existingSelections = newSelected.get(personId) || [];
+      const selectionKey = createSelectionKey(groupId, locationId, scheduleId);
+      const selectionIndex = existingSelections.findIndex(
+        (sel) => createSelectionKey(sel.groupId, sel.locationId, sel.scheduleId) === selectionKey
+      );
 
-    // Check if this opportunity is already selected using consistent key
-    const selectionKey = createSelectionKey(groupId, locationId, scheduleId);
-    const selectionIndex = existingSelections.findIndex(
-      (sel) => createSelectionKey(sel.groupId, sel.locationId, sel.scheduleId) === selectionKey
-    );
-
-    if (selectionIndex >= 0) {
-      // Deselect - remove this opportunity
-      const updatedSelections = existingSelections.filter((_, idx) => idx !== selectionIndex);
-      if (updatedSelections.length === 0) {
-        newSelected.delete(personId);
+      if (selectionIndex >= 0) {
+        const updatedSelections = existingSelections.filter((_, idx) => idx !== selectionIndex);
+        if (updatedSelections.length === 0) {
+          newSelected.delete(personId);
+        } else {
+          newSelected.set(personId, updatedSelections);
+        }
       } else {
-        newSelected.set(personId, updatedSelections);
+        const newSelection: OpportunitySelection = {
+          groupId,
+          locationId,
+          scheduleId,
+          groupName,
+          locationName,
+          scheduleName,
+          startTime,
+        };
+        newSelected.set(personId, [...existingSelections, newSelection]);
       }
-    } else {
-      // Select - add this opportunity
-      const newSelection: OpportunitySelection = {
-        groupId,
-        locationId,
-        scheduleId,
-        groupName,
-        locationName,
-        scheduleName,
-        startTime,
-      };
-      newSelected.set(personId, [...existingSelections, newSelection]);
-    }
 
-    setSelectedCheckins(newSelected);
-  };
+      return newSelected;
+    });
+  }, []);
 
   const handleCheckIn = async () => {
-    // Force synchronous render so button disables immediately (INP < 200ms)
-    flushSync(() => {
-      setIsCheckingIn(true);
-      setCheckinError(null);
-      setPrintError(null);
-      setPrintStatus('idle');
-    });
+    // React 18 batches these within a discrete click event and flushes the
+    // commit before the browser's next paint, so the button disables under
+    // the INP budget without the flushSync-forced full-tree re-render.
+    setIsCheckingIn(true);
+    setCheckinError(null);
+    setPrintError(null);
+    setPrintStatus('idle');
 
     // Flatten all selections into a single array of check-in items
     const checkins: CheckinRequestItem[] = [];


### PR DESCRIPTION
## Summary

- Gate `ReactQueryDevtools` behind `DEV && !VITE_E2E` and lazy-load it. Profile traces showed a 711ms blocking `resolve-promise` LoAF from the devtools chunk polluting the E2E bundle.
- Drop `flushSync` in `CheckinPage.handleCheckIn` — React 18 already flushes discrete click-event state updates before paint; the `flushSync` wrapper was forcing the entire unmemoized subtree to render synchronously on the click path, blowing the 200ms INP budget.
- Memoize `FamilyMemberList` + `PersonCard` with `React.memo`; convert the inline `onSelect` arrow to a stable `useCallback` that binds `personIdKey` internally. Stabilize `handleToggleCheckin` with `useCallback` + functional setState so the memo actually holds.

Addresses the root causes documented in the issue threads. Backend is not touched (SQL is <1ms per EXPLAIN; `ConstantTimeHelper` busy-work is dormant on the happy path).

Closes #649
Closes #650

## Test plan

- [ ] `npx playwright test e2e/tests/admin/checkin/checkin-performance.spec.ts --reporter=list`
- [ ] `npx playwright test -g "INP" --project=chromium`
- [ ] `npx playwright test -g "full check-in flow" --project=chromium`
- [ ] Manual smoke: kiosk search → select member → confirm → verify no visual regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)