### PR TITLE
fix(giving): unblock batch/contribution/statement flow (precursor to #493)

### DIFF
--- a/src/Koinon.Api/Controllers/DefinedTypesController.cs
+++ b/src/Koinon.Api/Controllers/DefinedTypesController.cs
@@ -70,6 +70,42 @@ public class DefinedTypesController(
     }
 
     /// <summary>
+    /// Gets the DefinedValues for a DefinedType. Accepts either IdKey or GUID as the
+    /// identifier so the frontend can look up values using the stable GUID from seed data.
+    /// </summary>
+    /// <param name="idKeyOrGuid">The DefinedType's IdKey or GUID</param>
+    /// <param name="ct">Cancellation token</param>
+    /// <returns>Array of DefinedValues ordered by Order</returns>
+    /// <response code="200">Returns list of values</response>
+    /// <response code="404">DefinedType not found</response>
+    [HttpGet("{idKeyOrGuid}/values")]
+    [ProducesResponseType(typeof(IReadOnlyList<DefinedValueDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> GetValues(string idKeyOrGuid, CancellationToken ct = default)
+    {
+        var result = await definedTypeService.GetValuesByTypeAsync(idKeyOrGuid, ct);
+
+        if (result.IsFailure)
+        {
+            logger.LogDebug("DefinedType not found for values lookup: {IdKeyOrGuid}", idKeyOrGuid);
+
+            return NotFound(new ProblemDetails
+            {
+                Title = "DefinedType not found",
+                Detail = result.Error!.Message,
+                Status = StatusCodes.Status404NotFound,
+                Instance = HttpContext.Request.Path
+            });
+        }
+
+        logger.LogDebug(
+            "DefinedType values retrieved: IdKeyOrGuid={IdKeyOrGuid}, Count={Count}",
+            idKeyOrGuid, result.Value!.Count);
+
+        return Ok(new { data = result.Value });
+    }
+
+    /// <summary>
     /// Creates a new DefinedValue within the specified DefinedType.
     /// </summary>
     /// <param name="typeIdKey">The DefinedType's IdKey</param>

--- a/src/Koinon.Api/Controllers/GivingController.cs
+++ b/src/Koinon.Api/Controllers/GivingController.cs
@@ -200,8 +200,10 @@ public class GivingController(
 
         logger.LogInformation("Created batch: {IdKey}", result.Value!.IdKey);
 
+        // ASP.NET strips the "Async" suffix from action names by default, so use the
+        // stripped name literal instead of nameof() — otherwise URL generation fails.
         return CreatedAtAction(
-            nameof(GetBatchAsync),
+            "GetBatch",
             new { idKey = result.Value.IdKey },
             result.Value);
     }
@@ -376,7 +378,7 @@ public class GivingController(
         logger.LogInformation("Added contribution {IdKey} to batch {BatchIdKey}", result.Value!.IdKey, batchIdKey);
 
         return CreatedAtAction(
-            nameof(GetContributionAsync),
+            "GetContribution",
             new { idKey = result.Value.IdKey },
             result.Value);
     }
@@ -575,7 +577,10 @@ public class GivingController(
     /// <returns>The contribution statement if found</returns>
     /// <response code="200">Returns the contribution statement</response>
     /// <response code="404">Statement not found</response>
+    // Preserve the "GetStatementAsync" action name (instead of ASP.NET's default strip)
+    // so that CreatedAtAction(nameof(GetStatementAsync), ...) resolves correctly.
     [HttpGet("statements/{idKey}")]
+    [ActionName(nameof(GetStatementAsync))]
     [ValidateIdKey]
     [RequiresClaim("financial", "view")]
     [ProducesResponseType(typeof(ContributionStatementDto), StatusCodes.Status200OK)]

--- a/src/Koinon.Application/Helpers/DateTimeNormalization.cs
+++ b/src/Koinon.Application/Helpers/DateTimeNormalization.cs
@@ -1,0 +1,38 @@
+namespace Koinon.Application.Helpers;
+
+/// <summary>
+/// Helpers for coercing DateTime values to a Kind that PostgreSQL's
+/// <c>timestamp with time zone</c> (timestamptz) columns will accept.
+/// </summary>
+/// <remarks>
+/// Npgsql refuses to write a <see cref="DateTime"/> whose
+/// <see cref="DateTime.Kind"/> is <see cref="DateTimeKind.Unspecified"/> to a
+/// timestamptz column, which is how System.Text.Json-bound DateTimes arrive
+/// from the frontend. These helpers normalize such values.
+/// </remarks>
+public static class DateTimeNormalization
+{
+    /// <summary>
+    /// Normalizes a <see cref="DateTime"/> to <see cref="DateTimeKind.Utc"/>
+    /// so it can be persisted to (or compared against) a PostgreSQL
+    /// timestamptz column.
+    /// </summary>
+    /// <remarks>
+    /// Treats <see cref="DateTimeKind.Unspecified"/> as already UTC. The
+    /// frontend contract for this application is ISO-8601 with a <c>Z</c>
+    /// suffix (or date-only strings) — both of those deserialize to a
+    /// DateTime whose wall-clock is UTC but whose Kind is Unspecified,
+    /// so re-stamping the Kind without converting is correct here. If a
+    /// future caller sends genuinely local-time values, it should convert
+    /// before handing the value in.
+    /// </remarks>
+    public static DateTime NormalizeToUtc(DateTime value)
+    {
+        return value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
+    }
+}

--- a/src/Koinon.Application/Interfaces/IDefinedTypeService.cs
+++ b/src/Koinon.Application/Interfaces/IDefinedTypeService.cs
@@ -23,6 +23,12 @@ public interface IDefinedTypeService
     Task<Result<DefinedTypeDto>> GetTypeByIdKeyAsync(string idKey, CancellationToken ct = default);
 
     /// <summary>
+    /// Returns the DefinedValues for a DefinedType, identified by either IdKey or GUID.
+    /// Values are ordered by Order. Used by the frontend to populate dropdowns.
+    /// </summary>
+    Task<Result<IReadOnlyList<DefinedValueDto>>> GetValuesByTypeAsync(string idKeyOrGuid, CancellationToken ct = default);
+
+    /// <summary>
     /// Creates a new DefinedValue within the specified DefinedType.
     /// Order defaults to max(existing)+1.
     /// </summary>

--- a/src/Koinon.Application/Services/BatchDonationEntryService.cs
+++ b/src/Koinon.Application/Services/BatchDonationEntryService.cs
@@ -715,12 +715,14 @@ public class BatchDonationEntryService(
         // Apply date filters
         if (filter.StartDate.HasValue)
         {
-            query = query.Where(b => b.BatchDate >= filter.StartDate.Value);
+            var startDateUtc = DateTimeNormalization.NormalizeToUtc(filter.StartDate.Value);
+            query = query.Where(b => b.BatchDate >= startDateUtc);
         }
 
         if (filter.EndDate.HasValue)
         {
-            query = query.Where(b => b.BatchDate <= filter.EndDate.Value);
+            var endDateUtc = DateTimeNormalization.NormalizeToUtc(filter.EndDate.Value);
+            query = query.Where(b => b.BatchDate <= endDateUtc);
         }
 
         // Get total count

--- a/src/Koinon.Application/Services/BatchDonationEntryService.cs
+++ b/src/Koinon.Application/Services/BatchDonationEntryService.cs
@@ -3,6 +3,7 @@ using FluentValidation;
 using Koinon.Application.Common;
 using Koinon.Application.DTOs.Giving;
 using Koinon.Application.DTOs.Requests;
+using Koinon.Application.Helpers;
 using Koinon.Application.Interfaces;
 using Koinon.Domain.Data;
 using Koinon.Domain.Entities;
@@ -66,7 +67,7 @@ public class BatchDonationEntryService(
         var batch = new ContributionBatch
         {
             Name = request.Name,
-            BatchDate = NormalizeToUtc(request.BatchDate),
+            BatchDate = DateTimeNormalization.NormalizeToUtc(request.BatchDate),
             Status = BatchStatus.Open,
             ControlAmount = request.ControlAmount,
             ControlItemCount = request.ControlItemCount,
@@ -364,7 +365,7 @@ public class BatchDonationEntryService(
         {
             PersonAliasId = personAliasId,
             BatchId = batchId,
-            TransactionDateTime = NormalizeToUtc(request.TransactionDateTime),
+            TransactionDateTime = DateTimeNormalization.NormalizeToUtc(request.TransactionDateTime),
             TransactionCode = request.TransactionCode,
             TransactionTypeValueId = transactionTypeValueId,
             SourceTypeValueId = sourceTypeValue.Id,
@@ -530,7 +531,7 @@ public class BatchDonationEntryService(
 
         // Update contribution
         contribution.PersonAliasId = personAliasId;
-        contribution.TransactionDateTime = NormalizeToUtc(request.TransactionDateTime);
+        contribution.TransactionDateTime = DateTimeNormalization.NormalizeToUtc(request.TransactionDateTime);
         contribution.TransactionCode = request.TransactionCode;
         contribution.TransactionTypeValueId = transactionTypeValueId;
         contribution.Summary = request.Summary;
@@ -888,21 +889,5 @@ public class BatchDonationEntryService(
         };
 
         await context.FinancialAuditLogs.AddAsync(auditLog, ct);
-    }
-
-    /// <summary>
-    /// Normalizes a DateTime to UTC Kind for persistence to PostgreSQL timestamptz columns.
-    /// Incoming JSON-bound DateTimes have Kind=Unspecified, which Npgsql refuses to write.
-    /// Assumes Unspecified values are already expressed in UTC (the frontend sends date-only
-    /// strings and UTC-ISO timestamps).
-    /// </summary>
-    private static DateTime NormalizeToUtc(DateTime value)
-    {
-        return value.Kind switch
-        {
-            DateTimeKind.Utc => value,
-            DateTimeKind.Local => value.ToUniversalTime(),
-            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
-        };
     }
 }

--- a/src/Koinon.Application/Services/BatchDonationEntryService.cs
+++ b/src/Koinon.Application/Services/BatchDonationEntryService.cs
@@ -61,10 +61,12 @@ public class BatchDonationEntryService(
         EnsureAuthenticated();
 
         // Create batch
+        // Normalize BatchDate to UTC — JSON-bound DateTimes from the frontend arrive
+        // as Kind=Unspecified, which PostgreSQL refuses to persist into a timestamptz column.
         var batch = new ContributionBatch
         {
             Name = request.Name,
-            BatchDate = request.BatchDate,
+            BatchDate = NormalizeToUtc(request.BatchDate),
             Status = BatchStatus.Open,
             ControlAmount = request.ControlAmount,
             ControlItemCount = request.ControlItemCount,
@@ -362,7 +364,7 @@ public class BatchDonationEntryService(
         {
             PersonAliasId = personAliasId,
             BatchId = batchId,
-            TransactionDateTime = request.TransactionDateTime,
+            TransactionDateTime = NormalizeToUtc(request.TransactionDateTime),
             TransactionCode = request.TransactionCode,
             TransactionTypeValueId = transactionTypeValueId,
             SourceTypeValueId = sourceTypeValue.Id,
@@ -528,7 +530,7 @@ public class BatchDonationEntryService(
 
         // Update contribution
         contribution.PersonAliasId = personAliasId;
-        contribution.TransactionDateTime = request.TransactionDateTime;
+        contribution.TransactionDateTime = NormalizeToUtc(request.TransactionDateTime);
         contribution.TransactionCode = request.TransactionCode;
         contribution.TransactionTypeValueId = transactionTypeValueId;
         contribution.Summary = request.Summary;
@@ -886,5 +888,21 @@ public class BatchDonationEntryService(
         };
 
         await context.FinancialAuditLogs.AddAsync(auditLog, ct);
+    }
+
+    /// <summary>
+    /// Normalizes a DateTime to UTC Kind for persistence to PostgreSQL timestamptz columns.
+    /// Incoming JSON-bound DateTimes have Kind=Unspecified, which Npgsql refuses to write.
+    /// Assumes Unspecified values are already expressed in UTC (the frontend sends date-only
+    /// strings and UTC-ISO timestamps).
+    /// </summary>
+    private static DateTime NormalizeToUtc(DateTime value)
+    {
+        return value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc)
+        };
     }
 }

--- a/src/Koinon.Application/Services/ContributionStatementService.cs
+++ b/src/Koinon.Application/Services/ContributionStatementService.cs
@@ -1,5 +1,6 @@
 using Koinon.Application.Common;
 using Koinon.Application.DTOs.Giving;
+using Koinon.Application.Helpers;
 using Koinon.Application.Interfaces;
 using Koinon.Domain.Data;
 using Koinon.Domain.Entities;
@@ -109,8 +110,14 @@ public class ContributionStatementService(
                 Error.NotFound("Person", request.PersonIdKey));
         }
 
+        // Normalize request dates to UTC Kind so they can be compared against
+        // PostgreSQL timestamptz columns without Npgsql throwing
+        // "Cannot write DateTime with Kind=Unspecified".
+        var startDate = DateTimeNormalization.NormalizeToUtc(request.StartDate);
+        var endDate = DateTimeNormalization.NormalizeToUtc(request.EndDate);
+
         // Validate date range
-        if (request.StartDate > request.EndDate)
+        if (startDate > endDate)
         {
             return Result<StatementPreviewDto>.Failure(
                 Error.Validation("StartDate must be before or equal to EndDate"));
@@ -140,7 +147,7 @@ public class ContributionStatementService(
         var churchAddress = FormatAddress(churchStreet1, churchStreet2, churchCity, churchState, churchPostalCode);
 
         // Get contributions for the period
-        var contributions = await GetContributionsForPeriodAsync(personId, request.StartDate, request.EndDate, ct);
+        var contributions = await GetContributionsForPeriodAsync(personId, startDate, endDate, ct);
 
         var totalAmount = contributions.Sum(c => c.Amount);
 
@@ -149,8 +156,8 @@ public class ContributionStatementService(
             PersonIdKey = person.IdKey,
             PersonName = person.FullName ?? "Unknown",
             PersonAddress = personAddress,
-            StartDate = request.StartDate,
-            EndDate = request.EndDate,
+            StartDate = startDate,
+            EndDate = endDate,
             TotalAmount = totalAmount,
             Contributions = contributions,
             ChurchName = churchName,
@@ -180,12 +187,18 @@ public class ContributionStatementService(
                 Error.NotFound("Person", request.PersonIdKey));
         }
 
+        // Normalize dates to UTC Kind so they can be persisted to the
+        // timestamptz start_date / end_date columns. See the preview path
+        // for the rationale.
+        var startDate = DateTimeNormalization.NormalizeToUtc(request.StartDate);
+        var endDate = DateTimeNormalization.NormalizeToUtc(request.EndDate);
+
         // Create statement entity
         var statement = new ContributionStatement
         {
             PersonId = personId,
-            StartDate = request.StartDate,
-            EndDate = request.EndDate,
+            StartDate = startDate,
+            EndDate = endDate,
             TotalAmount = preview.TotalAmount,
             ContributionCount = preview.Contributions.Count,
             GeneratedDateTime = DateTime.UtcNow
@@ -199,8 +212,8 @@ public class ContributionStatementService(
             statement.IdKey,
             request.PersonIdKey,
             preview.PersonName,
-            request.StartDate,
-            request.EndDate,
+            startDate,
+            endDate,
             preview.TotalAmount);
 
         var dto = new ContributionStatementDto
@@ -273,7 +286,13 @@ public class ContributionStatementService(
         BatchStatementRequest request,
         CancellationToken ct = default)
     {
-        if (request.StartDate > request.EndDate)
+        // Normalize request dates to UTC Kind; otherwise Npgsql throws when
+        // the parameters are bound against the timestamptz
+        // Contribution.TransactionDateTime column.
+        var startDate = DateTimeNormalization.NormalizeToUtc(request.StartDate);
+        var endDate = DateTimeNormalization.NormalizeToUtc(request.EndDate);
+
+        if (startDate > endDate)
         {
             return Result<List<EligiblePersonDto>>.Failure(
                 Error.Validation("StartDate must be before or equal to EndDate"));
@@ -283,7 +302,7 @@ public class ContributionStatementService(
         var eligiblePeople = await (from c in context.Contributions
                 .AsNoTracking()
                 .Where(c => c.PersonAliasId != null)
-                .Where(c => c.TransactionDateTime >= request.StartDate && c.TransactionDateTime <= request.EndDate)
+                .Where(c => c.TransactionDateTime >= startDate && c.TransactionDateTime <= endDate)
                                     from pa in context.PersonAliases.Where(pa => pa.Id == c.PersonAliasId)
                                     from p in context.People.Where(p => p.Id == pa.PersonId)
                                     from cd in context.ContributionDetails.Where(cd => cd.ContributionId == c.Id)

--- a/src/Koinon.Application/Services/DefinedTypeService.cs
+++ b/src/Koinon.Application/Services/DefinedTypeService.cs
@@ -61,6 +61,45 @@ public class DefinedTypeService(
         return Result<DefinedTypeDto>.Success(mapper.Map<DefinedTypeDto>(entity));
     }
 
+    public async Task<Result<IReadOnlyList<DefinedValueDto>>> GetValuesByTypeAsync(
+        string idKeyOrGuid,
+        CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(idKeyOrGuid))
+        {
+            return Result<IReadOnlyList<DefinedValueDto>>.Failure(Error.NotFound("DefinedType", idKeyOrGuid));
+        }
+
+        // Accept either IdKey (Hashids-encoded int) or a raw GUID.
+        // The frontend populates transaction-type dropdowns with the GUID from seed data.
+        var query = context.DefinedTypes.AsNoTracking();
+
+        if (Guid.TryParse(idKeyOrGuid, out var guid))
+        {
+            query = query.Where(t => t.Guid == guid);
+        }
+        else if (IdKeyHelper.TryDecode(idKeyOrGuid, out var id))
+        {
+            query = query.Where(t => t.Id == id);
+        }
+        else
+        {
+            return Result<IReadOnlyList<DefinedValueDto>>.Failure(Error.NotFound("DefinedType", idKeyOrGuid));
+        }
+
+        var entity = await query
+            .Include(t => t.DefinedValues.OrderBy(v => v.Order))
+            .FirstOrDefaultAsync(ct);
+
+        if (entity == null)
+        {
+            return Result<IReadOnlyList<DefinedValueDto>>.Failure(Error.NotFound("DefinedType", idKeyOrGuid));
+        }
+
+        var values = mapper.Map<IReadOnlyList<DefinedValueDto>>(entity.DefinedValues);
+        return Result<IReadOnlyList<DefinedValueDto>>.Success(values);
+    }
+
     public async Task<Result<DefinedValueManagementDto>> CreateValueAsync(
         string typeIdKey,
         CreateDefinedValueRequest request,

--- a/tests/Koinon.Application.Tests/Services/DefinedTypeServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/DefinedTypeServiceTests.cs
@@ -164,6 +164,59 @@ public class DefinedTypeServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task GetValuesByTypeAsync_WithValidIdKey_ReturnsValuesInOrder()
+    {
+        // Arrange
+        var type = await _context.DefinedTypes.FindAsync(1);
+        var idKey = type!.IdKey;
+
+        // Act
+        var result = await _service.GetValuesByTypeAsync(idKey);
+
+        // Assert — frontend-facing endpoint used to populate dropdowns; must succeed by IdKey.
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+        result.Value![0].Value.Should().Be("Active");
+        result.Value[1].Value.Should().Be("Inactive");
+    }
+
+    [Fact]
+    public async Task GetValuesByTypeAsync_WithValidGuid_ReturnsValues()
+    {
+        // Arrange — frontend calls this with a stable GUID from seed data, not the Hashid IdKey.
+        var type = await _context.DefinedTypes.FindAsync(1);
+
+        // Act
+        var result = await _service.GetValuesByTypeAsync(type!.Guid.ToString());
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task GetValuesByTypeAsync_WithUnknownGuid_ReturnsNotFound()
+    {
+        // Act
+        var result = await _service.GetValuesByTypeAsync(Guid.NewGuid().ToString());
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task GetValuesByTypeAsync_WithEmptyInput_ReturnsNotFound()
+    {
+        // Act
+        var result = await _service.GetValuesByTypeAsync(string.Empty);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("NOT_FOUND");
+    }
+
+    [Fact]
     public async Task CreateValueAsync_WithValidRequest_CreatesValueWithAutoOrder()
     {
         // Arrange

--- a/tests/Koinon.Application.Tests/Services/DefinedTypeServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/DefinedTypeServiceTests.cs
@@ -67,23 +67,25 @@ public class DefinedTypeServiceTests : IDisposable
             IsSystem = true,
             Order = 1,
             CreatedDateTime = DateTime.UtcNow,
+            // Seed Inactive (Order=2) BEFORE Active (Order=1) so insertion order ≠ expected order.
+            // Ordering tests must fail if the service drops OrderBy(v => v.Order).
             DefinedValues =
             [
-                new DefinedValue
-                {
-                    Id = 10,
-                    DefinedTypeId = 1,
-                    Value = "Active",
-                    Order = 1,
-                    IsActive = true,
-                    CreatedDateTime = DateTime.UtcNow
-                },
                 new DefinedValue
                 {
                     Id = 11,
                     DefinedTypeId = 1,
                     Value = "Inactive",
                     Order = 2,
+                    IsActive = true,
+                    CreatedDateTime = DateTime.UtcNow
+                },
+                new DefinedValue
+                {
+                    Id = 10,
+                    DefinedTypeId = 1,
+                    Value = "Active",
+                    Order = 1,
                     IsActive = true,
                     CreatedDateTime = DateTime.UtcNow
                 }

--- a/tools/Koinon.TestDataSeeder/DataSeeder.cs
+++ b/tools/Koinon.TestDataSeeder/DataSeeder.cs
@@ -40,6 +40,13 @@ public class DataSeeder
     private static readonly Guid _childRoleGuid = new("40404040-4040-4040-4040-404040404040");
     private static readonly Guid _memberRoleGuid = new("50505050-5050-5050-5050-505050505050");
     private static readonly Guid _adminSecurityRoleGuid = new("70707070-7070-7070-7070-707070707070");
+    private static readonly Guid _financialViewClaimGuid = new("a1b2c3d4-e5f6-4a1b-8c9d-111111111111");
+    private static readonly Guid _financialEditClaimGuid = new("a1b2c3d4-e5f6-4a1b-8c9d-222222222222");
+    private static readonly Guid _financialBatchCloseClaimGuid = new("a1b2c3d4-e5f6-4a1b-8c9d-333333333333");
+    private static readonly Guid _adminFinancialViewRscGuid = new("80808080-8080-4080-8080-111111111111");
+    private static readonly Guid _adminFinancialEditRscGuid = new("80808080-8080-4080-8080-222222222222");
+    private static readonly Guid _adminFinancialBatchCloseRscGuid = new("80808080-8080-4080-8080-333333333333");
+    private static readonly Guid _generalFundGuid = new("90909090-9090-4090-8090-111111111111");
 
     public DataSeeder(KoinonDbContext context, ILogger<DataSeeder> logger, IAuthService authService)
     {
@@ -114,6 +121,10 @@ public class DataSeeder
         // Seed security roles and assign Admin to John Smith
         _logger.LogInformation("Seeding security roles...");
         await SeedSecurityRolesAsync(people, now, cancellationToken);
+
+        // Seed funds (needed for contribution entry in giving flow)
+        _logger.LogInformation("Seeding funds...");
+        await SeedFundsAsync(now, cancellationToken);
 
         _logger.LogInformation("✅ Successfully seeded all test data");
     }
@@ -480,6 +491,111 @@ public class DataSeeder
         };
 
         _context.PersonSecurityRoles.Add(adminAssignment);
+        await _context.SaveChangesAsync(cancellationToken);
+
+        // Ensure financial claims exist (may be truncated by ResetDatabaseAsync) and grant
+        // them to the Admin role so the admin user can hit every /api/v1/giving/* endpoint.
+        // Using fixed GUIDs so the data round-trips across reset+seed deterministically.
+        await EnsureFinancialClaimsForAdminAsync(adminRole, now, cancellationToken);
+    }
+
+    /// <summary>
+    /// Ensures the three financial SecurityClaims exist and are linked (ALLOW) to the Admin role.
+    /// On fresh seed, Admin should be able to hit all /api/v1/giving/* endpoints.
+    /// </summary>
+    private async Task EnsureFinancialClaimsForAdminAsync(
+        SecurityRole adminRole,
+        DateTime now,
+        CancellationToken cancellationToken)
+    {
+        var claimSpecs = new (Guid Guid, string Value, string Description)[]
+        {
+            (_financialViewClaimGuid, "view", "View financial data including contributions and batches"),
+            (_financialEditClaimGuid, "edit", "Create and edit contributions and batches"),
+            (_financialBatchCloseClaimGuid, "batch.close", "Close contribution batches")
+        };
+
+        var existingClaims = await _context.SecurityClaims
+            .Where(c => claimSpecs.Select(s => s.Guid).Contains(c.Guid))
+            .ToDictionaryAsync(c => c.Guid, cancellationToken);
+
+        foreach (var (guid, value, description) in claimSpecs)
+        {
+            if (!existingClaims.ContainsKey(guid))
+            {
+                var claim = new SecurityClaim
+                {
+                    Guid = guid,
+                    ClaimType = "financial",
+                    ClaimValue = value,
+                    Description = description,
+                    CreatedDateTime = now
+                };
+                _context.SecurityClaims.Add(claim);
+                existingClaims[guid] = claim;
+            }
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+
+        var rscSpecs = new (Guid Guid, Guid ClaimGuid)[]
+        {
+            (_adminFinancialViewRscGuid, _financialViewClaimGuid),
+            (_adminFinancialEditRscGuid, _financialEditClaimGuid),
+            (_adminFinancialBatchCloseRscGuid, _financialBatchCloseClaimGuid)
+        };
+
+        foreach (var (rscGuid, claimGuid) in rscSpecs)
+        {
+            var claim = existingClaims[claimGuid];
+            var alreadyLinked = await _context.RoleSecurityClaims
+                .AnyAsync(
+                    r => r.SecurityRoleId == adminRole.Id && r.SecurityClaimId == claim.Id,
+                    cancellationToken);
+            if (alreadyLinked)
+            {
+                continue;
+            }
+
+            _context.RoleSecurityClaims.Add(new RoleSecurityClaim
+            {
+                Guid = rscGuid,
+                SecurityRoleId = adminRole.Id,
+                SecurityClaimId = claim.Id,
+                AllowOrDeny = 'A',
+                CreatedDateTime = now
+            });
+        }
+
+        await _context.SaveChangesAsync(cancellationToken);
+    }
+
+    /// <summary>
+    /// Seeds a default General Fund so the Contribution entry form has at least one
+    /// selectable fund. Uses a fixed GUID for deterministic test targeting.
+    /// </summary>
+    private async Task SeedFundsAsync(DateTime now, CancellationToken cancellationToken = default)
+    {
+        var exists = await _context.Funds.AnyAsync(f => f.Guid == _generalFundGuid, cancellationToken);
+        if (exists)
+        {
+            return;
+        }
+
+        var generalFund = new Fund
+        {
+            Guid = _generalFundGuid,
+            Name = "General Fund",
+            PublicName = "General Fund",
+            Description = "Default fund for undesignated contributions and tithes.",
+            IsActive = true,
+            IsPublic = true,
+            IsTaxDeductible = true,
+            Order = 0,
+            CreatedDateTime = now
+        };
+
+        _context.Funds.Add(generalFund);
         await _context.SaveChangesAsync(cancellationToken);
     }
 

--- a/tools/Koinon.TestDataSeeder/DataSeeder.cs
+++ b/tools/Koinon.TestDataSeeder/DataSeeder.cs
@@ -40,12 +40,11 @@ public class DataSeeder
     private static readonly Guid _childRoleGuid = new("40404040-4040-4040-4040-404040404040");
     private static readonly Guid _memberRoleGuid = new("50505050-5050-5050-5050-505050505050");
     private static readonly Guid _adminSecurityRoleGuid = new("70707070-7070-7070-7070-707070707070");
-    private static readonly Guid _financialViewClaimGuid = new("a1b2c3d4-e5f6-4a1b-8c9d-111111111111");
-    private static readonly Guid _financialEditClaimGuid = new("a1b2c3d4-e5f6-4a1b-8c9d-222222222222");
-    private static readonly Guid _financialBatchCloseClaimGuid = new("a1b2c3d4-e5f6-4a1b-8c9d-333333333333");
-    private static readonly Guid _adminFinancialViewRscGuid = new("80808080-8080-4080-8080-111111111111");
-    private static readonly Guid _adminFinancialEditRscGuid = new("80808080-8080-4080-8080-222222222222");
-    private static readonly Guid _adminFinancialBatchCloseRscGuid = new("80808080-8080-4080-8080-333333333333");
+    // Production-provisioned "Financial Admin" role from the SeedFinancialClaims
+    // migration. The admin user gets assigned to this role in addition to the
+    // generic Admin role so it inherits financial:* claims the same way as in
+    // prod (role separation preserved).
+    private static readonly Guid _financialAdminSecurityRoleGuid = new("F1F1F1F1-AAAA-4444-BBBB-CCCCCCCCCCCC");
     private static readonly Guid _generalFundGuid = new("90909090-9090-4090-8090-111111111111");
 
     public DataSeeder(KoinonDbContext context, ILogger<DataSeeder> logger, IAuthService authService)
@@ -481,42 +480,88 @@ public class DataSeeder
         _context.SecurityRoles.Add(adminRole);
         await _context.SaveChangesAsync(cancellationToken);
 
-        // Assign Admin role to John Smith (first person, the E2E test admin user)
+        // The "Financial Admin" role and financial:* claims are provisioned by the
+        // SeedFinancialClaims migration, but ResetDatabaseAsync truncates that data
+        // ahead of every seed. Re-provision both here so the role row (with its
+        // canonical GUID from production) and its claim links round-trip across
+        // reset+seed deterministically. This preserves the production role
+        // separation (Admin != Financial Admin) — we just give the seeded admin
+        // user BOTH roles below so giving endpoints are reachable in tests/dev.
+        var financialAdminRole = await EnsureFinancialAdminRoleAsync(now, cancellationToken);
+
+        // Assign Admin AND Financial Admin roles to John Smith (the E2E test admin user).
+        // Matches production semantics: to exercise /api/v1/giving/* an admin must
+        // also hold the Financial Admin role.
         var johnSmith = people.First(p => p.Email == "john.smith@example.com");
-        var adminAssignment = new PersonSecurityRole
+
+        _context.PersonSecurityRoles.Add(new PersonSecurityRole
         {
             PersonId = johnSmith.Id,
             SecurityRoleId = adminRole.Id,
             CreatedDateTime = now
-        };
+        });
 
-        _context.PersonSecurityRoles.Add(adminAssignment);
+        _context.PersonSecurityRoles.Add(new PersonSecurityRole
+        {
+            PersonId = johnSmith.Id,
+            SecurityRoleId = financialAdminRole.Id,
+            CreatedDateTime = now
+        });
+
         await _context.SaveChangesAsync(cancellationToken);
-
-        // Ensure financial claims exist (may be truncated by ResetDatabaseAsync) and grant
-        // them to the Admin role so the admin user can hit every /api/v1/giving/* endpoint.
-        // Using fixed GUIDs so the data round-trips across reset+seed deterministically.
-        await EnsureFinancialClaimsForAdminAsync(adminRole, now, cancellationToken);
     }
 
     /// <summary>
-    /// Ensures the three financial SecurityClaims exist and are linked (ALLOW) to the Admin role.
-    /// On fresh seed, Admin should be able to hit all /api/v1/giving/* endpoints.
+    /// Ensures the "Financial Admin" SecurityRole and its three financial SecurityClaims
+    /// exist (re-seeding what ResetDatabaseAsync truncated from the SeedFinancialClaims
+    /// migration) and that the role is linked (ALLOW) to all three claims. The GUIDs
+    /// below intentionally match the production migration so prod and dev/test share
+    /// a single definition of the Financial Admin role.
     /// </summary>
-    private async Task EnsureFinancialClaimsForAdminAsync(
-        SecurityRole adminRole,
+    private async Task<SecurityRole> EnsureFinancialAdminRoleAsync(
         DateTime now,
         CancellationToken cancellationToken)
     {
+        // GUIDs match 20260103165412_SeedFinancialClaims.cs so data round-trips
+        // identically whether provisioned by the migration (prod) or by this
+        // seeder (tests/dev) after a reset.
+        var financialViewClaimGuid = Guid.Parse("A1B2C3D4-E5F6-4A1B-8C9D-111111111111");
+        var financialEditClaimGuid = Guid.Parse("A1B2C3D4-E5F6-4A1B-8C9D-222222222222");
+        var financialBatchCloseClaimGuid = Guid.Parse("A1B2C3D4-E5F6-4A1B-8C9D-333333333333");
+        var financialViewRscGuid = Guid.Parse("11111111-1111-4AAA-BBBB-111111111111");
+        var financialEditRscGuid = Guid.Parse("22222222-2222-4AAA-BBBB-222222222222");
+        var financialBatchCloseRscGuid = Guid.Parse("33333333-3333-4AAA-BBBB-333333333333");
+
+        // 1. Ensure the Financial Admin role exists.
+        var financialAdminRole = await _context.SecurityRoles
+            .FirstOrDefaultAsync(r => r.Guid == _financialAdminSecurityRoleGuid, cancellationToken);
+
+        if (financialAdminRole is null)
+        {
+            financialAdminRole = new SecurityRole
+            {
+                Guid = _financialAdminSecurityRoleGuid,
+                Name = "Financial Admin",
+                Description = "Administrator role for financial operations",
+                IsSystemRole = true,
+                IsActive = true,
+                CreatedDateTime = now
+            };
+            _context.SecurityRoles.Add(financialAdminRole);
+            await _context.SaveChangesAsync(cancellationToken);
+        }
+
+        // 2. Ensure the three financial claims exist.
         var claimSpecs = new (Guid Guid, string Value, string Description)[]
         {
-            (_financialViewClaimGuid, "view", "View financial data including contributions and batches"),
-            (_financialEditClaimGuid, "edit", "Create and edit contributions and batches"),
-            (_financialBatchCloseClaimGuid, "batch.close", "Close contribution batches")
+            (financialViewClaimGuid, "view", "View financial data including contributions and batches"),
+            (financialEditClaimGuid, "edit", "Create and edit contributions and batches"),
+            (financialBatchCloseClaimGuid, "batch.close", "Close contribution batches")
         };
 
+        var claimGuids = claimSpecs.Select(s => s.Guid).ToList();
         var existingClaims = await _context.SecurityClaims
-            .Where(c => claimSpecs.Select(s => s.Guid).Contains(c.Guid))
+            .Where(c => claimGuids.Contains(c.Guid))
             .ToDictionaryAsync(c => c.Guid, cancellationToken);
 
         foreach (var (guid, value, description) in claimSpecs)
@@ -535,14 +580,14 @@ public class DataSeeder
                 existingClaims[guid] = claim;
             }
         }
-
         await _context.SaveChangesAsync(cancellationToken);
 
-        var rscSpecs = new (Guid Guid, Guid ClaimGuid)[]
+        // 3. Ensure the role -> claim links exist (ALLOW).
+        var rscSpecs = new (Guid RscGuid, Guid ClaimGuid)[]
         {
-            (_adminFinancialViewRscGuid, _financialViewClaimGuid),
-            (_adminFinancialEditRscGuid, _financialEditClaimGuid),
-            (_adminFinancialBatchCloseRscGuid, _financialBatchCloseClaimGuid)
+            (financialViewRscGuid, financialViewClaimGuid),
+            (financialEditRscGuid, financialEditClaimGuid),
+            (financialBatchCloseRscGuid, financialBatchCloseClaimGuid)
         };
 
         foreach (var (rscGuid, claimGuid) in rscSpecs)
@@ -550,7 +595,7 @@ public class DataSeeder
             var claim = existingClaims[claimGuid];
             var alreadyLinked = await _context.RoleSecurityClaims
                 .AnyAsync(
-                    r => r.SecurityRoleId == adminRole.Id && r.SecurityClaimId == claim.Id,
+                    r => r.SecurityRoleId == financialAdminRole.Id && r.SecurityClaimId == claim.Id,
                     cancellationToken);
             if (alreadyLinked)
             {
@@ -560,7 +605,7 @@ public class DataSeeder
             _context.RoleSecurityClaims.Add(new RoleSecurityClaim
             {
                 Guid = rscGuid,
-                SecurityRoleId = adminRole.Id,
+                SecurityRoleId = financialAdminRole.Id,
                 SecurityClaimId = claim.Id,
                 AllowOrDeny = 'A',
                 CreatedDateTime = now
@@ -568,6 +613,7 @@ public class DataSeeder
         }
 
         await _context.SaveChangesAsync(cancellationToken);
+        return financialAdminRole;
     }
 
     /// <summary>

--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-04-16T21:15:43-04:00",
+  "generated_at": "2026-04-21T09:20:17-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -2652,32 +2652,6 @@
         "CategoryCounts": "Dictionary<string, int>"
       },
       "linked_entity": "System"
-    },
-    "GroupAttendanceDetailDto": {
-      "name": "GroupAttendanceDetailDto",
-      "namespace": "Koinon.Application.DTOs",
-      "properties": {
-        "PersonIdKey": "string",
-        "FullName": "string",
-        "PhotoUrl": "string?",
-        "DidAttend": "bool",
-        "PresentDateTime": "DateTime?"
-      },
-      "linked_entity": "Group"
-    },
-    "GroupAttendanceOccurrenceDto": {
-      "name": "GroupAttendanceOccurrenceDto",
-      "namespace": "Koinon.Application.DTOs",
-      "properties": {
-        "IdKey": "string",
-        "OccurrenceDate": "DateOnly",
-        "AttendeeCount": "int",
-        "AnonymousCount": "int",
-        "DidNotOccur": "bool",
-        "LocationName": "string?",
-        "ScheduleName": "string?"
-      },
-      "linked_entity": "Group"
     },
     "GroupDto": {
       "name": "GroupDto",
@@ -5526,6 +5500,11 @@
           "is_async": false
         },
         {
+          "name": "GetValuesByTypeAsync",
+          "return_type": "Task<Result<IReadOnlyList<DefinedValueDto>>>",
+          "is_async": false
+        },
+        {
           "name": "CreateValueAsync",
           "return_type": "Task<Result<DefinedValueManagementDto>>",
           "is_async": false
@@ -6050,16 +6029,6 @@
           "name": "RemoveScheduleAsync",
           "return_type": "Task<Result>",
           "is_async": false
-        },
-        {
-          "name": "GetAttendanceHistoryAsync",
-          "return_type": "Task<IReadOnlyList<GroupAttendanceOccurrenceDto>>",
-          "is_async": false
-        },
-        {
-          "name": "GetAttendanceDetailAsync",
-          "return_type": "Task<Result<IReadOnlyList<GroupAttendanceDetailDto>>>",
-          "is_async": false
         }
       ],
       "dependencies": [
@@ -6246,11 +6215,6 @@
         {
           "name": "RecordAttendanceAsync",
           "return_type": "Task<Result>",
-          "is_async": false
-        },
-        {
-          "name": "IsGroupLeaderOrStaffAsync",
-          "return_type": "Task<bool>",
           "is_async": false
         }
       ],
@@ -7902,6 +7866,15 @@
           "required_roles": []
         },
         {
+          "name": "GetValues",
+          "method": "GET",
+          "route": "{idKeyOrGuid}/values",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
           "name": "CreateValue",
           "method": "POST",
           "route": "{typeIdKey}/values",
@@ -8575,24 +8548,6 @@
           "required_roles": []
         },
         {
-          "name": "GetAttendanceHistory",
-          "method": "GET",
-          "route": "{idKey}/attendance",
-          "request_type": null,
-          "response_type": null,
-          "requires_auth": true,
-          "required_roles": []
-        },
-        {
-          "name": "GetAttendanceDetail",
-          "method": "GET",
-          "route": "{idKey}/attendance/{occurrenceIdKey}",
-          "request_type": null,
-          "response_type": null,
-          "requires_auth": true,
-          "required_roles": []
-        },
-        {
           "name": "AddMember",
           "method": "POST",
           "route": "{idKey}/members",
@@ -8655,7 +8610,6 @@
       },
       "dependencies": [
         "IGroupService",
-        "IMyGroupsService",
         "ILogger<GroupsController>"
       ]
     },
@@ -10100,16 +10054,6 @@
       "relationship": "maps_to"
     },
     {
-      "source": "GroupAttendanceDetailDto",
-      "target": "Group",
-      "relationship": "maps_to"
-    },
-    {
-      "source": "GroupAttendanceOccurrenceDto",
-      "target": "Group",
-      "relationship": "maps_to"
-    },
-    {
       "source": "GroupDto",
       "target": "Group",
       "relationship": "maps_to"
@@ -10900,11 +10844,6 @@
       "relationship": "depends_on"
     },
     {
-      "source": "GroupsController",
-      "target": "IMyGroupsService",
-      "relationship": "depends_on"
-    },
-    {
       "source": "LocationsController",
       "target": "ILocationService",
       "relationship": "depends_on"
@@ -11441,6 +11380,11 @@
     },
     {
       "source": "DefinedTypeService",
+      "target": "DefinedValueDto",
+      "relationship": "returns"
+    },
+    {
+      "source": "DefinedTypeService",
       "target": "DefinedValueManagementDto",
       "relationship": "returns"
     },
@@ -11647,16 +11591,6 @@
     {
       "source": "GroupService",
       "target": "ScheduleDto",
-      "relationship": "returns"
-    },
-    {
-      "source": "GroupService",
-      "target": "GroupAttendanceOccurrenceDto",
-      "relationship": "returns"
-    },
-    {
-      "source": "GroupService",
-      "target": "GroupAttendanceDetailDto",
       "relationship": "returns"
     },
     {
@@ -12337,9 +12271,9 @@
   ],
   "summary": {
     "total_entities": 60,
-    "total_dtos": 225,
+    "total_dtos": 223,
     "total_services": 113,
     "total_controllers": 37,
-    "total_relationships": 528
+    "total_relationships": 524
   }
 }

--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-04-21T11:15:59-04:00",
+  "generated_at": "2026-04-21T12:14:02-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -2652,6 +2652,32 @@
         "CategoryCounts": "Dictionary<string, int>"
       },
       "linked_entity": "System"
+    },
+    "GroupAttendanceDetailDto": {
+      "name": "GroupAttendanceDetailDto",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {
+        "PersonIdKey": "string",
+        "FullName": "string",
+        "PhotoUrl": "string?",
+        "DidAttend": "bool",
+        "PresentDateTime": "DateTime?"
+      },
+      "linked_entity": "Group"
+    },
+    "GroupAttendanceOccurrenceDto": {
+      "name": "GroupAttendanceOccurrenceDto",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {
+        "IdKey": "string",
+        "OccurrenceDate": "DateOnly",
+        "AttendeeCount": "int",
+        "AnonymousCount": "int",
+        "DidNotOccur": "bool",
+        "LocationName": "string?",
+        "ScheduleName": "string?"
+      },
+      "linked_entity": "Group"
     },
     "GroupDto": {
       "name": "GroupDto",
@@ -6029,6 +6055,16 @@
           "name": "RemoveScheduleAsync",
           "return_type": "Task<Result>",
           "is_async": false
+        },
+        {
+          "name": "GetAttendanceHistoryAsync",
+          "return_type": "Task<IReadOnlyList<GroupAttendanceOccurrenceDto>>",
+          "is_async": false
+        },
+        {
+          "name": "GetAttendanceDetailAsync",
+          "return_type": "Task<Result<IReadOnlyList<GroupAttendanceDetailDto>>>",
+          "is_async": false
         }
       ],
       "dependencies": [
@@ -6215,6 +6251,11 @@
         {
           "name": "RecordAttendanceAsync",
           "return_type": "Task<Result>",
+          "is_async": false
+        },
+        {
+          "name": "IsGroupLeaderOrStaffAsync",
+          "return_type": "Task<bool>",
           "is_async": false
         }
       ],
@@ -8548,6 +8589,24 @@
           "required_roles": []
         },
         {
+          "name": "GetAttendanceHistory",
+          "method": "GET",
+          "route": "{idKey}/attendance",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
+          "name": "GetAttendanceDetail",
+          "method": "GET",
+          "route": "{idKey}/attendance/{occurrenceIdKey}",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
           "name": "AddMember",
           "method": "POST",
           "route": "{idKey}/members",
@@ -8610,6 +8669,7 @@
       },
       "dependencies": [
         "IGroupService",
+        "IMyGroupsService",
         "ILogger<GroupsController>"
       ]
     },
@@ -10054,6 +10114,16 @@
       "relationship": "maps_to"
     },
     {
+      "source": "GroupAttendanceDetailDto",
+      "target": "Group",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "GroupAttendanceOccurrenceDto",
+      "target": "Group",
+      "relationship": "maps_to"
+    },
+    {
       "source": "GroupDto",
       "target": "Group",
       "relationship": "maps_to"
@@ -10844,6 +10914,11 @@
       "relationship": "depends_on"
     },
     {
+      "source": "GroupsController",
+      "target": "IMyGroupsService",
+      "relationship": "depends_on"
+    },
+    {
       "source": "LocationsController",
       "target": "ILocationService",
       "relationship": "depends_on"
@@ -11594,6 +11669,16 @@
       "relationship": "returns"
     },
     {
+      "source": "GroupService",
+      "target": "GroupAttendanceOccurrenceDto",
+      "relationship": "returns"
+    },
+    {
+      "source": "GroupService",
+      "target": "GroupAttendanceDetailDto",
+      "relationship": "returns"
+    },
+    {
       "source": "GroupTypeService",
       "target": "GroupTypeDto",
       "relationship": "returns"
@@ -12271,9 +12356,9 @@
   ],
   "summary": {
     "total_entities": 60,
-    "total_dtos": 223,
+    "total_dtos": 225,
     "total_services": 113,
     "total_controllers": 37,
-    "total_relationships": 524
+    "total_relationships": 529
   }
 }

--- a/tools/graph/backend-graph.json
+++ b/tools/graph/backend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-04-21T09:20:17-04:00",
+  "generated_at": "2026-04-21T11:15:59-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-21T15:47:04.581Z",
+  "generated_at": "2026-04-21T16:32:15.045Z",
   "types": {
     "AttendanceAnalyticsDto": {
       "name": "AttendanceAnalyticsDto",

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-21T15:15:07.840Z",
+  "generated_at": "2026-04-21T15:47:04.581Z",
   "types": {
     "AttendanceAnalyticsDto": {
       "name": "AttendanceAnalyticsDto",

--- a/tools/graph/frontend-graph.json
+++ b/tools/graph/frontend-graph.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "generated_at": "2026-04-21T13:52:33.472Z",
+  "generated_at": "2026-04-21T15:15:07.840Z",
   "types": {
     "AttendanceAnalyticsDto": {
       "name": "AttendanceAnalyticsDto",

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-04-21T11:15:59-04:00",
+  "generated_at": "2026-04-21T12:14:02-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -2652,6 +2652,32 @@
         "CategoryCounts": "Dictionary<string, int>"
       },
       "linked_entity": "System"
+    },
+    "GroupAttendanceDetailDto": {
+      "name": "GroupAttendanceDetailDto",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {
+        "PersonIdKey": "string",
+        "FullName": "string",
+        "PhotoUrl": "string?",
+        "DidAttend": "bool",
+        "PresentDateTime": "DateTime?"
+      },
+      "linked_entity": "Group"
+    },
+    "GroupAttendanceOccurrenceDto": {
+      "name": "GroupAttendanceOccurrenceDto",
+      "namespace": "Koinon.Application.DTOs",
+      "properties": {
+        "IdKey": "string",
+        "OccurrenceDate": "DateOnly",
+        "AttendeeCount": "int",
+        "AnonymousCount": "int",
+        "DidNotOccur": "bool",
+        "LocationName": "string?",
+        "ScheduleName": "string?"
+      },
+      "linked_entity": "Group"
     },
     "GroupDto": {
       "name": "GroupDto",
@@ -6029,6 +6055,16 @@
           "name": "RemoveScheduleAsync",
           "return_type": "Task<Result>",
           "is_async": false
+        },
+        {
+          "name": "GetAttendanceHistoryAsync",
+          "return_type": "Task<IReadOnlyList<GroupAttendanceOccurrenceDto>>",
+          "is_async": false
+        },
+        {
+          "name": "GetAttendanceDetailAsync",
+          "return_type": "Task<Result<IReadOnlyList<GroupAttendanceDetailDto>>>",
+          "is_async": false
         }
       ],
       "dependencies": [
@@ -6215,6 +6251,11 @@
         {
           "name": "RecordAttendanceAsync",
           "return_type": "Task<Result>",
+          "is_async": false
+        },
+        {
+          "name": "IsGroupLeaderOrStaffAsync",
+          "return_type": "Task<bool>",
           "is_async": false
         }
       ],
@@ -8548,6 +8589,24 @@
           "required_roles": []
         },
         {
+          "name": "GetAttendanceHistory",
+          "method": "GET",
+          "route": "{idKey}/attendance",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
+          "name": "GetAttendanceDetail",
+          "method": "GET",
+          "route": "{idKey}/attendance/{occurrenceIdKey}",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
           "name": "AddMember",
           "method": "POST",
           "route": "{idKey}/members",
@@ -8610,6 +8669,7 @@
       },
       "dependencies": [
         "IGroupService",
+        "IMyGroupsService",
         "ILogger<GroupsController>"
       ]
     },
@@ -18373,6 +18433,16 @@
       "relationship": "maps_to"
     },
     {
+      "source": "GroupAttendanceDetailDto",
+      "target": "Group",
+      "relationship": "maps_to"
+    },
+    {
+      "source": "GroupAttendanceOccurrenceDto",
+      "target": "Group",
+      "relationship": "maps_to"
+    },
+    {
       "source": "GroupDto",
       "target": "Group",
       "relationship": "maps_to"
@@ -19163,6 +19233,11 @@
       "relationship": "depends_on"
     },
     {
+      "source": "GroupsController",
+      "target": "IMyGroupsService",
+      "relationship": "depends_on"
+    },
+    {
       "source": "LocationsController",
       "target": "ILocationService",
       "relationship": "depends_on"
@@ -19910,6 +19985,16 @@
     {
       "source": "GroupService",
       "target": "ScheduleDto",
+      "relationship": "returns"
+    },
+    {
+      "source": "GroupService",
+      "target": "GroupAttendanceOccurrenceDto",
+      "relationship": "returns"
+    },
+    {
+      "source": "GroupService",
+      "target": "GroupAttendanceDetailDto",
       "relationship": "returns"
     },
     {
@@ -21062,6 +21147,8 @@
     "dto:PersonLookupDto": "type:PersonLookupDto",
     "dto:GlobalSearchResultDto": "type:GlobalSearchResult",
     "dto:GlobalSearchResponse": "type:GlobalSearchResponse",
+    "dto:GroupAttendanceDetailDto": "type:GroupAttendanceDetailDto",
+    "dto:GroupAttendanceOccurrenceDto": "type:GroupAttendanceOccurrenceDto",
     "dto:GroupDto": "type:GroupDto",
     "dto:GroupSummaryDto": "type:GroupSummaryDto",
     "dto:GroupMemberDto": "type:GroupMemberDto",
@@ -21178,13 +21265,13 @@
   },
   "stats": {
     "entities": 60,
-    "dtos": 223,
+    "dtos": 225,
     "services": 113,
     "controllers": 37,
     "types": 313,
     "api_functions": 182,
     "hooks": 162,
     "components": 138,
-    "total_edges": 603
+    "total_edges": 608
   }
 }

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-04-21T09:20:17-04:00",
+  "generated_at": "2026-04-21T11:15:59-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",

--- a/tools/graph/graph-baseline.json
+++ b/tools/graph/graph-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "generated_at": "2026-04-16T21:15:43-04:00",
+  "generated_at": "2026-04-21T09:20:17-04:00",
   "entities": {
     "Attendance": {
       "name": "Attendance",
@@ -2652,32 +2652,6 @@
         "CategoryCounts": "Dictionary<string, int>"
       },
       "linked_entity": "System"
-    },
-    "GroupAttendanceDetailDto": {
-      "name": "GroupAttendanceDetailDto",
-      "namespace": "Koinon.Application.DTOs",
-      "properties": {
-        "PersonIdKey": "string",
-        "FullName": "string",
-        "PhotoUrl": "string?",
-        "DidAttend": "bool",
-        "PresentDateTime": "DateTime?"
-      },
-      "linked_entity": "Group"
-    },
-    "GroupAttendanceOccurrenceDto": {
-      "name": "GroupAttendanceOccurrenceDto",
-      "namespace": "Koinon.Application.DTOs",
-      "properties": {
-        "IdKey": "string",
-        "OccurrenceDate": "DateOnly",
-        "AttendeeCount": "int",
-        "AnonymousCount": "int",
-        "DidNotOccur": "bool",
-        "LocationName": "string?",
-        "ScheduleName": "string?"
-      },
-      "linked_entity": "Group"
     },
     "GroupDto": {
       "name": "GroupDto",
@@ -5526,6 +5500,11 @@
           "is_async": false
         },
         {
+          "name": "GetValuesByTypeAsync",
+          "return_type": "Task<Result<IReadOnlyList<DefinedValueDto>>>",
+          "is_async": false
+        },
+        {
           "name": "CreateValueAsync",
           "return_type": "Task<Result<DefinedValueManagementDto>>",
           "is_async": false
@@ -6050,16 +6029,6 @@
           "name": "RemoveScheduleAsync",
           "return_type": "Task<Result>",
           "is_async": false
-        },
-        {
-          "name": "GetAttendanceHistoryAsync",
-          "return_type": "Task<IReadOnlyList<GroupAttendanceOccurrenceDto>>",
-          "is_async": false
-        },
-        {
-          "name": "GetAttendanceDetailAsync",
-          "return_type": "Task<Result<IReadOnlyList<GroupAttendanceDetailDto>>>",
-          "is_async": false
         }
       ],
       "dependencies": [
@@ -6246,11 +6215,6 @@
         {
           "name": "RecordAttendanceAsync",
           "return_type": "Task<Result>",
-          "is_async": false
-        },
-        {
-          "name": "IsGroupLeaderOrStaffAsync",
-          "return_type": "Task<bool>",
           "is_async": false
         }
       ],
@@ -7902,6 +7866,15 @@
           "required_roles": []
         },
         {
+          "name": "GetValues",
+          "method": "GET",
+          "route": "{idKeyOrGuid}/values",
+          "request_type": null,
+          "response_type": null,
+          "requires_auth": true,
+          "required_roles": []
+        },
+        {
           "name": "CreateValue",
           "method": "POST",
           "route": "{typeIdKey}/values",
@@ -8575,24 +8548,6 @@
           "required_roles": []
         },
         {
-          "name": "GetAttendanceHistory",
-          "method": "GET",
-          "route": "{idKey}/attendance",
-          "request_type": null,
-          "response_type": null,
-          "requires_auth": true,
-          "required_roles": []
-        },
-        {
-          "name": "GetAttendanceDetail",
-          "method": "GET",
-          "route": "{idKey}/attendance/{occurrenceIdKey}",
-          "request_type": null,
-          "response_type": null,
-          "requires_auth": true,
-          "required_roles": []
-        },
-        {
           "name": "AddMember",
           "method": "POST",
           "route": "{idKey}/members",
@@ -8655,7 +8610,6 @@
       },
       "dependencies": [
         "IGroupService",
-        "IMyGroupsService",
         "ILogger<GroupsController>"
       ]
     },
@@ -18419,16 +18373,6 @@
       "relationship": "maps_to"
     },
     {
-      "source": "GroupAttendanceDetailDto",
-      "target": "Group",
-      "relationship": "maps_to"
-    },
-    {
-      "source": "GroupAttendanceOccurrenceDto",
-      "target": "Group",
-      "relationship": "maps_to"
-    },
-    {
       "source": "GroupDto",
       "target": "Group",
       "relationship": "maps_to"
@@ -19219,11 +19163,6 @@
       "relationship": "depends_on"
     },
     {
-      "source": "GroupsController",
-      "target": "IMyGroupsService",
-      "relationship": "depends_on"
-    },
-    {
       "source": "LocationsController",
       "target": "ILocationService",
       "relationship": "depends_on"
@@ -19760,6 +19699,11 @@
     },
     {
       "source": "DefinedTypeService",
+      "target": "DefinedValueDto",
+      "relationship": "returns"
+    },
+    {
+      "source": "DefinedTypeService",
       "target": "DefinedValueManagementDto",
       "relationship": "returns"
     },
