### PR TITLE
feat(ui): consistent loading / empty / error states across admin pages (#502)

### DIFF
--- a/src/web/src/pages/MyGroupsPage.tsx
+++ b/src/web/src/pages/MyGroupsPage.tsx
@@ -5,10 +5,11 @@
 
 import { useState } from 'react';
 import { Card } from '@/components/ui/Card';
-import { Button } from '@/components/ui/Button';
+import { Loading, EmptyState, ErrorState } from '@/components/ui';
 import { GroupMemberList } from '@/components/mygroups/GroupMemberList';
 import { TakeAttendanceModal } from '@/components/mygroups/TakeAttendanceModal';
 import { GroupCardWithRequests } from '@/components/mygroups/GroupCardWithRequests';
+import { getErrorMessage } from '@/lib/errorMessages';
 import {
   useMyGroups,
   useMyGroupMembers,
@@ -21,7 +22,7 @@ export function MyGroupsPage() {
   const [expandedGroupId, setExpandedGroupId] = useState<string | null>(null);
   const [attendanceGroupId, setAttendanceGroupId] = useState<string | null>(null);
 
-  const { data: groups = [], isLoading, error } = useMyGroups();
+  const { data: groups = [], isLoading, error, refetch } = useMyGroups();
 
   const { data: members = [] } = useMyGroupMembers(expandedGroupId || undefined);
 
@@ -66,10 +67,7 @@ export function MyGroupsPage() {
   if (isLoading) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto mb-4"></div>
-          <p className="text-gray-600">Loading your groups...</p>
-        </div>
+        <Loading text="Loading your groups..." />
       </div>
     );
   }
@@ -77,10 +75,11 @@ export function MyGroupsPage() {
   if (error) {
     return (
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
-        <div className="text-center">
-          <p className="text-red-600 mb-4">Failed to load groups</p>
-          <Button onClick={() => window.location.reload()}>Retry</Button>
-        </div>
+        <ErrorState
+          title="Failed to load your groups"
+          message={getErrorMessage(error).message}
+          onRetry={() => refetch()}
+        />
       </div>
     );
   }
@@ -101,26 +100,10 @@ export function MyGroupsPage() {
         {/* Groups List */}
         {groups.length === 0 ? (
           <Card>
-            <div className="text-center py-12">
-              <svg
-                className="mx-auto h-12 w-12 text-gray-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                />
-              </svg>
-              <h3 className="mt-2 text-sm font-medium text-gray-900">No groups</h3>
-              <p className="mt-1 text-sm text-gray-500">
-                You are not currently a leader of any groups.
-              </p>
-            </div>
+            <EmptyState
+              title="You don't lead any groups yet"
+              description="When you're assigned as a leader of a group, it will appear here so you can manage members and record attendance."
+            />
           </Card>
         ) : (
           <div className="space-y-4">

--- a/src/web/src/pages/admin/RosterPage.tsx
+++ b/src/web/src/pages/admin/RosterPage.tsx
@@ -7,8 +7,9 @@ import { useState, useEffect } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useRoomRoster } from '@/hooks/useRoomRoster';
 import { RosterList } from '@/components/admin/roster/RosterList';
-import { Button, Card } from '@/components/ui';
+import { Button, Card, EmptyState, ErrorState } from '@/components/ui';
 import { LocationPicker } from '@/components/LocationPicker';
+import { getErrorMessage } from '@/lib/errorMessages';
 import * as referenceApi from '@/services/api/reference';
 import { STORAGE_KEYS } from '@/lib/storageKeys';
 
@@ -120,12 +121,15 @@ export function RosterPage() {
 
       {/* Error state */}
       {error && (
-        <Card className="p-6 bg-red-50 border border-red-200" data-testid="roster-error">
-          <p className="text-red-700 font-medium">Failed to load roster</p>
-          <p className="text-red-600 text-sm mt-1">
-            {error instanceof Error ? error.message : 'An unknown error occurred'}
-          </p>
-        </Card>
+        <div data-testid="roster-error">
+          <Card>
+            <ErrorState
+              title="Failed to load roster"
+              message={getErrorMessage(error).message}
+              onRetry={() => refetch()}
+            />
+          </Card>
+        </div>
       )}
 
       {/* Roster display */}
@@ -135,22 +139,11 @@ export function RosterPage() {
 
       {/* Empty state */}
       {!selectedLocationIdKey && (
-        <Card className="p-12 text-center">
-          <svg
-            className="w-16 h-16 text-gray-400 mx-auto mb-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-            />
-          </svg>
-          <p className="text-gray-600">Select a room to view the roster</p>
+        <Card>
+          <EmptyState
+            title="Select a room to view the roster"
+            description="Pick a location above to see who is currently checked in. Toggle auto-refresh to keep the roster live during check-in."
+          />
         </Card>
       )}
     </div>

--- a/src/web/src/pages/admin/groups/GroupsTreePage.tsx
+++ b/src/web/src/pages/admin/groups/GroupsTreePage.tsx
@@ -7,6 +7,8 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useGroups } from '@/hooks/useGroups';
 import { GroupTree } from '@/components/admin/groups/GroupTree';
+import { Loading, EmptyState, ErrorState } from '@/components/ui';
+import { getErrorMessage } from '@/lib/errorMessages';
 
 type ViewMode = 'tree' | 'list';
 
@@ -16,7 +18,7 @@ export function GroupsTreePage() {
   const [searchQuery, setSearchQuery] = useState('');
 
   // Fetch top-level groups (no parent)
-  const { data, isLoading, error } = useGroups({
+  const { data, isLoading, error, refetch } = useGroups({
     q: searchQuery || undefined,
     includeInactive: false,
   });
@@ -118,59 +120,30 @@ export function GroupsTreePage() {
       {/* Content */}
       <div className="bg-white rounded-lg border border-gray-200">
         {isLoading ? (
-          <div className="p-12 text-center">
-            <div className="inline-block w-8 h-8 border-4 border-gray-200 border-t-primary-600 rounded-full animate-spin" />
-            <p className="mt-4 text-gray-500">Loading groups...</p>
-          </div>
+          <Loading text="Loading groups..." />
         ) : error ? (
-          <div className="p-12 text-center">
-            <svg
-              className="w-12 h-12 text-red-400 mx-auto mb-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            <p className="text-red-600">Failed to load groups</p>
-            <p className="text-sm text-gray-500 mt-2">
-              {error instanceof Error ? error.message : 'Unknown error'}
-            </p>
-          </div>
+          <ErrorState
+            title="Failed to load groups"
+            message={getErrorMessage(error).message}
+            onRetry={() => refetch()}
+          />
         ) : groups.length === 0 ? (
-          <div className="p-12 text-center">
-            <svg
-              className="w-12 h-12 text-gray-400 mx-auto mb-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 4.354a4 4 0 110 5.292M15 21H3v-1a6 6 0 0112 0v1zm0 0h6v-1a6 6 0 00-9-5.197M13 7a4 4 0 11-8 0 4 4 0 018 0z"
-              />
-            </svg>
-            <p className="text-gray-500">
-              {searchQuery ? 'No groups found matching your search' : 'No groups yet'}
-            </p>
-            {!searchQuery && (
-              <Link
-                to="/admin/groups/new"
-                className="inline-block mt-4 px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
-              >
-                Create your first group
-              </Link>
-            )}
-          </div>
+          <EmptyState
+            title={searchQuery ? 'No groups found' : 'No groups yet'}
+            description={
+              searchQuery
+                ? 'Try adjusting your search or create a new group.'
+                : 'Organize your ministry by creating groups for classes, teams, or serving areas.'
+            }
+            action={
+              !searchQuery
+                ? {
+                    label: 'Create your first group',
+                    onClick: () => navigate('/admin/groups/new'),
+                  }
+                : undefined
+            }
+          />
         ) : viewMode === 'tree' ? (
           <div className="p-4">
             {topLevelGroups.map((group) => (

--- a/src/web/src/pages/admin/settings/AuditLogsPage.tsx
+++ b/src/web/src/pages/admin/settings/AuditLogsPage.tsx
@@ -11,6 +11,8 @@ import {
   AuditLogTable,
   AuditLogDetailModal,
 } from '@/components/admin/audit';
+import { ErrorState } from '@/components/ui';
+import { getErrorMessage } from '@/lib/errorMessages';
 import type { AuditLogSearchParams, AuditLogDto } from '@/services/api/types';
 import { ExportFormat } from '@/services/api/types';
 
@@ -23,7 +25,7 @@ export function AuditLogsPage() {
   const [selectedLog, setSelectedLog] = useState<AuditLogDto | null>(null);
 
   // Queries
-  const { data, isLoading, error } = useAuditLogs(filters);
+  const { data, isLoading, error, refetch } = useAuditLogs(filters);
   const exportMutation = useExportAuditLogs();
 
   // Handlers
@@ -136,24 +138,12 @@ export function AuditLogsPage() {
 
       {/* Error State */}
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-          <div className="flex items-center gap-2">
-            <svg
-              className="w-5 h-5 text-red-600"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            <p className="text-sm font-medium text-red-800">Failed to load audit logs</p>
-          </div>
+        <div className="bg-white rounded-lg border border-gray-200">
+          <ErrorState
+            title="Failed to load audit logs"
+            message={getErrorMessage(error).message}
+            onRetry={() => refetch()}
+          />
         </div>
       )}
 

--- a/src/web/src/pages/admin/settings/CampusesPage.tsx
+++ b/src/web/src/pages/admin/settings/CampusesPage.tsx
@@ -7,6 +7,8 @@ import { useState } from 'react';
 import { useCampuses, useDeleteCampus } from '@/hooks/useCampuses';
 import { CampusCard } from '@/components/admin/CampusCard';
 import { CampusEditorModal } from '@/components/admin/CampusEditorModal';
+import { Loading, EmptyState, ErrorState } from '@/components/ui';
+import { getErrorMessage } from '@/lib/errorMessages';
 import type { CampusDto } from '@/services/api/types';
 
 export function CampusesPage() {
@@ -14,7 +16,7 @@ export function CampusesPage() {
   const [editingCampus, setEditingCampus] = useState<CampusDto | null>(null);
   const [isCreating, setIsCreating] = useState(false);
 
-  const { data: campuses = [], isLoading, error } = useCampuses(includeInactive);
+  const { data: campuses = [], isLoading, error, refetch } = useCampuses(includeInactive);
   const deleteMutation = useDeleteCampus();
 
   const handleEdit = (campus: CampusDto) => {
@@ -76,31 +78,19 @@ export function CampusesPage() {
 
       {/* Loading State */}
       {isLoading && (
-        <div className="flex items-center justify-center py-12">
-          <div className="inline-block w-8 h-8 border-4 border-gray-200 border-t-primary-600 rounded-full animate-spin" />
+        <div className="bg-white rounded-lg border border-gray-200">
+          <Loading text="Loading campuses..." />
         </div>
       )}
 
       {/* Error State */}
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-          <div className="flex items-center gap-2">
-            <svg
-              className="w-5 h-5 text-red-600"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            <p className="text-sm font-medium text-red-800">Failed to load campuses</p>
-          </div>
+        <div className="bg-white rounded-lg border border-gray-200">
+          <ErrorState
+            title="Failed to load campuses"
+            message={getErrorMessage(error).message}
+            onRetry={() => refetch()}
+          />
         </div>
       )}
 
@@ -108,28 +98,15 @@ export function CampusesPage() {
       {!isLoading && !error && (
         <div className="space-y-4">
           {campuses.length === 0 ? (
-            <div className="bg-white rounded-lg border border-gray-200 p-12 text-center">
-              <svg
-                className="w-12 h-12 text-gray-400 mx-auto mb-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M19 21V5a2 2 0 00-2-2H7a2 2 0 00-2 2v16m14 0h2m-2 0h-5m-9 0H3m2 0h5M9 7h1m-1 4h1m4-4h1m-1 4h1m-5 10v-5a1 1 0 011-1h2a1 1 0 011 1v5m-4 0h4"
-                />
-              </svg>
-              <p className="text-gray-500 mb-4">No campuses found</p>
-              <button
-                onClick={handleCreate}
-                className="inline-block px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
-              >
-                Create First Campus
-              </button>
+            <div className="bg-white rounded-lg border border-gray-200">
+              <EmptyState
+                title="No campuses yet"
+                description="Campuses represent physical or virtual locations where your ministry meets. Create one to organize people and events."
+                action={{
+                  label: 'Create First Campus',
+                  onClick: handleCreate,
+                }}
+              />
             </div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/web/src/pages/admin/settings/DefinedTypesPage.tsx
+++ b/src/web/src/pages/admin/settings/DefinedTypesPage.tsx
@@ -16,6 +16,8 @@ import {
   useReorderDefinedValues,
 } from '@/features/admin/defined-types';
 import type { DefinedTypeSummary, DefinedValueDto } from '@/features/admin/defined-types';
+import { Loading, EmptyState, ErrorState } from '@/components/ui';
+import { getErrorMessage } from '@/lib/errorMessages';
 import type { IdKey } from '@/services/api/types';
 
 // ============================================================================
@@ -527,7 +529,7 @@ function DefinedTypeRow({ type, isExpanded, onToggle }: DefinedTypeRowProps) {
 export function DefinedTypesPage() {
   const [expandedIdKey, setExpandedIdKey] = useState<IdKey | null>(null);
 
-  const { data: definedTypes = [], isLoading, error } = useDefinedTypes();
+  const { data: definedTypes = [], isLoading, error, refetch } = useDefinedTypes();
 
   const handleToggle = (idKey: IdKey) => {
     setExpandedIdKey((prev) => (prev === idKey ? null : idKey));
@@ -557,52 +559,29 @@ export function DefinedTypesPage() {
 
       {/* Loading State */}
       {isLoading && (
-        <div className="flex items-center justify-center py-12">
-          <div className="inline-block w-8 h-8 border-4 border-gray-200 border-t-primary-600 rounded-full animate-spin" />
+        <div className="bg-white rounded-lg border border-gray-200">
+          <Loading text="Loading defined types..." />
         </div>
       )}
 
       {/* Error State */}
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-          <div className="flex items-center gap-2">
-            <svg
-              className="w-5 h-5 text-red-600 flex-shrink-0"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            <p className="text-sm font-medium text-red-800">Failed to load defined types</p>
-          </div>
+        <div className="bg-white rounded-lg border border-gray-200">
+          <ErrorState
+            title="Failed to load defined types"
+            message={getErrorMessage(error).message}
+            onRetry={() => refetch()}
+          />
         </div>
       )}
 
       {/* Empty State */}
       {!isLoading && !error && definedTypes.length === 0 && (
-        <div className="bg-white rounded-lg border border-gray-200 p-12 text-center">
-          <svg
-            className="w-12 h-12 text-gray-400 mx-auto mb-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M4 6h16M4 10h16M4 14h16M4 18h16"
-            />
-          </svg>
-          <p className="text-gray-500">No defined types found</p>
+        <div className="bg-white rounded-lg border border-gray-200">
+          <EmptyState
+            title="No defined types configured"
+            description="Defined types power dropdown lists throughout the system (e.g., phone types, connection statuses). These are typically seeded on install."
+          />
         </div>
       )}
 

--- a/src/web/src/pages/admin/settings/FundsPage.tsx
+++ b/src/web/src/pages/admin/settings/FundsPage.tsx
@@ -5,6 +5,8 @@
 
 import { useState } from 'react';
 import { useAdminFunds, useCreateFund, useUpdateFund, useDeactivateFund } from '@/hooks/useGiving';
+import { Loading, EmptyState, ErrorState } from '@/components/ui';
+import { getErrorMessage } from '@/lib/errorMessages';
 import type { FundAdminDto, CreateFundRequest, UpdateFundRequest } from '@/types/giving';
 
 // ============================================================================
@@ -311,7 +313,7 @@ export function FundsPage() {
   const [isCreating, setIsCreating] = useState(false);
   const [editingFund, setEditingFund] = useState<FundAdminDto | null>(null);
 
-  const { data: funds = [], isLoading, error } = useAdminFunds();
+  const { data: funds = [], isLoading, error, refetch } = useAdminFunds();
   const deactivateMutation = useDeactivateFund();
 
   const handleEdit = (fund: FundAdminDto) => {
@@ -356,31 +358,19 @@ export function FundsPage() {
 
       {/* Loading */}
       {isLoading && (
-        <div className="flex items-center justify-center py-12">
-          <div className="inline-block w-8 h-8 border-4 border-gray-200 border-t-primary-600 rounded-full animate-spin" />
+        <div className="bg-white rounded-lg border border-gray-200">
+          <Loading text="Loading funds..." />
         </div>
       )}
 
       {/* Error */}
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-          <div className="flex items-center gap-2">
-            <svg
-              className="w-5 h-5 text-red-600"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            <p className="text-sm font-medium text-red-800">Failed to load funds</p>
-          </div>
+        <div className="bg-white rounded-lg border border-gray-200">
+          <ErrorState
+            title="Failed to load funds"
+            message={getErrorMessage(error).message}
+            onRetry={() => refetch()}
+          />
         </div>
       )}
 
@@ -388,29 +378,15 @@ export function FundsPage() {
       {!isLoading && !error && (
         <div data-testid="fund-list" className="space-y-3">
           {funds.length === 0 ? (
-            <div className="bg-white rounded-lg border border-gray-200 p-12 text-center">
-              <svg
-                className="w-12 h-12 text-gray-400 mx-auto mb-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                />
-              </svg>
-              <p className="text-gray-500 mb-4">No funds found</p>
-              <button
-                type="button"
-                onClick={() => setIsCreating(true)}
-                className="inline-block px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
-              >
-                Create First Fund
-              </button>
+            <div className="bg-white rounded-lg border border-gray-200">
+              <EmptyState
+                title="No funds yet"
+                description="Funds categorize contributions (e.g., General, Missions, Building). Create your first fund to start tracking giving."
+                action={{
+                  label: 'Create First Fund',
+                  onClick: () => setIsCreating(true),
+                }}
+              />
             </div>
           ) : (
             funds.map((fund) => (

--- a/src/web/src/pages/admin/settings/GroupTypesPage.tsx
+++ b/src/web/src/pages/admin/settings/GroupTypesPage.tsx
@@ -8,6 +8,8 @@ import { useGroupTypes, useArchiveGroupType } from '@/hooks/useGroupTypes';
 import { GroupTypeCard } from '@/components/admin/GroupTypeCard';
 import { GroupTypeEditorModal } from '@/components/admin/GroupTypeEditorModal';
 import { GroupTypeGroupsModal } from '@/components/admin/GroupTypeGroupsModal';
+import { Loading, EmptyState, ErrorState } from '@/components/ui';
+import { getErrorMessage } from '@/lib/errorMessages';
 import type { GroupTypeAdminDto } from '@/services/api/types';
 
 export function GroupTypesPage() {
@@ -17,7 +19,7 @@ export function GroupTypesPage() {
   const [viewingGroupsFor, setViewingGroupsFor] = useState<GroupTypeAdminDto | null>(null);
   const [archivingId, setArchivingId] = useState<string | null>(null);
 
-  const { data: groupTypes = [], isLoading, error } = useGroupTypes(includeArchived);
+  const { data: groupTypes = [], isLoading, error, refetch } = useGroupTypes(includeArchived);
   const archiveMutation = useArchiveGroupType();
 
   const handleEdit = (groupType: GroupTypeAdminDto) => {
@@ -90,31 +92,19 @@ export function GroupTypesPage() {
 
       {/* Loading State */}
       {isLoading && (
-        <div className="flex items-center justify-center py-12">
-          <div className="inline-block w-8 h-8 border-4 border-gray-200 border-t-primary-600 rounded-full animate-spin" />
+        <div className="bg-white rounded-lg border border-gray-200">
+          <Loading text="Loading group types..." />
         </div>
       )}
 
       {/* Error State */}
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-          <div className="flex items-center gap-2">
-            <svg
-              className="w-5 h-5 text-red-600"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            <p className="text-sm font-medium text-red-800">Failed to load group types</p>
-          </div>
+        <div className="bg-white rounded-lg border border-gray-200">
+          <ErrorState
+            title="Failed to load group types"
+            message={getErrorMessage(error).message}
+            onRetry={() => refetch()}
+          />
         </div>
       )}
 
@@ -122,28 +112,15 @@ export function GroupTypesPage() {
       {!isLoading && !error && (
         <div className="space-y-4">
           {groupTypes.length === 0 ? (
-            <div className="bg-white rounded-lg border border-gray-200 p-12 text-center">
-              <svg
-                className="w-12 h-12 text-gray-400 mx-auto mb-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                />
-              </svg>
-              <p className="text-gray-500 mb-4">No group types found</p>
-              <button
-                onClick={handleCreate}
-                className="inline-block px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
-              >
-                Create First Group Type
-              </button>
+            <div className="bg-white rounded-lg border border-gray-200">
+              <EmptyState
+                title="No group types yet"
+                description="Group types define the default settings and behavior for groups (e.g., Small Group, Serving Team, Class). Create one to organize your groups."
+                action={{
+                  label: 'Create First Group Type',
+                  onClick: handleCreate,
+                }}
+              />
             </div>
           ) : (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/src/web/src/pages/admin/settings/LocationsPage.tsx
+++ b/src/web/src/pages/admin/settings/LocationsPage.tsx
@@ -8,6 +8,8 @@ import { useLocationTree, useDeleteLocation } from '@/hooks/useLocations';
 import { useCampuses } from '@/hooks/useCampuses';
 import { LocationTreeNode } from '@/components/admin/LocationTreeNode';
 import { LocationEditorModal } from '@/components/admin/LocationEditorModal';
+import { Loading, EmptyState, ErrorState } from '@/components/ui';
+import { getErrorMessage as getFriendlyErrorMessage } from '@/lib/errorMessages';
 import type { LocationDto } from '@/types/location';
 
 export function LocationsPage() {
@@ -29,6 +31,7 @@ export function LocationsPage() {
     data: locationTree = [],
     isLoading,
     error,
+    refetch,
   } = useLocationTree({
     campusIdKey: selectedCampusIdKey || undefined,
     includeInactive,
@@ -82,17 +85,6 @@ export function LocationsPage() {
   const handleCloseDeleteConfirm = () => {
     setIsDeleteConfirmOpen(false);
     setLocationToDelete(undefined);
-  };
-
-  // Helper to extract user-friendly error messages
-  const getErrorMessage = (err: unknown): string => {
-    if (err instanceof Error) {
-      return err.message;
-    }
-    if (typeof err === 'object' && err !== null && 'message' in err) {
-      return String((err as { message: unknown }).message);
-    }
-    return 'An unexpected error occurred. Please try again.';
   };
 
   // Find location name for delete confirmation
@@ -168,31 +160,19 @@ export function LocationsPage() {
 
       {/* Loading State */}
       {isLoading && (
-        <div className="flex items-center justify-center py-12">
-          <div className="inline-block w-8 h-8 border-4 border-gray-200 border-t-primary-600 rounded-full animate-spin" />
+        <div className="bg-white rounded-lg border border-gray-200">
+          <Loading text="Loading locations..." />
         </div>
       )}
 
       {/* Error State */}
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4" role="alert">
-          <div className="flex items-center gap-2">
-            <svg
-              className="w-5 h-5 text-red-600"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            <p className="text-sm font-medium text-red-800">{getErrorMessage(error)}</p>
-          </div>
+        <div className="bg-white rounded-lg border border-gray-200">
+          <ErrorState
+            title="Failed to load locations"
+            message={getFriendlyErrorMessage(error).message}
+            onRetry={() => refetch()}
+          />
         </div>
       )}
 
@@ -200,39 +180,22 @@ export function LocationsPage() {
       {!isLoading && !error && (
         <div className="bg-white rounded-lg border border-gray-200">
           {locationTree.length === 0 ? (
-            <div className="p-12 text-center">
-              <svg
-                className="w-12 h-12 text-gray-400 mx-auto mb-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden="true"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-              </svg>
-              <p className="text-gray-500 mb-4">
-                {selectedCampusIdKey || !includeInactive
-                  ? 'No locations found with current filters'
-                  : 'No locations found'}
-              </p>
-              <button
-                onClick={handleAddLocation}
-                className="inline-block px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
-              >
-                Add First Location
-              </button>
-            </div>
+            <EmptyState
+              title={
+                selectedCampusIdKey || !includeInactive
+                  ? 'No locations match these filters'
+                  : 'No locations yet'
+              }
+              description={
+                selectedCampusIdKey || !includeInactive
+                  ? 'Try clearing the campus filter or including inactive locations.'
+                  : 'Locations organize rooms and spaces used for check-in and events. Create a top-level location to get started.'
+              }
+              action={{
+                label: 'Add First Location',
+                onClick: handleAddLocation,
+              }}
+            />
           ) : (
             <div className="p-2">
               {locationTree.map((location) => (
@@ -286,7 +249,7 @@ export function LocationsPage() {
                 </p>
                 {deleteMutation.error && (
                   <p className="mt-2 text-sm text-red-600" role="alert">
-                    {getErrorMessage(deleteMutation.error)}
+                    {getFriendlyErrorMessage(deleteMutation.error).message}
                   </p>
                 )}
               </div>

--- a/src/web/src/pages/admin/settings/SecurityRolesPage.tsx
+++ b/src/web/src/pages/admin/settings/SecurityRolesPage.tsx
@@ -27,6 +27,8 @@ import {
   useUpdateSecurityRole,
 } from '@/hooks/useSecurityRoles';
 import { peopleApi } from '@/services/api';
+import { Loading, EmptyState, ErrorState } from '@/components/ui';
+import { getErrorMessage } from '@/lib/errorMessages';
 import type {
   RoleSecurityClaimDto,
   SecurityRoleDto,
@@ -55,7 +57,7 @@ function Badge({
 }
 
 export function SecurityRolesPage() {
-  const { data: roles = [], isLoading, error } = useSecurityRoles();
+  const { data: roles = [], isLoading, error, refetch } = useSecurityRoles();
   const [selectedIdKey, setSelectedIdKey] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState(false);
 
@@ -106,22 +108,38 @@ export function SecurityRolesPage() {
       </div>
 
       {isLoading && (
-        <div className="flex items-center justify-center py-12">
-          <div className="inline-block w-8 h-8 border-4 border-gray-200 border-t-primary-600 rounded-full animate-spin" />
+        <div className="bg-white rounded-lg border border-gray-200">
+          <Loading text="Loading security roles..." />
         </div>
       )}
 
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4" role="alert">
-          <p className="text-sm font-medium text-red-800">
-            Failed to load security roles. You may not have the
-            <code className="mx-1 bg-red-100 px-1 rounded">security:manage</code>
-            permission.
-          </p>
+        <div className="bg-white rounded-lg border border-gray-200">
+          <ErrorState
+            title="Failed to load security roles"
+            message={
+              getErrorMessage(error).message +
+              ' You may not have the security:manage permission.'
+            }
+            onRetry={() => refetch()}
+          />
         </div>
       )}
 
-      {!isLoading && !error && (
+      {!isLoading && !error && roles.length === 0 && (
+        <div className="bg-white rounded-lg border border-gray-200">
+          <EmptyState
+            title="No security roles yet"
+            description="Security roles group permissions that can be assigned to people. Create a role (e.g., 'Check-in Staff') and assign claims and members."
+            action={{
+              label: 'Create Role',
+              onClick: () => setIsCreating(true),
+            }}
+          />
+        </div>
+      )}
+
+      {!isLoading && !error && roles.length > 0 && (
         <div
           className="bg-white rounded-lg border border-gray-200 overflow-hidden"
           data-testid="security-roles-list"
@@ -148,13 +166,7 @@ export function SecurityRolesPage() {
               </tr>
             </thead>
             <tbody className="bg-white divide-y divide-gray-200">
-              {roles.length === 0 && (
-                <tr>
-                  <td colSpan={6} className="px-6 py-10 text-center text-gray-500">
-                    No security roles yet. Create one to get started.
-                  </td>
-                </tr>
-              )}
+
               {roles.map((role) => (
                 <tr
                   key={role.idKey}

--- a/src/web/src/pages/communications/CommunicationsPage.tsx
+++ b/src/web/src/pages/communications/CommunicationsPage.tsx
@@ -8,6 +8,8 @@ import { Link } from 'react-router-dom';
 import { useCommunications } from '@/hooks/useCommunications';
 import { useGroups } from '@/hooks/useGroups';
 import { CommunicationComposer } from '@/components/communication/CommunicationComposer';
+import { Loading, EmptyState, ErrorState } from '@/components/ui';
+import { getErrorMessage } from '@/lib/errorMessages';
 import type { CommunicationSummaryDto } from '@/services/api/communications';
 
 const STATUS_OPTIONS = [
@@ -147,7 +149,7 @@ export function CommunicationsPage() {
   const [statusFilter, setStatusFilter] = useState('');
   const [isComposerOpen, setIsComposerOpen] = useState(false);
 
-  const { data: communicationsData, isLoading, error } = useCommunications({
+  const { data: communicationsData, isLoading, error, refetch } = useCommunications({
     status: statusFilter || undefined,
     pageSize: 50,
   });
@@ -212,30 +214,19 @@ export function CommunicationsPage() {
 
       {/* Loading State */}
       {isLoading && (
-        <div className="flex items-center justify-center py-12">
-          <div className="inline-block w-8 h-8 border-4 border-gray-200 border-t-primary-600 rounded-full animate-spin" />
+        <div className="bg-white rounded-lg border border-gray-200">
+          <Loading text="Loading communications..." />
         </div>
       )}
 
       {/* Error State */}
       {error && (
-        <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-          <div className="flex items-center gap-2">
-            <svg
-              className="w-5 h-5 text-red-600"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-            <p className="text-sm font-medium text-red-800">Failed to load communications</p>
-          </div>
+        <div className="bg-white rounded-lg border border-gray-200">
+          <ErrorState
+            title="Failed to load communications"
+            message={getErrorMessage(error).message}
+            onRetry={() => refetch()}
+          />
         </div>
       )}
 
@@ -243,27 +234,19 @@ export function CommunicationsPage() {
       {!isLoading && !error && (
         <div className="space-y-4">
           {communications.length === 0 ? (
-            <div className="bg-white rounded-lg border border-gray-200 p-12 text-center">
-              <svg
-                className="w-12 h-12 text-gray-400 mx-auto mb-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
-                />
-              </svg>
-              <p className="text-gray-500 mb-4">No communications found</p>
-              <button
-                onClick={() => setIsComposerOpen(true)}
-                className="inline-block px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors"
-              >
-                Send First Communication
-              </button>
+            <div className="bg-white rounded-lg border border-gray-200">
+              <EmptyState
+                title="No communications found"
+                description={
+                  statusFilter
+                    ? 'Try selecting a different status filter, or compose a new communication.'
+                    : 'Send targeted emails or SMS to people and groups. Messages you send will appear here.'
+                }
+                action={{
+                  label: statusFilter ? 'Compose New' : 'Send First Communication',
+                  onClick: () => setIsComposerOpen(true),
+                }}
+              />
             </div>
           ) : (
             <div className="space-y-3">


### PR DESCRIPTION
## Summary

Audited every list/admin page that uses TanStack Query. Migrated pages that shipped bespoke inline spinners, red error banners, or bare "No X found" empty states to the existing shared primitives (`Loading`, `EmptyState`, `ErrorState`) from `@/components/ui`, and to the user-friendly error helper (`getErrorMessage`) from `@/lib/errorMessages`. All converted pages now expose a refetch-based **Retry** affordance for network failures and a guidance-oriented empty state instead of a bare label.

Closes UX polish for #502 (the PM will close the issue after independent review).

## AC coverage

1. **Loading state on every list page** — shared `<Loading />` component now used on every list/admin page in scope.
2. **Empty states with guidance (not just "No records")** — every converted page now shows a descriptive title + explanation + optional CTA instead of a bare label.
3. **User-friendly API errors** — `getErrorMessage` in `@/lib/errorMessages` (which handles `ApiClientError` + `ProblemDetails`) is now used for every converted list page's error message; no raw status codes or stack traces are exposed.
4. **Form validation errors display inline** — already consistent. Forms (`PersonFormPage`, `FamilyFormPage`, `BatchFormPage`, `ScheduleFormPage`, etc.) display inline field-level errors via `validationErrors[fieldName]` under each input. **No changes made** per scope guidance.
5. **Network failures show a retry option** — every converted page now passes `refetch` from `useQuery` to `<ErrorState onRetry={...} />`, which renders a "Try Again" button.

## Audit table

| Page | Loading | Empty | Error | Action |
|------|---------|-------|-------|--------|
| `pages/admin/people/PeopleListPage.tsx` | OK | OK | OK | **No-op** — already uses shared primitives + refetch. |
| `pages/admin/families/FamilyListPage.tsx` | OK | OK | OK | **No-op** — already uses shared primitives + refetch. |
| `pages/admin/groups/GroupsTreePage.tsx` | bespoke | bespoke | bespoke | Migrated to shared primitives; added `refetch` retry. |
| `pages/admin/schedules/ScheduleListPage.tsx` | OK | OK | OK | **No-op**. |
| `pages/admin/giving/BatchListPage.tsx` | OK | OK | OK | **No-op**. |
| `pages/admin/giving/StatementsPage.tsx` | OK | OK | OK | **No-op**. |
| `pages/admin/settings/CampusesPage.tsx` | bespoke | bespoke | bespoke | Migrated; added retry + guidance. |
| `pages/admin/settings/LocationsPage.tsx` | bespoke | bespoke | bespoke | Migrated; removed duplicated local error helper; added retry. |
| `pages/admin/settings/FundsPage.tsx` | bespoke | bespoke | bespoke | Migrated; added retry. |
| `pages/admin/settings/GroupTypesPage.tsx` | bespoke | bespoke | bespoke | Migrated; added retry. |
| `pages/admin/settings/DefinedTypesPage.tsx` | bespoke | bespoke | bespoke | Migrated; added retry. |
| `pages/admin/settings/AuditLogsPage.tsx` | delegated to `<AuditLogTable>` | delegated | bespoke top-level banner | Migrated error banner to `<ErrorState>` with retry. Table's own empty/loading unchanged. |
| `pages/admin/settings/SecurityRolesPage.tsx` | bespoke | inline "No security roles yet" row | bespoke | Migrated; empty state now guides the user + offers a Create action. Preserved `data-testid="security-roles-list"` on the rendered table. |
| `pages/admin/settings/ImportSettingsPage.tsx` | n/a | n/a | n/a | **No-op** — static CTA page, no list query. |
| `pages/admin/import/ImportHistoryPage.tsx` | OK | OK | OK | **No-op**. |
| `features/admin/DataExportsPage.tsx` | OK | OK | OK | **No-op**. |
| `pages/admin/RosterPage.tsx` | delegated to `<RosterList>` | bespoke (select-a-room hint) | bespoke red card | Migrated empty + error to shared primitives; added retry. Preserved `data-testid="roster-error"` wrapper. |
| `pages/admin/people/DuplicateReviewPage.tsx` | OK | OK | OK | **No-op**. |
| `pages/admin/people/MergeHistoryPage.tsx` | OK | OK | OK | **No-op**. |
| `pages/admin/checkin/CheckinAreasTab.tsx` | OK | OK | OK | **No-op**. |
| `pages/admin/checkin/CheckinLocationsTab.tsx` | OK | OK | OK | **No-op**. |
| `pages/admin/checkin/CheckinDevicesTab.tsx` | OK | OK | OK | **No-op**. |
| `pages/communications/CommunicationsPage.tsx` | bespoke | bespoke | bespoke | Migrated; preserved exact empty-state text `"No communications found"` because `feat-490-feat-comms-end-to-end-email-co.spec.ts` asserts on it. |
| `pages/communications/TemplatesPage.tsx` | OK | OK | OK | **No-op**. |
| `pages/MyGroupsPage.tsx` | bespoke full-screen | bespoke | bespoke (reload button) | Migrated; retry now uses `refetch()` instead of full page reload. |

## Shared primitives (already existed, no changes)

- `src/web/src/components/ui/Loading.tsx`
- `src/web/src/components/ui/EmptyState.tsx`
- `src/web/src/components/ui/ErrorState.tsx`
- `src/web/src/lib/errorMessages.ts` — unwraps `ApiClientError` / `ProblemDetails` / network errors into a friendly `{ title, message, variant }` triple; never exposes stack traces or raw status codes.

No new primitives were added. No changes to `@/components/ui/`, the error helper, or the API client.

## Files modified

- `src/web/src/pages/MyGroupsPage.tsx`
- `src/web/src/pages/admin/RosterPage.tsx`
- `src/web/src/pages/admin/groups/GroupsTreePage.tsx`
- `src/web/src/pages/admin/settings/AuditLogsPage.tsx`
- `src/web/src/pages/admin/settings/CampusesPage.tsx`
- `src/web/src/pages/admin/settings/DefinedTypesPage.tsx`
- `src/web/src/pages/admin/settings/FundsPage.tsx`
- `src/web/src/pages/admin/settings/GroupTypesPage.tsx`
- `src/web/src/pages/admin/settings/LocationsPage.tsx`
- `src/web/src/pages/admin/settings/SecurityRolesPage.tsx`
- `src/web/src/pages/communications/CommunicationsPage.tsx`

Net diff: **+220 / -414 LOC** (11 files). Every change is a net reduction in bespoke code.

## Guardrails observed

- No backend changes (`dotnet build` clean; backend tests still pass under pre-push hook: 218 / 312 / 55 / 727 passed).
- No E2E spec edits. `CommunicationsPage` empty-state text preserved exactly (`"No communications found"`) because `feat-490` asserts on it.
- `data-testid` attributes preserved on touched pages (`security-roles-list`, `security-roles-create`, `security-role-row`, `roster-error`, `roster-list`, `funds-page`, `fund-list`, `create-fund-btn`).
- No graph baseline or route definition changes.

## Test plan

- [x] `cd src/web && npx tsc --noEmit` — 0 errors.
- [x] `cd src/web && npm run lint` — 0 warnings.
- [x] `dotnet build src/koinon-rms.sln` — 0 warnings, 0 errors.
- [x] Pre-push hook ran full backend test suite: Domain (218), Api (312), ContractTests (55), Infrastructure, Application (727) — all passed.
- [ ] **Playwright E2E not executed in this run** — the demo-box API on `localhost:5000` was not responding at verification time. The changes are selector-preserving (`data-testid`s intact) and the one E2E text assertion on a touched page (`"No communications found"` in `feat-490`) was preserved verbatim. Please trigger CI to confirm.
- [ ] **Manual spot-check recommended**: log in as `john.smith@example.com` / `admin123` and visit a handful of the converted pages (Campuses, Funds, Groups, My Groups) to verify the polished empty-state copy reads well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)