### PR TITLE
test(giving): E2E spec for end-to-end giving flow (#493)

### DIFF
--- a/src/web/e2e/tests/feat-493-end-to-end-giving-flow.spec.ts
+++ b/src/web/e2e/tests/feat-493-end-to-end-giving-flow.spec.ts
@@ -206,7 +206,9 @@ test.describe('Feature #493 — End-to-end giving flow', () => {
 
   test('AC3 — Admin adds a contribution to the batch for John Smith', async ({ page }) => {
     const batchName = `E2E 493 Contrib ${uniqueSuffix('b')}`;
-    await createBatchViaUi(page, batchName, '75.50');
+    // Distinct control vs contribution amounts: proves the $75.50 assertion below
+    // tracks Actual, not Control (which is $100.00 here).
+    await createBatchViaUi(page, batchName, '100.00');
 
     // Sanity: empty state first
     await expect(page.getByText('Contributions (0)')).toBeVisible({ timeout: 10_000 });

--- a/src/web/e2e/tests/feat-493-end-to-end-giving-flow.spec.ts
+++ b/src/web/e2e/tests/feat-493-end-to-end-giving-flow.spec.ts
@@ -1,0 +1,363 @@
+/**
+ * E2E Tests: Feature #493 — Verify end-to-end giving flow via admin batch entry
+ *
+ * Covers the six acceptance criteria from issue #493:
+ *  AC1 — Admin opens Giving area (batch list)
+ *  AC2 — Admin creates a batch (Name, BatchDate, Control Amount, status Open)
+ *  AC3 — Admin adds a contribution to the batch (person, fund, amount, type)
+ *  AC4 — Admin closes the batch (status flips Open -> Closed)
+ *  AC5 — Admin generates a contribution statement for the contributor
+ *  AC6 — Batch summary reports balanced totals (variance = 0)
+ *
+ * Strategy: we drive the UI for acceptance flows, but perform the statement
+ * generation and one balanced-summary assertion via the HTTP API directly.
+ * Statement generation is API-driven because the /statements/eligible LINQ
+ * query is a pre-existing (pre-#493) 500 that the UI eats silently; the
+ * /statements POST endpoint works and is what the UI would call in the final
+ * step anyway. AC5 still exercises the full pipeline: seeded contribution ->
+ * API-produced statement -> asserted total matches the AC3 amount.
+ */
+
+import { test, expect, type Page } from '../fixtures/auth.fixture';
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+/** Unique per-test suffix so parallel/repeat runs don't collide. */
+function uniqueSuffix(label: string): string {
+  return `${label}-${Date.now()}-${Math.floor(Math.random() * 10_000)}`;
+}
+
+/** Returns a yyyy-mm-dd date string for the local date N days ago (0 = today). */
+function localDateString(daysAgo = 0): string {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  return `${y}-${m}-${day}`;
+}
+
+/** Local datetime string for datetime-local inputs (yyyy-mm-ddTHH:MM). */
+function localDateTimeString(): string {
+  const d = new Date();
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, '0');
+  const day = String(d.getDate()).padStart(2, '0');
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mm = String(d.getMinutes()).padStart(2, '0');
+  return `${y}-${m}-${day}T${hh}:${mm}`;
+}
+
+/** Creates a batch through the Batch Form UI and returns the assigned idKey. */
+async function createBatchViaUi(
+  page: Page,
+  name: string,
+  controlAmount: string,
+): Promise<{ idKey: string; name: string }> {
+  await page.goto('/admin/giving/new');
+  await expect(
+    page.getByRole('heading', { name: /create batch/i }),
+  ).toBeVisible({ timeout: 10_000 });
+
+  await page.locator('#name').fill(name);
+  // Use today (matches AC2: "BatchDate (today)"). Schema forbids future dates.
+  await page.locator('#batchDate').fill(localDateString(0));
+  await page.locator('#controlAmount').fill(controlAmount);
+
+  await page.getByRole('button', { name: /create batch/i }).click();
+
+  // Success redirects to /admin/giving/:idKey (not /admin/giving/new) —
+  // capture the idKey from the URL once the redirect has settled.
+  await expect(page).toHaveURL(/\/admin\/giving\/(?!new(?:\/|$))[^/]+$/, {
+    timeout: 10_000,
+  });
+  const url = new URL(page.url());
+  const idKey = url.pathname.split('/').pop()!;
+  return { idKey, name };
+}
+
+/** Fills and submits the Add Contribution modal for John Smith / General Fund. */
+async function addJohnSmithContribution(page: Page, amount: string): Promise<void> {
+  await page.getByRole('button', { name: /add contribution/i }).click();
+  await expect(
+    page.getByRole('heading', { name: 'Add Contribution' }),
+  ).toBeVisible({ timeout: 5_000 });
+
+  // Person lookup: search debounces at 300ms, needs >= 2 chars
+  const personSearch = page.getByPlaceholder(/search for contributor/i);
+  await expect(personSearch).toBeVisible();
+  await personSearch.fill('John Sm');
+  // The dropdown renders a <button> per person containing both the fullName
+  // and the email (e.g. "John Smith john.smith@example.com"). Scope on the
+  // unique email so we don't collide with the logged-in user pill in the
+  // header which also shows "John Smith".
+  const johnRow = page
+    .getByRole('button', { name: /John Smith.*john\.smith@example\.com/i })
+    .first();
+  await expect(johnRow).toBeVisible({ timeout: 5_000 });
+  await johnRow.click();
+  // Confirm the selected-person card renders
+  await expect(page.getByText('John Smith').first()).toBeVisible();
+
+  // Transaction date/time — use current local time
+  await page.locator('input[type="datetime-local"]').fill(localDateTimeString());
+
+  // Transaction type: "Contribution" (first non-placeholder option)
+  const typeSelect = page.locator('select').filter({ hasText: 'Select Type' });
+  await expect(typeSelect).toBeVisible();
+  // Wait until the API-fed options are populated
+  await expect
+    .poll(async () => typeSelect.locator('option').count(), {
+      timeout: 5_000,
+      message: 'transaction type options loaded',
+    })
+    .toBeGreaterThan(1);
+  await typeSelect.selectOption({ label: 'Contribution' });
+
+  // Fund split row 1 — pick General Fund by label
+  const fundSelect = page.locator('select[aria-label="Fund selection 1"]');
+  await expect(fundSelect).toBeVisible();
+  await expect
+    .poll(async () => fundSelect.locator('option').count(), { timeout: 5_000 })
+    .toBeGreaterThan(1);
+  await fundSelect.selectOption({ label: 'General Fund' });
+
+  // Amount
+  await page.locator('input[aria-label="Amount for split 1"]').fill(amount);
+
+  // Submit — the modal action button label reads "Add Contribution"
+  await page
+    .getByRole('button', { name: 'Add Contribution' })
+    .last()
+    .click();
+
+  // Modal closes on success
+  await expect(
+    page.getByRole('heading', { name: 'Add Contribution' }),
+  ).not.toBeVisible({ timeout: 10_000 });
+}
+
+/**
+ * Issues a backend login and returns a bearer token. We use this for AC5
+ * (statement generation) because the Statements UI funnels through the
+ * eligible-people endpoint which currently 500s for reasons unrelated to #493
+ * (pre-existing EF Core LINQ translation bug in GetEligiblePeopleAsync).
+ */
+async function apiLogin(page: Page): Promise<string> {
+  const resp = await page.request.post('http://localhost:5000/api/v1/auth/login', {
+    data: { email: 'john.smith@example.com', password: 'admin123' },
+  });
+  expect(resp.ok(), 'admin login').toBe(true);
+  const body = await resp.json();
+  return body.data.accessToken as string;
+}
+
+// --------------------------------------------------------------------------
+// Tests
+// --------------------------------------------------------------------------
+
+test.describe('Feature #493 — End-to-end giving flow', () => {
+  test.beforeEach(async ({ loginAsAdmin }) => {
+    await loginAsAdmin();
+  });
+
+  test('AC1 — Admin opens Giving area and the batch list loads', async ({ page }) => {
+    await page.goto('/admin/giving');
+
+    // Heading confirms we're on the giving batches page
+    await expect(
+      page.getByRole('heading', { name: /giving.*batches/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Create Batch CTA is the primary affordance for AC2
+    await expect(page.getByRole('link', { name: /create batch/i })).toBeVisible();
+
+    // List region renders (either a table or an empty-state message); we
+    // assert that at least one of those containers is visible so we know
+    // the page actually finished loading rather than stuck on a spinner.
+    await expect(page.getByText(/No batches|Name.*Date.*Status/i).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test('AC2 — Admin creates a new batch and it appears with Open status', async ({ page }) => {
+    const batchName = `E2E 493 Create ${uniqueSuffix('b')}`;
+    const { idKey } = await createBatchViaUi(page, batchName, '150.00');
+
+    // After redirect, the detail page renders the batch name and Open status
+    await expect(page.locator('h1')).toContainText(batchName, { timeout: 10_000 });
+    await expect(page.getByText('Open', { exact: true }).first()).toBeVisible();
+
+    // And the batch shows up in the list
+    await page.goto('/admin/giving');
+    await expect(
+      page.getByRole('heading', { name: /giving.*batches/i }),
+    ).toBeVisible({ timeout: 10_000 });
+    // Filter down to our row by the unique batch name link
+    await expect(page.getByRole('link', { name: batchName })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Belt-and-suspenders: the idKey from the redirect is well-formed
+    expect(idKey).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  test('AC3 — Admin adds a contribution to the batch for John Smith', async ({ page }) => {
+    const batchName = `E2E 493 Contrib ${uniqueSuffix('b')}`;
+    await createBatchViaUi(page, batchName, '75.50');
+
+    // Sanity: empty state first
+    await expect(page.getByText('Contributions (0)')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Actual Amount')).toBeVisible();
+
+    await addJohnSmithContribution(page, '75.50');
+
+    // React Query invalidation: contribution count ticks to 1
+    await expect(page.getByText('Contributions (1)')).toBeVisible({ timeout: 10_000 });
+
+    // John Smith shows up in the contributions table
+    await expect(page.getByRole('cell', { name: 'John Smith' }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Batch summary Actual Amount reflects $75.50
+    await expect(page.getByText('$75.50').first()).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('AC4 — Admin closes the batch and status flips Open -> Closed', async ({ page }) => {
+    const batchName = `E2E 493 Close ${uniqueSuffix('b')}`;
+    await createBatchViaUi(page, batchName, '20.00');
+
+    // Status badge starts Open
+    await expect(page.getByText('Open', { exact: true }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // The Close action lives on the BatchSummaryCard in the sidebar.
+    // (The header "Add Contribution" button is unrelated.)
+    await page.getByRole('button', { name: 'Close', exact: true }).click();
+
+    // Status flips to Closed — this is the #664 persistence fix under test
+    await expect(page.getByText('Closed', { exact: true }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // The editable affordance disappears, and the re-open button appears
+    await expect(
+      page.getByRole('button', { name: /add contribution/i }),
+    ).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Open', exact: true })).toBeVisible({
+      timeout: 5_000,
+    });
+
+    // And a page reload preserves the Closed status (the persistence fix)
+    await page.reload();
+    await expect(page.getByText('Closed', { exact: true }).first()).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test('AC5 — Admin generates a contribution statement for John Smith', async ({ page }) => {
+    // Seed a dedicated batch + contribution so this test is isolated from the others
+    const batchName = `E2E 493 Statement ${uniqueSuffix('b')}`;
+    await createBatchViaUi(page, batchName, '42.00');
+    await addJohnSmithContribution(page, '42.00');
+
+    // 1. Statements admin UI loads (part of AC5 — the generation UI exists)
+    await page.goto('/admin/giving/statements');
+    await expect(
+      page.getByRole('heading', { name: /contribution statements/i }),
+    ).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator('#startDate')).toBeVisible();
+    await expect(page.locator('#endDate')).toBeVisible();
+    await expect(
+      page.getByRole('button', { name: /find eligible/i }),
+    ).toBeVisible();
+
+    // 2. Drive the statement generation via the API (see file-header note on
+    //    the pre-existing eligible-people 500). The preview endpoint exercises
+    //    the same aggregation logic the PDF/statement flow consumes, so a
+    //    successful preview proves end-to-end data flow from AC3.
+    const token = await apiLogin(page);
+    const year = new Date().getFullYear();
+
+    const preview = await page.request.post(
+      'http://localhost:5000/api/v1/giving/statements/preview',
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        data: {
+          personIdKey: 'AQAAAA', // John Smith — seeded person #1
+          startDate: `${year}-01-01`,
+          endDate: `${year}-12-31`,
+        },
+      },
+    );
+    expect(preview.ok(), 'preview statement').toBe(true);
+    const previewBody = await preview.json();
+    const dto = previewBody.data;
+    expect(dto.personName).toBe('John Smith');
+    // Total must include at least the $42.00 we just booked for this spec.
+    // Other tests in this file add more contributions for John during the
+    // same run, so we check ">=" not "==".
+    expect(Number(dto.totalAmount)).toBeGreaterThanOrEqual(42);
+    expect(Array.isArray(dto.contributions)).toBe(true);
+    expect(dto.contributions.length).toBeGreaterThan(0);
+
+    // 3. And a saved statement can be created (returns 201 with the DTO)
+    const saved = await page.request.post(
+      'http://localhost:5000/api/v1/giving/statements',
+      {
+        headers: { Authorization: `Bearer ${token}` },
+        data: {
+          personIdKey: 'AQAAAA',
+          startDate: `${year}-01-01`,
+          endDate: `${year}-12-31`,
+        },
+      },
+    );
+    expect(saved.status(), 'generate statement').toBe(201);
+    const savedBody = await saved.json();
+    const savedDto = savedBody.data ?? savedBody;
+    expect(savedDto.personName).toBe('John Smith');
+    expect(Number(savedDto.totalAmount)).toBeGreaterThanOrEqual(42);
+  });
+
+  test('AC6 — Batch summary shows balanced totals (variance = 0)', async ({ page }) => {
+    // Isolate: a batch whose control matches a single contribution exactly
+    const batchName = `E2E 493 Balanced ${uniqueSuffix('b')}`;
+    const { idKey } = await createBatchViaUi(page, batchName, '60.00');
+    await addJohnSmithContribution(page, '60.00');
+
+    // UI summary card should render Actual = Control = $60.00 and the
+    // Balanced indicator ("Balanced" label)
+    await expect(page.getByText('Actual Amount')).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Control Amount')).toBeVisible();
+    // There are two "$60.00" labels (control + actual); assert both exist by
+    // checking the count is >= 2.
+    await expect
+      .poll(async () => page.getByText('$60.00').count(), { timeout: 10_000 })
+      .toBeGreaterThanOrEqual(2);
+    await expect(page.getByText('Balanced', { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
+
+    // Backend summary endpoint agrees — variance=0, isBalanced=true. This
+    // is the same endpoint the summary card consumes; asserting it directly
+    // guards against a render-only success where data is stale.
+    const token = await apiLogin(page);
+    const summary = await page.request.get(
+      `http://localhost:5000/api/v1/giving/batches/${idKey}/summary`,
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+    expect(summary.ok(), 'batch summary').toBe(true);
+    const summaryBody = await summary.json();
+    const summaryDto = summaryBody.data;
+    expect(Number(summaryDto.controlAmount)).toBe(60);
+    expect(Number(summaryDto.actualAmount)).toBe(60);
+    expect(Number(summaryDto.variance)).toBe(0);
+    expect(summaryDto.isBalanced).toBe(true);
+    expect(summaryDto.contributionCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Adds `src/web/e2e/tests/feat-493-end-to-end-giving-flow.spec.ts` covering all six acceptance criteria from issue #493. Uses UI-driven flows for AC1-AC4 and AC6; AC5 drives the statement preview + POST /statements endpoints directly (see note below). All 6 tests pass on chromium.

## Acceptance criteria coverage

- **AC1** — Admin opens Giving area; batch list heading + Create Batch CTA + list container visible
- **AC2** — Admin creates batch (Name, today's BatchDate, control amount); redirects to detail, status Open, appears in list
- **AC3** — Admin adds a contribution for John Smith / General Fund / Contribution / Manual Entry (source defaulted server-side); contribution count ticks 0→1, table shows John Smith, Actual Amount reflects amount
- **AC4** — Admin closes the batch; Open→Closed visible, Add Contribution disappears, re-open button appears, survives page reload (the #664 persistence fix under test)
- **AC5** — Statements UI loads with date filters + Find Eligible button; API-driven preview + generate return 200/201 with `personName: "John Smith"` and total ≥ $42 seeded for this spec
- **AC6** — UI summary card shows Control = Actual = \$60.00 + Balanced label; backend `/batches/{idKey}/summary` confirms `variance: 0, isBalanced: true, contributionCount: 1`

## Discovery notes (for reviewer)

- **Pre-existing 500 on `GET /giving/statements/eligible`** — `ContributionStatementService.GetEligiblePeopleAsync` uses an untranslatable LINQ expression (`(int?)p.Id == c.PersonAliasId` cross-joins). This predates #663/#664 (introduced by #380). The Statements UI catches the error in an ErrorState component, so I didn't work around it in UI — I drove AC5 via the working `POST /statements/preview` and `POST /statements` endpoints, which exercise the same aggregation. File: `src/Koinon.Application/Services/ContributionStatementService.cs:285`. Not fixed here; should be its own issue.
- **PersonLookup aria-name contains email** — the dropdown button text is `"John Smith john.smith@example.com"` rather than just the full name. Scope your selector on the email to avoid colliding with the header pill showing the logged-in user.
- **Redirect regex must exclude `new`** — `/admin/giving/new` matches the same shape as `/admin/giving/:idKey`; test needs `(?!new(?:\/|$))` to wait for the real post-create idKey.
- **Transaction source defaults to Manual Entry server-side** — the AC3 form has no source picker; the backend sets `sourceTypeValueIdKey` to the Manual Entry value automatically, which matches the AC3 requirement.

## Playwright output

```
Running 6 tests using 1 worker
  ✓ AC1 — Admin opens Giving area and the batch list loads (2.9s)
  ✓ AC2 — Admin creates a new batch and it appears with Open status (3.8s)
  ✓ AC3 — Admin adds a contribution to the batch for John Smith (3.7s)
  ✓ AC4 — Admin closes the batch and status flips Open -> Closed (3.8s)
  ✓ AC5 — Admin generates a contribution statement for John Smith (6.8s)
  ✓ AC6 — Batch summary shows balanced totals (variance = 0) (4.2s)

  6 passed (27.7s)
```

Ran stable across two full passes. Other specs in `e2e/tests/` are not impacted (no shared state or fixtures touched).

## Test plan

- [x] `cd src/web && npx playwright test e2e/tests/feat-493-end-to-end-giving-flow.spec.ts --project=chromium` — 6/6 passing
- [x] `tsc --noEmit` — clean (pre-commit hook)
- [x] ESLint — clean (pre-commit hook)
- [ ] CI Playwright run on the PR (to verify it holds against a fresh seed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)