@@ -19966,16 +19910,6 @@
     {
       "source": "GroupService",
       "target": "ScheduleDto",
-      "relationship": "returns"
-    },
-    {
-      "source": "GroupService",
-      "target": "GroupAttendanceOccurrenceDto",
-      "relationship": "returns"
-    },
-    {
-      "source": "GroupService",
-      "target": "GroupAttendanceDetailDto",
       "relationship": "returns"
     },
     {
@@ -21128,8 +21062,6 @@
     "dto:PersonLookupDto": "type:PersonLookupDto",
     "dto:GlobalSearchResultDto": "type:GlobalSearchResult",
     "dto:GlobalSearchResponse": "type:GlobalSearchResponse",
-    "dto:GroupAttendanceDetailDto": "type:GroupAttendanceDetailDto",
-    "dto:GroupAttendanceOccurrenceDto": "type:GroupAttendanceOccurrenceDto",
     "dto:GroupDto": "type:GroupDto",
     "dto:GroupSummaryDto": "type:GroupSummaryDto",
     "dto:GroupMemberDto": "type:GroupMemberDto",
@@ -21246,13 +21178,13 @@
   },
   "stats": {
     "entities": 60,
-    "dtos": 225,
+    "dtos": 223,
     "services": 113,
     "controllers": 37,
     "types": 313,
     "api_functions": 182,
     "hooks": 162,
     "components": 138,
-    "total_edges": 607
+    "total_edges": 603
   }
 }


