### PR TITLE
fix(security): map SecurityClaimsController errors to structured responses

### DIFF
--- a/src/Koinon.Api/Controllers/SecurityClaimsController.cs
+++ b/src/Koinon.Api/Controllers/SecurityClaimsController.cs
@@ -1,4 +1,5 @@
 using Koinon.Api.Authorization;
+using Koinon.Application.Common;
 using Koinon.Application.DTOs.Security;
 using Koinon.Application.Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -27,12 +28,37 @@ public class SecurityClaimsController(
         var result = await service.GetAllClaimsAsync(ct);
         if (result.IsFailure)
         {
-            return Problem(
-                detail: result.Error?.Message ?? "Failed to load security claims",
-                statusCode: StatusCodes.Status500InternalServerError,
-                title: "Internal Error");
+            return MapError(result.Error!);
         }
 
         return Ok(new { data = result.Value });
     }
+
+    private IActionResult MapError(Error error) => error.Code switch
+    {
+        "NOT_FOUND" => NotFound(new ProblemDetails
+        {
+            Title = "Not Found",
+            Detail = error.Message,
+            Status = StatusCodes.Status404NotFound,
+            Instance = HttpContext.Request.Path
+        }),
+        "VALIDATION_ERROR" => BadRequest(new ProblemDetails
+        {
+            Title = error.Message,
+            Detail = error.Details != null
+                ? string.Join("; ", error.Details.SelectMany(kvp => kvp.Value))
+                : null,
+            Status = StatusCodes.Status400BadRequest,
+            Instance = HttpContext.Request.Path,
+            Extensions = { ["errors"] = error.Details }
+        }),
+        _ => UnprocessableEntity(new ProblemDetails
+        {
+            Title = error.Code,
+            Detail = error.Message,
+            Status = StatusCodes.Status422UnprocessableEntity,
+            Instance = HttpContext.Request.Path
+        })
+    };
 }


### PR DESCRIPTION
## Summary
Mirrors the `MapError` switch from `SecurityRolesController` into `SecurityClaimsController` so `NOT_FOUND` / `VALIDATION_ERROR` / other non-success result codes map to their proper HTTP status codes instead of a bare 500 with the raw error message.

## Why
Reviewer on PR #667 flagged that `SecurityClaimsController.GetAllAsync` had only one failure branch and it returned `Problem(StatusCodes.Status500InternalServerError)` regardless of the underlying error. Blast radius today is zero (the service's only code path can't fail), but as soon as structured failures are added they'd 500-ify and leak internals. This fix was drafted during the #667 merge but didn't make it into the squash.

## Changes
- `src/Koinon.Api/Controllers/SecurityClaimsController.cs` — add `using Koinon.Application.Common;` + private `MapError` switch matching `SecurityRolesController`.

## Test plan
- [x] `dotnet build src/Koinon.Api/Koinon.Api.csproj` — 0 warnings, 0 errors.
- Not adding a test — there's no failure path to exercise today; the `MapError` switch is there for future code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)