### PR TITLE
fix(auth): HttpContextUserContext reads correct JWT claim (#668)

### DIFF
--- a/src/Koinon.Api/Services/HttpContextUserContext.cs
+++ b/src/Koinon.Api/Services/HttpContextUserContext.cs
@@ -16,7 +16,15 @@ public class HttpContextUserContext(IHttpContextAccessor httpContextAccessor) : 
     {
         get
         {
-            var claim = httpContextAccessor.HttpContext?.User.FindFirst(PersonIdClaimType);
+            // Prefer the standard ClaimTypes.NameIdentifier claim, which the JWT
+            // handler always surfaces (mapped from the JWT "sub"/"nameid" token
+            // claim regardless of MapInboundClaims). Fall back to the custom
+            // "person_id" claim that AuthService also emits. This makes the
+            // lookup resilient to JWT handler inbound-claim-map configuration
+            // changes. See issue #668.
+            var user = httpContextAccessor.HttpContext?.User;
+            var claim = user?.FindFirst(ClaimTypes.NameIdentifier)
+                ?? user?.FindFirst(PersonIdClaimType);
             return claim != null && int.TryParse(claim.Value, out var personId)
                 ? personId
                 : null;

--- a/src/web/e2e/tests/feat-497-security-roles-admin.spec.ts
+++ b/src/web/e2e/tests/feat-497-security-roles-admin.spec.ts
@@ -96,19 +96,6 @@ async function openSecurityRoleDetail(page: Page, roleName: string): Promise<voi
 // token mid-test.
 test.describe.serial('feat(#497) Security role and permissions management UI', () => {
   test.beforeEach(async ({ page }) => {
-    // The notifications/unread-count endpoint is broken in the demo app
-    // (pre-existing bug unrelated to #497 — it uses a JWT claim name the
-    // AuthService does not emit). Its 401 response triggers the web client's
-    // token-refresh logic repeatedly, which can invalidate the admin session
-    // mid-test. Stub it to an empty success response so the page can
-    // authenticate normally for admin operations.
-    await page.route('**/api/v1/notifications/**', (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ data: { count: 0 } }),
-      }),
-    );
     await loginAsAdmin(page);
   });
 

--- a/tests/Koinon.Api.Tests/Services/HttpContextUserContextTests.cs
+++ b/tests/Koinon.Api.Tests/Services/HttpContextUserContextTests.cs
@@ -1,0 +1,114 @@
+using System.Security.Claims;
+using FluentAssertions;
+using Koinon.Api.Services;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace Koinon.Api.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="HttpContextUserContext"/>.
+/// Focuses on the #668 regression: CurrentPersonId must resolve whether the JWT
+/// handler surfaces the person identifier as ClaimTypes.NameIdentifier (the
+/// standard, always-mapped claim) or the custom "person_id" claim.
+/// </summary>
+public class HttpContextUserContextTests
+{
+    private static HttpContextUserContext CreateSut(params Claim[] claims)
+    {
+        var identity = new ClaimsIdentity(claims, authenticationType: "TestJwt");
+        var principal = new ClaimsPrincipal(identity);
+        var httpContext = new DefaultHttpContext { User = principal };
+        var accessor = new Mock<IHttpContextAccessor>();
+        accessor.Setup(a => a.HttpContext).Returns(httpContext);
+        return new HttpContextUserContext(accessor.Object);
+    }
+
+    [Fact]
+    public void CurrentPersonId_WithNameIdentifierClaim_ReturnsPersonId()
+    {
+        // Arrange: only the standard NameIdentifier claim is present (the case
+        // when the JWT handler's inbound claim map rewrites "sub"/"nameid" and
+        // the custom "person_id" claim is missing or dropped).
+        var sut = CreateSut(new Claim(ClaimTypes.NameIdentifier, "42"));
+
+        // Act
+        var result = sut.CurrentPersonId;
+
+        // Assert
+        result.Should().Be(42);
+    }
+
+    [Fact]
+    public void CurrentPersonId_WithPersonIdClaimOnly_ReturnsPersonId()
+    {
+        // Arrange: only the custom "person_id" claim is present (the case when
+        // MapInboundClaims is disabled and NameIdentifier is not produced).
+        var sut = CreateSut(new Claim("person_id", "99"));
+
+        // Act
+        var result = sut.CurrentPersonId;
+
+        // Assert
+        result.Should().Be(99);
+    }
+
+    [Fact]
+    public void CurrentPersonId_WithBothClaims_PrefersNameIdentifier()
+    {
+        // Arrange: AuthService emits both claims with the same value. Either
+        // would be correct, but NameIdentifier is the canonical source.
+        var sut = CreateSut(
+            new Claim(ClaimTypes.NameIdentifier, "7"),
+            new Claim("person_id", "7"));
+
+        // Act
+        var result = sut.CurrentPersonId;
+
+        // Assert
+        result.Should().Be(7);
+    }
+
+    [Fact]
+    public void CurrentPersonId_WithNoRelevantClaims_ReturnsNull()
+    {
+        // Arrange
+        var sut = CreateSut(new Claim(ClaimTypes.Email, "a@b.c"));
+
+        // Act
+        var result = sut.CurrentPersonId;
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void CurrentPersonId_WithNonNumericNameIdentifier_ReturnsNull()
+    {
+        // Arrange: defensive — if the claim contains a non-integer value the
+        // accessor must return null rather than throw.
+        var sut = CreateSut(new Claim(ClaimTypes.NameIdentifier, "not-a-number"));
+
+        // Act
+        var result = sut.CurrentPersonId;
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void CurrentPersonId_WithNullHttpContext_ReturnsNull()
+    {
+        // Arrange
+        var accessor = new Mock<IHttpContextAccessor>();
+        accessor.Setup(a => a.HttpContext).Returns((HttpContext?)null);
+        var sut = new HttpContextUserContext(accessor.Object);
+
+        // Act
+        var result = sut.CurrentPersonId;
+
+        // Assert
+        result.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary
Hardens `HttpContextUserContext.CurrentPersonId` to prefer `ClaimTypes.NameIdentifier` with `"person_id"` as fallback. Adds 6 xUnit tests. Removes the `**/api/v1/notifications/**` stub from the feat-497 E2E spec (spec remains 5/5 green without it).

## Reviewer finding (correcting the original PR narrative)
The independent reviewer determined the old code (`user.FindFirst("person_id")`) is NOT actually broken for any JWT this system emits — `AuthService.GenerateAccessTokenAsync` adds both `ClaimTypes.NameIdentifier` and the custom `"person_id"` claim, and both survive the default `MapInboundClaims=true` JWT handler. The 401 originally reported in issue #668 was almost certainly a stale/expired admin token during the #497 E2E run, NOT a claim-name mismatch.

**Therefore this PR is defensive hardening, not a corrective fix.** It's still worth landing because (a) it codifies the contract in unit tests, (b) it removes the notifications stub that was masking an unknown cause, (c) `ClaimTypes.NameIdentifier` is the more idiomatic first lookup.

## Files
- `src/Koinon.Api/Services/HttpContextUserContext.cs` — read NameIdentifier first, fallback to `person_id`.
- `tests/Koinon.Api.Tests/Services/HttpContextUserContextTests.cs` — new, 6 tests covering both claim paths + negative cases.
- `src/web/e2e/tests/feat-497-security-roles-admin.spec.ts` — remove the notifications stub (13 lines).

## Verification
- `dotnet build` — 0 errors.
- `dotnet test tests/Koinon.Api.Tests` — 323/323 pass.
- `npx playwright test e2e/tests/feat-497-security-roles-admin.spec.ts --project=chromium` — 5/5 pass without the stub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)