### PR DESCRIPTION
## Summary

Precursor to #493. Fixes 4 backend bugs that together make the giving batch → contribution → statements workflow non-functional. Without this PR, the giving E2E spec (#493) cannot be written.

### Bugs fixed

1. **`POST /api/v1/giving/batches` returned 500** — `DateTime` fields arriving from JSON with `Kind=Unspecified` were written directly to `timestamp with time zone` columns, throwing `Npgsql.PostgresException: Cannot write DateTime with Kind=Unspecified`. Fixed across `BatchDonationEntryService` (create/update write + date-range filter in `GetBatchesAsync`) and `ContributionStatementService` (preview, generate, eligible-people query) via a shared `DateTimeNormalization.NormalizeToUtc` helper.

2. **`CreatedAtAction` route resolution failures** — three sites in `GivingController` called `CreatedAtAction(nameof(Get*Async), ...)` which produced names like `"GetBatchAsync"` but ASP.NET Core strips the `Async` suffix from registered action names. Result: `No route matches the supplied values` after every successful save. Fixed by using literal stripped names (`"GetBatch"`, `"GetContribution"`) and one `[ActionName(nameof(GetStatementAsync))]`.

3. **`GET /api/v1/defined-types/{idKeyOrGuid}/values` → 405** — the frontend's transaction-type dropdown calls an endpoint that didn't exist. Added the action on `DefinedTypesController` + `DefinedTypeService.GetValuesByTypeAsync` (accepts IdKey or GUID, returns `{ data: [...] }` with ordered values).

4. **Admin user couldn't use any `/api/v1/giving/*` endpoint** — production role separation means financial claims are only on the `Financial Admin` role (GUID F1F1F1F1-...). The test seeder wasn't assigning that role to john.smith. Fixed by assigning the seeded admin to BOTH `Admin` and `Financial Admin` roles. Production role structure unchanged.

5. **`fund` table empty on fresh seed** — ContributionForm's Fund dropdown had no options. Added a default "General Fund" seed with fixed GUID `90909090-9090-4090-8090-111111111111`.

## Changes

- `src/Koinon.Application/Helpers/DateTimeNormalization.cs` — new shared helper
- `src/Koinon.Application/Services/BatchDonationEntryService.cs` — use helper on all DateTime writes/filters
- `src/Koinon.Application/Services/ContributionStatementService.cs` — same, plus eligible-people query
- `src/Koinon.Api/Controllers/GivingController.cs` — CreatedAtAction route names
- `src/Koinon.Api/Controllers/DefinedTypesController.cs` — new `GET /{idKeyOrGuid}/values` action
- `src/Koinon.Application/Services/DefinedTypeService.cs` + `Interfaces/IDefinedTypeService.cs` — `GetValuesByTypeAsync`
- `tools/Koinon.TestDataSeeder/DataSeeder.cs` — Financial Admin role idempotent provisioning, john.smith gets both roles, General Fund seed
- `tests/Koinon.Application.Tests/Services/DefinedTypeServiceTests.cs` — new tests for `GetValuesByTypeAsync`; ordering test strengthened

## Test plan

- [x] `dotnet build` clean
- [x] `dotnet test` — 1419 pass / 42 skip / 0 fail
- [x] Curl smoke: `POST /giving/batches` → 201; `POST /giving/statements` → 201; `GET /giving/batches?startDate=...&endDate=...` → 200; `GET /defined-types/{guid}/values` → 200 with array; admin authenticates + not 403
- [x] Independent code review: 3 rounds (CHANGES_REQUESTED → CHANGES_REQUESTED → APPROVED). Final review passes with no blockers.

## Follow-up (non-blocking, tracked separately)

- Same DateTime.Kind pattern exists in `AuditService.SearchAsync/ExportAsync` and `PersonService.NoteDate`. Pre-existing — not in scope for this PR.
- `CreatedAtAction` style in `GivingController` mixes literal strings with `[ActionName]` attribute; consider unifying in a cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)