### PR TITLE
test(frontend): wave 2 — contexts + UI primitives + data components (#498)

### DIFF
--- a/src/web/src/components/__tests__/ErrorBoundary.test.tsx
+++ b/src/web/src/components/__tests__/ErrorBoundary.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * ErrorBoundary tests
+ *
+ * Catches:
+ *  - Renders children when no error (happy path).
+ *  - Fallback UI shows when a child throws.
+ *  - Custom fallback prop replaces default UI.
+ *  - handleReset clears error state so subsequent children render.
+ *  - captureError (error tracking) is called on errors.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ErrorBoundary } from '../ErrorBoundary';
+
+vi.mock('../../services/errorTracking', () => ({
+  captureError: vi.fn(),
+}));
+import * as errorTracking from '../../services/errorTracking';
+
+function BoomComponent({ shouldThrow }: { shouldThrow: boolean }) {
+  if (shouldThrow) throw new Error('kaboom');
+  return <div>no boom</div>;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ErrorBoundary', () => {
+  it('renders children when no error', () => {
+    render(
+      <ErrorBoundary>
+        <BoomComponent shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByText('no boom')).toBeInTheDocument();
+  });
+
+  it('shows the default fallback UI when a child throws', () => {
+    // Silence the expected React error logs.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(
+      <ErrorBoundary>
+        <BoomComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /go home/i })).toBeInTheDocument();
+    spy.mockRestore();
+  });
+
+  it('reports the error to the error tracking service', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary>
+        <BoomComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(errorTracking.captureError).toHaveBeenCalled();
+    const [err] = (errorTracking.captureError as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect((err as Error).message).toBe('kaboom');
+    spy.mockRestore();
+  });
+
+  it('renders a custom fallback when the prop is provided', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(
+      <ErrorBoundary fallback={<div data-testid="custom-fallback">custom</div>}>
+        <BoomComponent shouldThrow />
+      </ErrorBoundary>,
+    );
+    expect(screen.getByTestId('custom-fallback')).toBeInTheDocument();
+    // Default UI strings should not be visible.
+    expect(screen.queryByText('Something went wrong')).toBeNull();
+    spy.mockRestore();
+  });
+
+  it('resets error state when Try Again is clicked', async () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const user = userEvent.setup();
+
+    // Use a wrapper that toggles off thrown on reset.
+    function App() {
+      return (
+        <ErrorBoundary>
+          <BoomComponent shouldThrow />
+        </ErrorBoundary>
+      );
+    }
+    const { rerender } = render(<App />);
+
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+
+    // After reset, re-render with a safe child: boundary should show it.
+    rerender(
+      <ErrorBoundary>
+        <BoomComponent shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+
+    // Still stuck on the error UI because rerender re-instantiates boundary
+    // with fresh state and clean children.
+    expect(screen.getByText('no boom')).toBeInTheDocument();
+    spy.mockRestore();
+  });
+});

--- a/src/web/src/components/__tests__/LocationPicker.test.tsx
+++ b/src/web/src/components/__tests__/LocationPicker.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * LocationPicker tests
+ *
+ * Catches:
+ *  - Disabled + "Loading locations..." option while the query is loading.
+ *  - Error message renders when the query fails.
+ *  - Option list is built from area.locations, filters inactive, sorts by name.
+ *  - Helper message appears when campus is missing.
+ *  - onChange fires with the selected idKey.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+vi.mock('@/services/api/checkin', () => ({
+  getCheckinConfiguration: vi.fn(),
+}));
+import { getCheckinConfiguration } from '@/services/api/checkin';
+import { LocationPicker } from '../LocationPicker';
+
+function makeClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+}
+
+function wrap(ui: ReactNode, client = makeClient()) {
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+const fakeConfig = {
+  areas: [
+    {
+      locations: [
+        { idKey: 'L2', name: 'Bravo Room', isActive: true, softThreshold: 20 },
+        { idKey: 'L1', name: 'Alpha Room', isActive: true, softThreshold: null },
+        { idKey: 'L3', name: 'Charlie (inactive)', isActive: false, softThreshold: 10 },
+      ],
+    },
+  ],
+};
+
+beforeEach(() => {
+  (getCheckinConfiguration as ReturnType<typeof vi.fn>).mockReset();
+});
+
+describe('LocationPicker', () => {
+  it('renders the campus-required helper when no campus is provided', () => {
+    (getCheckinConfiguration as ReturnType<typeof vi.fn>).mockResolvedValue(fakeConfig);
+    wrap(<LocationPicker value="" onChange={() => {}} />);
+    expect(screen.getByText(/please configure a campus/i)).toBeInTheDocument();
+  });
+
+  it('does not call the API when campusIdKey is absent', () => {
+    (getCheckinConfiguration as ReturnType<typeof vi.fn>).mockResolvedValue(fakeConfig);
+    wrap(<LocationPicker value="" onChange={() => {}} />);
+    expect(getCheckinConfiguration).not.toHaveBeenCalled();
+  });
+
+  it('shows an error message when the query fails', async () => {
+    (getCheckinConfiguration as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('server down'),
+    );
+    wrap(<LocationPicker value="" onChange={() => {}} campusIdKey="CAM1" />);
+    expect(await screen.findByText(/failed to load locations/i)).toBeInTheDocument();
+    expect(screen.getByText(/server down/i)).toBeInTheDocument();
+  });
+
+  it('renders active locations sorted by name and filters out inactive ones', async () => {
+    (getCheckinConfiguration as ReturnType<typeof vi.fn>).mockResolvedValue(fakeConfig);
+    wrap(<LocationPicker value="" onChange={() => {}} campusIdKey="CAM1" />);
+
+    // Wait for the options to be rendered post-fetch.
+    await waitFor(() =>
+      expect(screen.getByRole('option', { name: /alpha room/i })).toBeInTheDocument(),
+    );
+
+    const options = screen.getAllByRole('option');
+    // First option is the placeholder ("Select a room").
+    // Active locations, sorted alphabetically: Alpha, Bravo (capacity label differs).
+    expect(options[1].textContent).toMatch(/alpha/i);
+    expect(options[2].textContent).toMatch(/bravo/i);
+    // Inactive "Charlie" should NOT be rendered.
+    expect(screen.queryByRole('option', { name: /charlie/i })).toBeNull();
+  });
+
+  it('shows capacity in the label when softThreshold is set', async () => {
+    (getCheckinConfiguration as ReturnType<typeof vi.fn>).mockResolvedValue(fakeConfig);
+    wrap(<LocationPicker value="" onChange={() => {}} campusIdKey="CAM1" />);
+    const bravo = await screen.findByRole('option', { name: /bravo room/i });
+    expect(bravo.textContent).toMatch(/capacity.*20/i);
+  });
+
+  it('fires onChange with the selected idKey', async () => {
+    (getCheckinConfiguration as ReturnType<typeof vi.fn>).mockResolvedValue(fakeConfig);
+    const onChange = vi.fn();
+    wrap(<LocationPicker value="" onChange={onChange} campusIdKey="CAM1" />);
+
+    const select = (await screen.findByRole('combobox')) as HTMLSelectElement;
+    // Wait for options to be populated.
+    await waitFor(() =>
+      expect(screen.getByRole('option', { name: /alpha room/i })).toBeInTheDocument(),
+    );
+
+    const user = userEvent.setup();
+    await user.selectOptions(select, 'L2');
+    expect(onChange).toHaveBeenCalledWith('L2');
+  });
+});

--- a/src/web/src/components/admin/__tests__/Breadcrumb.test.tsx
+++ b/src/web/src/components/admin/__tests__/Breadcrumb.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Breadcrumb tests
+ *
+ * Catches:
+ *  - Renders nothing when explicit items has length <= 1.
+ *  - Auto-generates breadcrumbs from the current pathname.
+ *  - Path-label map produces human-friendly labels (catches regression if the
+ *    mapping entries are dropped).
+ *  - Last item is NOT a link; intermediate items ARE links.
+ *  - Home icon link always points to /.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { Breadcrumb } from '../Breadcrumb';
+
+describe('Breadcrumb', () => {
+  it('renders nothing when only one breadcrumb item exists', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/admin']}>
+        <Breadcrumb items={[{ label: 'Admin' }]} />
+      </MemoryRouter>,
+    );
+    expect(container.querySelector('nav')).toBeNull();
+  });
+
+  it('renders nothing when auto-generated pathname has no segments', () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/']}>
+        <Breadcrumb />
+      </MemoryRouter>,
+    );
+    expect(container.querySelector('nav')).toBeNull();
+  });
+
+  it('renders explicit items with the last not linked', () => {
+    render(
+      <MemoryRouter initialEntries={['/admin/people']}>
+        <Breadcrumb
+          items={[
+            { label: 'Admin', path: '/admin' },
+            { label: 'People' },
+          ]}
+        />
+      </MemoryRouter>,
+    );
+    const linked = screen.getByRole('link', { name: 'Admin' });
+    expect(linked).toHaveAttribute('href', '/admin');
+    // The current page "People" renders as a span, not a link.
+    expect(screen.queryByRole('link', { name: 'People' })).toBeNull();
+    expect(screen.getByText('People')).toBeInTheDocument();
+  });
+
+  it('auto-generates breadcrumbs from the current pathname', () => {
+    render(
+      <MemoryRouter initialEntries={['/admin/people']}>
+        <Breadcrumb />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('link', { name: 'Admin' })).toHaveAttribute('href', '/admin');
+    // Last segment is not linked.
+    expect(screen.getByText('People')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'People' })).toBeNull();
+  });
+
+  it('falls back to the raw segment when no label mapping exists', () => {
+    render(
+      <MemoryRouter initialEntries={['/admin/frobnicator']}>
+        <Breadcrumb />
+      </MemoryRouter>,
+    );
+    // "frobnicator" has no mapping → renders as-is.
+    expect(screen.getByText('frobnicator')).toBeInTheDocument();
+  });
+
+  it('always renders the Home link', () => {
+    render(
+      <MemoryRouter initialEntries={['/admin/people']}>
+        <Breadcrumb />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('link', { name: /home/i })).toHaveAttribute('href', '/');
+  });
+});

--- a/src/web/src/components/admin/__tests__/CampusCard.test.tsx
+++ b/src/web/src/components/admin/__tests__/CampusCard.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * CampusCard tests
+ *
+ * Catches:
+ *  - Renders required fields (name) and optional badges (shortCode, Inactive).
+ *  - Omits description/timezone/phone when fields are empty.
+ *  - Edit and Delete buttons fire their callbacks.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { CampusCard } from '../CampusCard';
+import type { CampusDto } from '@/types';
+
+function baseCampus(overrides: Partial<CampusDto> = {}): CampusDto {
+  return {
+    idKey: 'C1',
+    name: 'Main Campus',
+    isActive: true,
+    ...overrides,
+  } as CampusDto;
+}
+
+describe('CampusCard', () => {
+  it('shows the campus name', () => {
+    render(<CampusCard campus={baseCampus()} onEdit={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.getByRole('heading', { name: 'Main Campus' })).toBeInTheDocument();
+  });
+
+  it('shows the short code when provided', () => {
+    render(
+      <CampusCard
+        campus={baseCampus({ shortCode: 'MAIN' })}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('MAIN')).toBeInTheDocument();
+  });
+
+  it('shows the Inactive badge when isActive=false', () => {
+    render(
+      <CampusCard
+        campus={baseCampus({ isActive: false })}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Inactive')).toBeInTheDocument();
+  });
+
+  it('does NOT show the Inactive badge when isActive=true', () => {
+    render(
+      <CampusCard
+        campus={baseCampus({ isActive: true })}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText('Inactive')).toBeNull();
+  });
+
+  it('shows the description when provided', () => {
+    render(
+      <CampusCard
+        campus={baseCampus({ description: 'Primary campus' })}
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Primary campus')).toBeInTheDocument();
+  });
+
+  it('fires onEdit and onDelete when the respective buttons are clicked', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    const onDelete = vi.fn();
+    render(<CampusCard campus={baseCampus()} onEdit={onEdit} onDelete={onDelete} />);
+
+    await user.click(screen.getByTitle('Edit campus'));
+    expect(onEdit).toHaveBeenCalledOnce();
+
+    await user.click(screen.getByTitle('Delete campus'));
+    expect(onDelete).toHaveBeenCalledOnce();
+  });
+});

--- a/src/web/src/components/admin/__tests__/GroupTypeCard.test.tsx
+++ b/src/web/src/components/admin/__tests__/GroupTypeCard.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * GroupTypeCard tests
+ *
+ * Catches:
+ *  - Name always renders; description only when provided.
+ *  - Capability badges appear conditionally (Attendance, Self-Registration, Public).
+ *  - System badge appears only for system groupTypes.
+ *  - groupCount singular / plural term rendering (uses groupTerm/groupMemberTerm).
+ *  - Edit button disabled when isArchived=true.
+ *  - onEdit / onViewGroups fire correct callbacks.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { GroupTypeCard } from '../GroupTypeCard';
+import type { GroupTypeAdminDto } from '@/services/api/types';
+
+function base(overrides: Partial<GroupTypeAdminDto> = {}): GroupTypeAdminDto {
+  return {
+    idKey: 'GT1',
+    guid: '00000000-0000-0000-0000-000000000001',
+    name: 'Small Group',
+    groupTerm: 'Group',
+    groupMemberTerm: 'Member',
+    takesAttendance: false,
+    allowSelfRegistration: false,
+    requiresMemberApproval: false,
+    defaultIsPublic: false,
+    isSystem: false,
+    isArchived: false,
+    order: 0,
+    groupCount: 5,
+    ...overrides,
+  };
+}
+
+describe('GroupTypeCard', () => {
+  it('renders the group type name', () => {
+    render(
+      <GroupTypeCard groupType={base()} onEdit={vi.fn()} onViewGroups={vi.fn()} />,
+    );
+    expect(screen.getByRole('heading', { name: 'Small Group' })).toBeInTheDocument();
+  });
+
+  it('shows the description when provided', () => {
+    render(
+      <GroupTypeCard
+        groupType={base({ description: 'Community groups' })}
+        onEdit={vi.fn()}
+        onViewGroups={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Community groups')).toBeInTheDocument();
+  });
+
+  it('shows capability badges for enabled capabilities', () => {
+    render(
+      <GroupTypeCard
+        groupType={base({
+          takesAttendance: true,
+          allowSelfRegistration: true,
+          defaultIsPublic: true,
+        })}
+        onEdit={vi.fn()}
+        onViewGroups={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Attendance')).toBeInTheDocument();
+    expect(screen.getByText('Self-Registration')).toBeInTheDocument();
+    expect(screen.getByText('Public')).toBeInTheDocument();
+  });
+
+  it('omits capability badges for disabled capabilities', () => {
+    render(
+      <GroupTypeCard groupType={base()} onEdit={vi.fn()} onViewGroups={vi.fn()} />,
+    );
+    expect(screen.queryByText('Attendance')).toBeNull();
+    expect(screen.queryByText('Self-Registration')).toBeNull();
+    expect(screen.queryByText('Public')).toBeNull();
+  });
+
+  it('shows the System badge when isSystem=true', () => {
+    render(
+      <GroupTypeCard
+        groupType={base({ isSystem: true })}
+        onEdit={vi.fn()}
+        onViewGroups={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('System')).toBeInTheDocument();
+  });
+
+  it('uses singular groupTerm when groupCount=1', () => {
+    render(
+      <GroupTypeCard
+        groupType={base({ groupCount: 1, groupTerm: 'Group' })}
+        onEdit={vi.fn()}
+        onViewGroups={vi.fn()}
+      />,
+    );
+    // Button label "1 Group"
+    expect(screen.getByRole('button', { name: '1 Group' })).toBeInTheDocument();
+  });
+
+  it('pluralizes groupTerm when groupCount !== 1', () => {
+    render(
+      <GroupTypeCard
+        groupType={base({ groupCount: 5, groupTerm: 'Group' })}
+        onEdit={vi.fn()}
+        onViewGroups={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: '5 Groups' })).toBeInTheDocument();
+  });
+
+  it('disables Edit when isArchived=true', () => {
+    render(
+      <GroupTypeCard
+        groupType={base({ isArchived: true })}
+        onEdit={vi.fn()}
+        onViewGroups={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeDisabled();
+  });
+
+  it('fires callbacks on button click', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    const onViewGroups = vi.fn();
+    render(
+      <GroupTypeCard
+        groupType={base({ groupCount: 3 })}
+        onEdit={onEdit}
+        onViewGroups={onViewGroups}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /3 groups/i }));
+    expect(onViewGroups).toHaveBeenCalledOnce();
+
+    await user.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(onEdit).toHaveBeenCalledOnce();
+  });
+});

--- a/src/web/src/components/admin/dashboard/__tests__/QuickActions.test.tsx
+++ b/src/web/src/components/admin/dashboard/__tests__/QuickActions.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * QuickActions tests
+ *
+ * Catches:
+ *  - Renders the expected admin quick-action links with correct hrefs
+ *    (regressions would break primary dashboard navigation).
+ *  - Each tile exposes both label and description text.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { QuickActions } from '../QuickActions';
+
+describe('QuickActions', () => {
+  function renderQA() {
+    return render(
+      <MemoryRouter>
+        <QuickActions />
+      </MemoryRouter>,
+    );
+  }
+
+  it('renders the four primary quick actions', () => {
+    renderQA();
+    expect(screen.getByRole('link', { name: /add person/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /create family/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /group directory/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /upcoming events/i })).toBeInTheDocument();
+  });
+
+  it('wires Add Person to /admin/people/new', () => {
+    renderQA();
+    expect(screen.getByRole('link', { name: /add person/i })).toHaveAttribute(
+      'href',
+      '/admin/people/new',
+    );
+  });
+
+  it('wires Create Family to /admin/families/new', () => {
+    renderQA();
+    expect(screen.getByRole('link', { name: /create family/i })).toHaveAttribute(
+      'href',
+      '/admin/families/new',
+    );
+  });
+
+  it('wires Group Directory to /admin/groups', () => {
+    renderQA();
+    expect(screen.getByRole('link', { name: /group directory/i })).toHaveAttribute(
+      'href',
+      '/admin/groups',
+    );
+  });
+
+  it('renders descriptions for each action', () => {
+    renderQA();
+    expect(screen.getByText(/create a new person record/i)).toBeInTheDocument();
+    expect(screen.getByText(/add a new family household/i)).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/admin/dashboard/__tests__/RecentBatches.test.tsx
+++ b/src/web/src/components/admin/dashboard/__tests__/RecentBatches.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * RecentBatches tests
+ *
+ * Catches:
+ *  - Empty state renders "No recent batches" when list is empty.
+ *  - Shows at most 5 batches (regression: dashboards should not render 100+ rows).
+ *  - Status → colour mapping (Open=blue, Pending=yellow, Closed=green).
+ *  - Each row links to the batch detail page using batch.idKey.
+ *  - Currency formatting includes cents.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { RecentBatches } from '../RecentBatches';
+import type { BatchSummary } from '@/types';
+
+function batch(overrides: Partial<BatchSummary> = {}): BatchSummary {
+  return {
+    idKey: 'B1',
+    name: 'Sunday',
+    batchDate: '2026-01-01T00:00:00Z',
+    status: 'Open',
+    total: 1234.56,
+    ...overrides,
+  };
+}
+
+function wrap(ui: React.ReactNode) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('RecentBatches', () => {
+  it('renders the empty state when there are no batches', () => {
+    wrap(<RecentBatches batches={[]} />);
+    expect(screen.getByText(/no recent batches/i)).toBeInTheDocument();
+  });
+
+  it('renders a row per batch (up to 5)', () => {
+    const many: BatchSummary[] = Array.from({ length: 10 }, (_, i) =>
+      batch({ idKey: `B${i}`, name: `Batch ${i}` }),
+    );
+    wrap(<RecentBatches batches={many} />);
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(5);
+  });
+
+  it('links each row to /admin/giving/batches/{idKey}', () => {
+    wrap(<RecentBatches batches={[batch({ idKey: 'XYZ' })]} />);
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      '/admin/giving/batches/XYZ',
+    );
+  });
+
+  it('formats the total as USD with cents', () => {
+    wrap(<RecentBatches batches={[batch({ total: 9.5 })]} />);
+    expect(screen.getByText(/\$9\.50/)).toBeInTheDocument();
+  });
+
+  it('applies Open status → blue styling', () => {
+    wrap(<RecentBatches batches={[batch({ status: 'Open' })]} />);
+    const badge = screen.getByText('Open');
+    expect(badge.className).toMatch(/text-blue-700/);
+  });
+
+  it('applies Pending status → yellow styling', () => {
+    wrap(<RecentBatches batches={[batch({ status: 'Pending' })]} />);
+    expect(screen.getByText('Pending').className).toMatch(/text-yellow-700/);
+  });
+
+  it('applies Closed status → green styling', () => {
+    wrap(<RecentBatches batches={[batch({ status: 'Closed' })]} />);
+    expect(screen.getByText('Closed').className).toMatch(/text-green-700/);
+  });
+});

--- a/src/web/src/components/admin/dashboard/__tests__/RecentCommunications.test.tsx
+++ b/src/web/src/components/admin/dashboard/__tests__/RecentCommunications.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * RecentCommunications tests
+ *
+ * Catches:
+ *  - Empty state renders when the list is empty.
+ *  - Limits display to 5 rows.
+ *  - Links each row to /admin/communications/{idKey}.
+ *  - Type → colour (Email=blue, SMS=green, Push=purple).
+ *  - Status → colour (Draft=gray, Pending=yellow, Sent=green, Failed=red).
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { RecentCommunications } from '../RecentCommunications';
+import type { CommunicationSummary } from '@/types';
+
+function make(overrides: Partial<CommunicationSummary> = {}): CommunicationSummary {
+  return {
+    idKey: 'C1',
+    subject: 'Hello',
+    type: 'Email',
+    status: 'Draft',
+    createdDateTime: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function wrap(ui: React.ReactNode) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('RecentCommunications', () => {
+  it('renders the empty state when there are no communications', () => {
+    wrap(<RecentCommunications communications={[]} />);
+    expect(screen.getByText(/no recent communications/i)).toBeInTheDocument();
+  });
+
+  it('limits the list to at most 5 rows', () => {
+    const many: CommunicationSummary[] = Array.from({ length: 8 }, (_, i) =>
+      make({ idKey: `C${i}`, subject: `Subject ${i}` }),
+    );
+    wrap(<RecentCommunications communications={many} />);
+    expect(screen.getAllByRole('link')).toHaveLength(5);
+  });
+
+  it('links each row to the communication detail page', () => {
+    wrap(<RecentCommunications communications={[make({ idKey: 'ABC' })]} />);
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      '/admin/communications/ABC',
+    );
+  });
+
+  it.each([
+    ['Email', 'text-blue-700'],
+    ['SMS', 'text-green-700'],
+    ['Push', 'text-purple-700'],
+  ] as const)('maps type=%s to %s', (type, cls) => {
+    wrap(<RecentCommunications communications={[make({ type })]} />);
+    expect(screen.getByText(type).className).toMatch(cls);
+  });
+
+  it.each([
+    ['Draft', 'text-gray-700'],
+    ['Pending', 'text-yellow-700'],
+    ['Sent', 'text-green-700'],
+    ['Failed', 'text-red-700'],
+  ] as const)('maps status=%s to %s', (status, cls) => {
+    wrap(<RecentCommunications communications={[make({ status })]} />);
+    expect(screen.getByText(status).className).toMatch(cls);
+  });
+});

--- a/src/web/src/components/admin/dashboard/__tests__/StatCard.test.tsx
+++ b/src/web/src/components/admin/dashboard/__tests__/StatCard.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * StatCard tests
+ *
+ * Catches:
+ *  - Title, value, subtitle rendering.
+ *  - Colour variant maps to bg/text classes.
+ *  - Trend (up/down/neutral) renders the correct icon + colour.
+ *  - trendValue only renders when both trend and trendValue are provided.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { StatCard } from '../StatCard';
+
+function icon() {
+  return <svg data-testid="stat-icon" />;
+}
+
+describe('StatCard', () => {
+  it('renders title, value, and subtitle', () => {
+    render(
+      <StatCard
+        title="Active Members"
+        value={42}
+        subtitle="up from last week"
+        icon={icon()}
+        color="blue"
+      />,
+    );
+    expect(screen.getByText('Active Members')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('up from last week')).toBeInTheDocument();
+  });
+
+  it('applies the blue color classes to the icon container', () => {
+    render(<StatCard title="t" value={1} icon={icon()} color="blue" />);
+    const card = screen.getByTestId('stat-card');
+    // The icon wrapper is a div with bg-blue-50 text-blue-600.
+    expect(card.querySelector('.bg-blue-50')).not.toBeNull();
+  });
+
+  it('applies the green color classes when color="green"', () => {
+    render(<StatCard title="t" value={1} icon={icon()} color="green" />);
+    expect(screen.getByTestId('stat-card').querySelector('.bg-green-50')).not.toBeNull();
+  });
+
+  it('renders the up trend with green colour when trend=up and trendValue is set', () => {
+    render(
+      <StatCard
+        title="t"
+        value={1}
+        icon={icon()}
+        color="blue"
+        trend="up"
+        trendValue="+5%"
+      />,
+    );
+    const trendWrapper = screen.getByText('+5%').parentElement;
+    expect(trendWrapper?.className).toMatch(/text-green-600/);
+  });
+
+  it('renders the down trend with red colour when trend=down', () => {
+    render(
+      <StatCard
+        title="t"
+        value={1}
+        icon={icon()}
+        color="blue"
+        trend="down"
+        trendValue="-3%"
+      />,
+    );
+    const trendWrapper = screen.getByText('-3%').parentElement;
+    expect(trendWrapper?.className).toMatch(/text-red-600/);
+  });
+
+  it('does not render trend info when only trend is set (without trendValue)', () => {
+    const { container } = render(
+      <StatCard title="t" value={1} icon={icon()} color="blue" trend="up" />,
+    );
+    // No element with the trend colour classes should exist.
+    expect(container.querySelectorAll('.text-green-600')).toHaveLength(0);
+  });
+});

--- a/src/web/src/components/admin/dashboard/__tests__/SummaryCards.test.tsx
+++ b/src/web/src/components/admin/dashboard/__tests__/SummaryCards.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * GivingSummaryCard + CommunicationsSummaryCard tests
+ *
+ * Catches:
+ *  - Currency formatting uses USD with no fractional digits
+ *    (regression category: floating-point display artefacts like "$12345.67").
+ *  - Zero values render correctly (fallback safety).
+ *  - Both MTD and YTD totals appear.
+ *  - Communications card renders pending + sent counts.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { GivingSummaryCard } from '../GivingSummaryCard';
+import { CommunicationsSummaryCard } from '../CommunicationsSummaryCard';
+
+describe('GivingSummaryCard', () => {
+  it('renders month-to-date and year-to-date totals as USD currency', () => {
+    render(<GivingSummaryCard monthToDateTotal={12345} yearToDateTotal={98765} />);
+
+    expect(screen.getByText('Month to Date')).toBeInTheDocument();
+    expect(screen.getByText('Year to Date')).toBeInTheDocument();
+    expect(screen.getByText('$12,345')).toBeInTheDocument();
+    expect(screen.getByText('$98,765')).toBeInTheDocument();
+  });
+
+  it('handles zero values', () => {
+    render(<GivingSummaryCard monthToDateTotal={0} yearToDateTotal={0} />);
+    // Two "$0" renders.
+    const zeros = screen.getAllByText('$0');
+    expect(zeros).toHaveLength(2);
+  });
+
+  it('rounds fractional amounts (no decimals shown)', () => {
+    render(<GivingSummaryCard monthToDateTotal={100.49} yearToDateTotal={100.51} />);
+    expect(screen.getByText('$100')).toBeInTheDocument();
+    expect(screen.getByText('$101')).toBeInTheDocument();
+  });
+});
+
+describe('CommunicationsSummaryCard', () => {
+  it('renders pending and sent-this-week counts', () => {
+    render(<CommunicationsSummaryCard pendingCount={3} sentThisWeekCount={12} />);
+
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('Sent This Week')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('handles zero counts', () => {
+    render(<CommunicationsSummaryCard pendingCount={0} sentThisWeekCount={0} />);
+    expect(screen.getAllByText('0')).toHaveLength(2);
+  });
+});

--- a/src/web/src/components/admin/dashboard/__tests__/UpcomingSchedules.test.tsx
+++ b/src/web/src/components/admin/dashboard/__tests__/UpcomingSchedules.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * UpcomingSchedules tests
+ *
+ * Catches:
+ *  - Loading state shows spinner text.
+ *  - Empty state shows "No upcoming schedules".
+ *  - Schedule row links to /admin/schedules/{idKey}.
+ *  - Status text + colour depends on minutesUntilCheckIn:
+ *    * <= 0      → "Open" (green)
+ *    * < 60      → "Opens in N min" (yellow)
+ *    * >= 60     → "Opens in N hr(s)" (gray)
+ *  - Singular vs plural hour label.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { UpcomingSchedules } from '../UpcomingSchedules';
+import type { UpcomingScheduleDto } from '@/types';
+
+function schedule(overrides: Partial<UpcomingScheduleDto> = {}): UpcomingScheduleDto {
+  return {
+    idKey: 'S1',
+    name: 'Sunday Service',
+    nextOccurrence: '2026-04-25T09:00:00Z',
+    minutesUntilCheckIn: 30,
+    ...overrides,
+  };
+}
+
+function wrap(ui: React.ReactNode) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('UpcomingSchedules', () => {
+  it('renders loading state when isLoading=true', () => {
+    wrap(<UpcomingSchedules schedules={[]} isLoading />);
+    expect(screen.getByText(/loading schedules/i)).toBeInTheDocument();
+  });
+
+  it('renders empty state when no schedules', () => {
+    wrap(<UpcomingSchedules schedules={[]} isLoading={false} />);
+    expect(screen.getByText(/no upcoming schedules/i)).toBeInTheDocument();
+  });
+
+  it('shows "Open" in green when minutesUntilCheckIn <= 0', () => {
+    wrap(
+      <UpcomingSchedules
+        isLoading={false}
+        schedules={[schedule({ minutesUntilCheckIn: 0 })]}
+      />,
+    );
+    const badge = screen.getByText('Open');
+    expect(badge.className).toMatch(/text-green-700/);
+  });
+
+  it('shows "Opens in N min" in yellow when < 60 minutes', () => {
+    wrap(
+      <UpcomingSchedules
+        isLoading={false}
+        schedules={[schedule({ minutesUntilCheckIn: 45 })]}
+      />,
+    );
+    const badge = screen.getByText(/opens in 45 min/i);
+    expect(badge.className).toMatch(/text-yellow-700/);
+  });
+
+  it('shows "Opens in 1 hr" (singular) at exactly 60 minutes', () => {
+    wrap(
+      <UpcomingSchedules
+        isLoading={false}
+        schedules={[schedule({ minutesUntilCheckIn: 60 })]}
+      />,
+    );
+    expect(screen.getByText(/opens in 1 hr$/i)).toBeInTheDocument();
+  });
+
+  it('pluralizes "Opens in 2 hrs" at 120 minutes', () => {
+    wrap(
+      <UpcomingSchedules
+        isLoading={false}
+        schedules={[schedule({ minutesUntilCheckIn: 120 })]}
+      />,
+    );
+    expect(screen.getByText(/opens in 2 hrs/i)).toBeInTheDocument();
+  });
+
+  it('links each row to /admin/schedules/{idKey}', () => {
+    wrap(
+      <UpcomingSchedules
+        isLoading={false}
+        schedules={[schedule({ idKey: 'S9' })]}
+      />,
+    );
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/admin/schedules/S9');
+  });
+});

--- a/src/web/src/components/admin/families/__tests__/FamilyMemberCard.test.tsx
+++ b/src/web/src/components/admin/families/__tests__/FamilyMemberCard.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * FamilyMemberCard tests
+ *
+ * Catches:
+ *  - Link target wiring to /admin/people/{idKey}.
+ *  - Avatar falls back to SVG when no photoUrl.
+ *  - Role indicator dot: blue for Adult, green otherwise.
+ *  - `familyRoles` prop renders the textual legend instead of a colour dot.
+ *  - Remove button shows only when readOnly=false AND onRemove is provided.
+ *  - Remove button ARIA label mentions the person's name.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { FamilyMemberCard } from '../FamilyMemberCard';
+import type { FamilyMemberDto } from '@/services/api/types';
+
+function member(
+  overrides: Partial<FamilyMemberDto> & { personOverrides?: Partial<FamilyMemberDto['person']>; roleName?: string } = {},
+): FamilyMemberDto {
+  const { personOverrides, roleName = 'Adult', ...rest } = overrides;
+  return {
+    idKey: 'M1',
+    status: 'Active',
+    person: {
+      idKey: 'PER1',
+      firstName: 'Alice',
+      lastName: 'Smith',
+      fullName: 'Alice Smith',
+      gender: 'Female',
+      ...personOverrides,
+    } as FamilyMemberDto['person'],
+    role: { name: roleName } as FamilyMemberDto['role'],
+    ...rest,
+  };
+}
+
+function wrap(ui: React.ReactNode) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('FamilyMemberCard', () => {
+  it('links the avatar and name to /admin/people/{idKey}', () => {
+    wrap(<FamilyMemberCard member={member({ personOverrides: { idKey: 'XYZ' } })} />);
+    const links = screen.getAllByRole('link');
+    expect(links.length).toBeGreaterThanOrEqual(2);
+    links.forEach((l) => {
+      expect(l).toHaveAttribute('href', '/admin/people/XYZ');
+    });
+  });
+
+  it('renders a blue dot for Adult role', () => {
+    const { container } = wrap(<FamilyMemberCard member={member({ roleName: 'Adult' })} />);
+    expect(container.querySelector('.bg-blue-500')).not.toBeNull();
+  });
+
+  it('renders a green dot for Child role', () => {
+    const { container } = wrap(<FamilyMemberCard member={member({ roleName: 'Child' })} />);
+    expect(container.querySelector('.bg-green-500')).not.toBeNull();
+  });
+
+  it('renders the familyRoles legend instead of the dot when provided', () => {
+    wrap(
+      <FamilyMemberCard
+        member={member({ roleName: 'Adult' })}
+        familyRoles={['Adult', 'Parent']}
+      />,
+    );
+    expect(screen.getByText('Adult · Parent')).toBeInTheDocument();
+  });
+
+  it('hides the remove button when readOnly=true', () => {
+    wrap(
+      <FamilyMemberCard member={member()} readOnly onRemove={vi.fn()} />,
+    );
+    expect(
+      screen.queryByRole('button', { name: /remove .* from family/i }),
+    ).toBeNull();
+  });
+
+  it('shows remove button and calls onRemove when clicked', async () => {
+    const user = userEvent.setup();
+    const onRemove = vi.fn();
+    wrap(<FamilyMemberCard member={member()} onRemove={onRemove} />);
+    await user.click(
+      screen.getByRole('button', { name: /remove alice smith from family/i }),
+    );
+    expect(onRemove).toHaveBeenCalledOnce();
+  });
+
+  it('shows age suffix with "y" when person has age', () => {
+    wrap(<FamilyMemberCard member={member({ personOverrides: { age: 42 } })} />);
+    expect(screen.getByText('(42y)')).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/admin/people/__tests__/PersonCard.test.tsx
+++ b/src/web/src/components/admin/people/__tests__/PersonCard.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * PersonCard tests
+ *
+ * Catches:
+ *  - Links the card to /admin/people/{idKey}.
+ *  - Shows fullName + age when provided; omits age when undefined.
+ *  - Gender='Unknown' is hidden (privacy / clutter).
+ *  - connectionStatus and recordStatus badges render conditionally.
+ *  - recordStatus=Active is NOT shown as a badge.
+ *  - primaryCampus name renders when provided.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+import { PersonCard } from '../PersonCard';
+import type { PersonSummaryDto } from '@/services/api/types';
+
+function person(overrides: Partial<PersonSummaryDto> = {}): PersonSummaryDto {
+  return {
+    idKey: 'PER1',
+    firstName: 'Alice',
+    lastName: 'Smith',
+    fullName: 'Alice Smith',
+    gender: 'Female',
+    ...overrides,
+  } as PersonSummaryDto;
+}
+
+function wrap(ui: React.ReactNode) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('PersonCard', () => {
+  it('links the card to /admin/people/{idKey}', () => {
+    wrap(<PersonCard person={person({ idKey: 'XYZ' })} />);
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/admin/people/XYZ');
+  });
+
+  it('shows the fullName', () => {
+    wrap(<PersonCard person={person()} />);
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+  });
+
+  it('shows age when provided, hides when undefined', () => {
+    wrap(<PersonCard person={person({ age: 32 })} />);
+    expect(screen.getByText('(32)')).toBeInTheDocument();
+  });
+
+  it('omits gender when it is "Unknown"', () => {
+    wrap(<PersonCard person={person({ gender: 'Unknown' } as unknown as PersonSummaryDto)} />);
+    expect(screen.queryByText('Unknown')).toBeNull();
+  });
+
+  it('shows gender when it is not "Unknown"', () => {
+    wrap(<PersonCard person={person({ gender: 'Male' } as unknown as PersonSummaryDto)} />);
+    expect(screen.getByText('Male')).toBeInTheDocument();
+  });
+
+  it('hides recordStatus badge when value=Active', () => {
+    wrap(
+      <PersonCard
+        person={person({
+          recordStatus: { value: 'Active' } as PersonSummaryDto['recordStatus'],
+        })}
+      />,
+    );
+    expect(screen.queryByText('Active')).toBeNull();
+  });
+
+  it('shows recordStatus badge when value !== Active', () => {
+    wrap(
+      <PersonCard
+        person={person({
+          recordStatus: { value: 'Inactive' } as PersonSummaryDto['recordStatus'],
+        })}
+      />,
+    );
+    expect(screen.getByText('Inactive')).toBeInTheDocument();
+  });
+
+  it('shows connectionStatus badge when provided', () => {
+    wrap(
+      <PersonCard
+        person={person({
+          connectionStatus: { value: 'Member' } as PersonSummaryDto['connectionStatus'],
+        })}
+      />,
+    );
+    expect(screen.getByText('Member')).toBeInTheDocument();
+  });
+
+  it('shows primaryCampus name when provided', () => {
+    wrap(
+      <PersonCard
+        person={person({
+          primaryCampus: { name: 'Main Campus' } as PersonSummaryDto['primaryCampus'],
+        })}
+      />,
+    );
+    expect(screen.getByText('Main Campus')).toBeInTheDocument();
+  });
+
+  it('renders photo when photoUrl is provided', () => {
+    wrap(<PersonCard person={person({ photoUrl: 'https://x/y.jpg' })} />);
+    const img = screen.getByAltText('Alice Smith') as HTMLImageElement;
+    expect(img.src).toContain('https://x/y.jpg');
+  });
+});

--- a/src/web/src/components/auth/__tests__/LoginForm.test.tsx
+++ b/src/web/src/components/auth/__tests__/LoginForm.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * LoginForm tests
+ *
+ * Catches:
+ *  - Email + password form submits via the login() function.
+ *  - 400/401 error from API shows "Invalid email or password" inline (no toast).
+ *  - Other errors flow through handleError and surface its user-facing message.
+ *  - Loading button text while request in flight.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted mocks. The factories cannot reference outer variables, so we define
+// the error class inside the factory and pull it out later via dynamic import.
+vi.mock('../../../services/api', () => {
+  class ApiClientError extends Error {
+    statusCode: number;
+    constructor(statusCode: number, message: string) {
+      super(message);
+      this.statusCode = statusCode;
+      this.name = 'ApiClientError';
+    }
+  }
+  return { ApiClientError };
+});
+
+const loginMock = vi.fn();
+const handleErrorMock = vi.fn();
+
+vi.mock('../../../hooks/useAuth', () => ({
+  useAuth: () => ({ login: loginMock }),
+}));
+
+vi.mock('../../../hooks/useErrorHandler', () => ({
+  useErrorHandler: () => ({ handleError: handleErrorMock }),
+}));
+
+import { LoginForm } from '../LoginForm';
+import { ApiClientError } from '../../../services/api';
+
+describe('LoginForm', () => {
+  beforeEach(() => {
+    loginMock.mockReset();
+    handleErrorMock.mockReset();
+  });
+
+  it('calls login with the entered credentials on submit', async () => {
+    const user = userEvent.setup();
+    loginMock.mockResolvedValue(undefined);
+
+    render(<LoginForm />);
+    await user.type(screen.getByLabelText(/email/i), 'alice@example.com');
+    await user.type(screen.getByLabelText(/password/i), 'secret');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(loginMock).toHaveBeenCalledWith({
+      email: 'alice@example.com',
+      password: 'secret',
+    });
+  });
+
+  it('shows "Invalid email or password" inline for a 401 error', async () => {
+    const user = userEvent.setup();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    loginMock.mockRejectedValue(new (ApiClientError as any)(401, 'Unauthorized'));
+
+    render(<LoginForm />);
+    await user.type(screen.getByLabelText(/email/i), 'a@b.c');
+    await user.type(screen.getByLabelText(/password/i), 'bad');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /invalid email or password/i,
+      ),
+    );
+    expect(handleErrorMock).not.toHaveBeenCalled();
+  });
+
+  it('shows inline error for 400 errors as well', async () => {
+    const user = userEvent.setup();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    loginMock.mockRejectedValue(new (ApiClientError as any)(400, 'Bad Request'));
+
+    render(<LoginForm />);
+    await user.type(screen.getByLabelText(/email/i), 'a@b.c');
+    await user.type(screen.getByLabelText(/password/i), 'bad');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(
+        /invalid email or password/i,
+      ),
+    );
+  });
+
+  it('delegates other errors to handleError and surfaces its message', async () => {
+    const user = userEvent.setup();
+    loginMock.mockRejectedValue(new Error('network down'));
+    handleErrorMock.mockReturnValue({ message: 'Please try again later.' });
+
+    render(<LoginForm />);
+    await user.type(screen.getByLabelText(/email/i), 'a@b.c');
+    await user.type(screen.getByLabelText(/password/i), 'pw');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/please try again later/i),
+    );
+    expect(handleErrorMock).toHaveBeenCalled();
+  });
+
+  it('shows loading label while request is in flight', async () => {
+    const user = userEvent.setup();
+    let resolveLogin: () => void = () => {};
+    loginMock.mockImplementation(
+      () => new Promise<void>((r) => (resolveLogin = r)),
+    );
+
+    render(<LoginForm />);
+    await user.type(screen.getByLabelText(/email/i), 'a@b.c');
+    await user.type(screen.getByLabelText(/password/i), 'pw');
+    await user.click(screen.getByRole('button', { name: /sign in/i }));
+
+    expect(screen.getByRole('button', { name: /signing in/i })).toBeDisabled();
+
+    resolveLogin();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /sign in/i })).not.toBeDisabled(),
+    );
+  });
+});

--- a/src/web/src/components/auth/__tests__/ProtectedRoute.test.tsx
+++ b/src/web/src/components/auth/__tests__/ProtectedRoute.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * ProtectedRoute tests
+ *
+ * Catches:
+ *  - Loading spinner renders while auth state is loading.
+ *  - Unauthenticated users are redirected to /login (or custom redirect).
+ *  - Authenticated users see the protected children.
+ */
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { ProtectedRoute } from '../ProtectedRoute';
+
+vi.mock('../../../hooks/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+import { useAuth } from '../../../hooks/useAuth';
+
+describe('ProtectedRoute', () => {
+  it('shows the loading state while auth is loading', () => {
+    (useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      isAuthenticated: false,
+      isLoading: true,
+    });
+
+    render(
+      <MemoryRouter>
+        <ProtectedRoute>
+          <div>secret</div>
+        </ProtectedRoute>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+    expect(screen.queryByText('secret')).toBeNull();
+  });
+
+  it('redirects to /login when not authenticated', () => {
+    (useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route
+            path="/dashboard"
+            element={
+              <ProtectedRoute>
+                <div>secret</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/login" element={<div>login page</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('login page')).toBeInTheDocument();
+    expect(screen.queryByText('secret')).toBeNull();
+  });
+
+  it('redirects to a custom redirectTo when provided', () => {
+    (useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      isAuthenticated: false,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <Routes>
+          <Route
+            path="/dashboard"
+            element={
+              <ProtectedRoute redirectTo="/signin">
+                <div>secret</div>
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/signin" element={<div>signin page</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('signin page')).toBeInTheDocument();
+  });
+
+  it('renders children when authenticated', () => {
+    (useAuth as unknown as ReturnType<typeof vi.fn>).mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+    });
+
+    render(
+      <MemoryRouter>
+        <ProtectedRoute>
+          <div>secret</div>
+        </ProtectedRoute>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('secret')).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/checkin/__tests__/CheckoutFlow.test.tsx
+++ b/src/web/src/components/checkin/__tests__/CheckoutFlow.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * CheckoutFlow tests
+ *
+ * Catches:
+ *  - Empty list message depends on whether a search query is active.
+ *  - Search filters by person name.
+ *  - Search filters by security code.
+ *  - Security code display is partially masked (first 2 digits + dots).
+ *  - "First Time" badge appears when flag is set.
+ *  - Clicking Check Out advances to the verify step (renders SecurityCodeVerify).
+ *  - Cancel from verify step returns to list.
+ *  - Successful onCheckout → success screen → Continue returns to list.
+ *  - onCheckout failure → error banner on list.
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { CheckoutFlow } from '../CheckoutFlow';
+import type { AttendanceResultDto } from '@/services/api/types';
+
+function attend(overrides: Partial<AttendanceResultDto> = {}): AttendanceResultDto {
+  return {
+    attendanceIdKey: 'ATT1',
+    personIdKey: 'PER1',
+    personName: 'Billy Smith',
+    groupName: 'Kids',
+    locationName: 'Room 101',
+    scheduleName: '9am',
+    securityCode: '1234',
+    checkInTime: '2026-04-22T10:00:00Z',
+    isFirstTime: false,
+    ...overrides,
+  };
+}
+
+describe('CheckoutFlow', () => {
+  it('shows the empty-no-search message when there is nothing to check out', () => {
+    render(<CheckoutFlow currentAttendance={[]} onCheckout={vi.fn()} />);
+    expect(screen.getByText(/no one is currently checked in/i)).toBeInTheDocument();
+  });
+
+  it('lists checked-in people and masks the security code', () => {
+    render(
+      <CheckoutFlow
+        currentAttendance={[attend({ securityCode: '4321' })]}
+        onCheckout={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Billy Smith')).toBeInTheDocument();
+    // Only first 2 digits + bullets.
+    expect(screen.getByText('43••')).toBeInTheDocument();
+  });
+
+  it('shows the First Time badge when isFirstTime=true', () => {
+    render(
+      <CheckoutFlow
+        currentAttendance={[attend({ isFirstTime: true })]}
+        onCheckout={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/first time/i)).toBeInTheDocument();
+  });
+
+  it('filters the list by person name via search', async () => {
+    const user = userEvent.setup();
+    render(
+      <CheckoutFlow
+        currentAttendance={[
+          attend({ attendanceIdKey: 'A', personName: 'Alice' }),
+          attend({ attendanceIdKey: 'B', personName: 'Bob' }),
+        ]}
+        onCheckout={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+
+    await user.type(screen.getByPlaceholderText(/search by name/i), 'ali');
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.queryByText('Bob')).toBeNull();
+  });
+
+  it('shows "no matching check-ins" when search matches nothing', async () => {
+    const user = userEvent.setup();
+    render(
+      <CheckoutFlow
+        currentAttendance={[attend({ personName: 'Alice' })]}
+        onCheckout={vi.fn()}
+      />,
+    );
+    await user.type(screen.getByPlaceholderText(/search by name/i), 'xyz');
+    expect(screen.getByText(/no matching check-ins/i)).toBeInTheDocument();
+  });
+
+  it('filters by security code digits in search', async () => {
+    const user = userEvent.setup();
+    render(
+      <CheckoutFlow
+        currentAttendance={[
+          attend({ attendanceIdKey: 'A', personName: 'Alice', securityCode: '1111' }),
+          attend({ attendanceIdKey: 'B', personName: 'Bob', securityCode: '2222' }),
+        ]}
+        onCheckout={vi.fn()}
+      />,
+    );
+    await user.type(screen.getByPlaceholderText(/search by name/i), '11');
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.queryByText('Bob')).toBeNull();
+  });
+
+  it('advances to the verify step when Check Out is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <CheckoutFlow
+        currentAttendance={[attend({ personName: 'Billy Smith' })]}
+        onCheckout={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /check out/i }));
+    // Verify step renders the security code heading.
+    expect(screen.getByText(/verify security code/i)).toBeInTheDocument();
+    expect(screen.getByText('Billy Smith')).toBeInTheDocument();
+  });
+
+  it('returns to list when the verify step is cancelled', async () => {
+    const user = userEvent.setup();
+    render(
+      <CheckoutFlow
+        currentAttendance={[attend()]}
+        onCheckout={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /check out/i }));
+    expect(screen.getByText(/verify security code/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.getByPlaceholderText(/search by name/i)).toBeInTheDocument();
+  });
+
+  it('shows success screen when the correct code completes checkout', async () => {
+    vi.useFakeTimers();
+    const onCheckout = vi.fn().mockResolvedValue(undefined);
+
+    render(
+      <CheckoutFlow
+        currentAttendance={[attend({ personName: 'Billy', securityCode: '1234' })]}
+        onCheckout={onCheckout}
+      />,
+    );
+
+    // Click Check Out button via fireEvent (synchronous, plays well with timers).
+    fireEvent.click(screen.getByRole('button', { name: /check out/i }));
+
+    // Now in verify; enter correct digits.
+    fireEvent.click(screen.getByRole('button', { name: '1' }));
+    fireEvent.click(screen.getByRole('button', { name: '2' }));
+    fireEvent.click(screen.getByRole('button', { name: '3' }));
+    fireEvent.click(screen.getByRole('button', { name: '4' }));
+
+    // Advance constant-time delay + microtasks for the async onCheckout.
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+      // Flush pending promises.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(onCheckout).toHaveBeenCalledWith('ATT1');
+    expect(screen.getByText(/checkout complete/i)).toBeInTheDocument();
+    vi.useRealTimers();
+  });
+});

--- a/src/web/src/components/checkin/__tests__/FamilyQrCard.test.tsx
+++ b/src/web/src/components/checkin/__tests__/FamilyQrCard.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * FamilyQrCard tests
+ *
+ * Catches:
+ *  - Renders family name and family ID.
+ *  - Encodes koinon://family/{idKey} into the QR value (regression on URL scheme).
+ *  - Print button visibility respects the showPrintButton prop.
+ *  - Clicking Print triggers window.print().
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+// Stub qrcode.react before importing the component under test.
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: ({ value, size }: { value: string; size: number }) => (
+    <svg data-testid="qr" data-value={value} data-size={size} />
+  ),
+}));
+
+import { FamilyQrCard } from '../FamilyQrCard';
+
+describe('FamilyQrCard', () => {
+  it('renders the family name and family id key', () => {
+    render(<FamilyQrCard familyIdKey="FAM123" familyName="The Smiths" />);
+    expect(screen.getByRole('heading', { name: 'The Smiths' })).toBeInTheDocument();
+    expect(screen.getByText(/FAM123/)).toBeInTheDocument();
+  });
+
+  it('encodes the family id with the koinon URL scheme in the QR value', () => {
+    render(<FamilyQrCard familyIdKey="FAM123" familyName="The Smiths" />);
+    const qr = screen.getByTestId('qr');
+    expect(qr.getAttribute('data-value')).toBe('koinon://family/FAM123');
+  });
+
+  it('passes the qrSize prop through to the QR renderer', () => {
+    render(
+      <FamilyQrCard familyIdKey="A" familyName="B" qrSize={400} />,
+    );
+    const qr = screen.getByTestId('qr');
+    expect(qr.getAttribute('data-size')).toBe('400');
+  });
+
+  it('shows the print button by default and calls window.print when clicked', async () => {
+    const printSpy = vi.fn();
+    const original = window.print;
+    window.print = printSpy;
+
+    const user = userEvent.setup();
+    render(<FamilyQrCard familyIdKey="A" familyName="B" />);
+    await user.click(screen.getByRole('button', { name: /print qr code/i }));
+    expect(printSpy).toHaveBeenCalled();
+
+    window.print = original;
+  });
+
+  it('hides the print button when showPrintButton=false', () => {
+    render(<FamilyQrCard familyIdKey="A" familyName="B" showPrintButton={false} />);
+    expect(screen.queryByRole('button', { name: /print qr code/i })).toBeNull();
+  });
+});

--- a/src/web/src/components/checkin/__tests__/FamilySearch.test.tsx
+++ b/src/web/src/components/checkin/__tests__/FamilySearch.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * FamilySearch tests
+ *
+ * Catches:
+ *  - Submit only fires when name length >= 2 (prevents abusive 1-char queries).
+ *  - Button is disabled until the threshold is met.
+ *  - onInputChange fires with a boolean reflecting non-empty input.
+ *  - Loading prop propagates to the Button's loading state.
+ *  - Submitted value is trimmed.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { FamilySearch } from '../FamilySearch';
+
+describe('FamilySearch', () => {
+  it('disables submit until 2+ chars are entered', async () => {
+    const user = userEvent.setup();
+    const onSearch = vi.fn();
+    render(<FamilySearch onSearch={onSearch} />);
+
+    const button = screen.getByRole('button', { name: /find family/i });
+    expect(button).toBeDisabled();
+
+    const input = screen.getByPlaceholderText('Last name...') as HTMLInputElement;
+    await user.type(input, 'a');
+    expect(button).toBeDisabled();
+
+    await user.type(input, 'b');
+    expect(button).not.toBeDisabled();
+  });
+
+  it('invokes onSearch with the trimmed name on submit', async () => {
+    const user = userEvent.setup();
+    const onSearch = vi.fn();
+    render(<FamilySearch onSearch={onSearch} />);
+
+    const input = screen.getByPlaceholderText('Last name...') as HTMLInputElement;
+    await user.type(input, '   Smith   ');
+    await user.click(screen.getByRole('button', { name: /find family/i }));
+
+    expect(onSearch).toHaveBeenCalledWith('Smith');
+  });
+
+  it('does NOT invoke onSearch for a 1-char query', async () => {
+    const user = userEvent.setup();
+    const onSearch = vi.fn();
+    render(<FamilySearch onSearch={onSearch} />);
+
+    const input = screen.getByPlaceholderText('Last name...') as HTMLInputElement;
+    await user.type(input, 'a');
+    // Press Enter to submit the form even with button disabled — fallback safety.
+    input.focus();
+    await user.keyboard('{Enter}');
+
+    expect(onSearch).not.toHaveBeenCalled();
+  });
+
+  it('fires onInputChange with a boolean reflecting non-empty input', async () => {
+    const user = userEvent.setup();
+    const onInputChange = vi.fn();
+    render(<FamilySearch onSearch={vi.fn()} onInputChange={onInputChange} />);
+
+    const input = screen.getByPlaceholderText('Last name...') as HTMLInputElement;
+    await user.type(input, 'a');
+    expect(onInputChange).toHaveBeenLastCalledWith(true);
+
+    await user.clear(input);
+    expect(onInputChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('passes loading=true through to the Button', () => {
+    render(<FamilySearch onSearch={vi.fn()} loading />);
+    // Button component renders the "Loading..." label when loading.
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/checkin/__tests__/KioskLayout.test.tsx
+++ b/src/web/src/components/checkin/__tests__/KioskLayout.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * KioskLayout tests
+ *
+ * Catches:
+ *  - Renders title when provided and hides when not.
+ *  - Supervisor button visibility depends on the onSupervisorTrigger prop.
+ *  - Reset button visibility depends on the onReset prop.
+ *  - Triple-tap on the header triggers supervisor mode.
+ *  - Supervisor button click triggers immediately.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { KioskLayout } from '../KioskLayout';
+
+describe('KioskLayout', () => {
+  it('renders the title when provided', () => {
+    render(
+      <KioskLayout title="Sunday 9AM">
+        <div>content</div>
+      </KioskLayout>,
+    );
+    expect(screen.getByText('Sunday 9AM')).toBeInTheDocument();
+  });
+
+  it('renders children in the main content area', () => {
+    render(
+      <KioskLayout>
+        <div>hello world</div>
+      </KioskLayout>,
+    );
+    expect(screen.getByText('hello world')).toBeInTheDocument();
+  });
+
+  it('hides the supervisor button when no onSupervisorTrigger is given', () => {
+    render(
+      <KioskLayout>
+        <div />
+      </KioskLayout>,
+    );
+    expect(screen.queryByRole('button', { name: /supervisor mode/i })).toBeNull();
+  });
+
+  it('fires onSupervisorTrigger when the button is clicked', async () => {
+    const user = userEvent.setup();
+    const onSupervisor = vi.fn();
+    render(
+      <KioskLayout onSupervisorTrigger={onSupervisor}>
+        <div />
+      </KioskLayout>,
+    );
+    await user.click(screen.getByRole('button', { name: /supervisor mode/i }));
+    expect(onSupervisor).toHaveBeenCalledOnce();
+  });
+
+  it('hides Start Over when no onReset is given', () => {
+    render(
+      <KioskLayout>
+        <div />
+      </KioskLayout>,
+    );
+    expect(screen.queryByRole('button', { name: /start over/i })).toBeNull();
+  });
+
+  it('fires onReset when Start Over is clicked', async () => {
+    const user = userEvent.setup();
+    const onReset = vi.fn();
+    render(
+      <KioskLayout onReset={onReset}>
+        <div />
+      </KioskLayout>,
+    );
+    await user.click(screen.getByRole('button', { name: /start over/i }));
+    expect(onReset).toHaveBeenCalledOnce();
+  });
+
+  it('triggers supervisor mode after three taps on the header logo', async () => {
+    const user = userEvent.setup();
+    const onSupervisor = vi.fn();
+    render(
+      <KioskLayout onSupervisorTrigger={onSupervisor}>
+        <div />
+      </KioskLayout>,
+    );
+    const logo = screen.getByRole('heading', { name: 'Check-In' });
+
+    // Each tap on the header container triggers the handler.
+    await user.click(logo);
+    await user.click(logo);
+    // Not yet triggered.
+    expect(onSupervisor).toHaveBeenCalledTimes(0);
+
+    await user.click(logo);
+    // Three taps → supervisor button click triggers, plus the direct
+    // onSupervisorTrigger from the triple-tap path. We expect at least one call.
+    expect(onSupervisor).toHaveBeenCalled();
+  });
+});

--- a/src/web/src/components/checkin/__tests__/OfflineQueueIndicator.test.tsx
+++ b/src/web/src/components/checkin/__tests__/OfflineQueueIndicator.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * OfflineQueueIndicator tests
+ *
+ * Catches:
+ *  - Returns null when online with an empty queue (no stray banner).
+ *  - Shows offline banner when mode=offline.
+ *  - Shows queue count with correct pluralization.
+ *  - Shows "Send Now" button only when online with queued items AND onSync provided.
+ *  - Syncing, success, and error statuses each render their distinct banners.
+ *  - Retry button fires onSync in error state.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { OfflineQueueIndicator } from '../OfflineQueueIndicator';
+import type { OfflineCheckinState } from '@/hooks/useOfflineCheckin';
+
+function baseState(overrides: Partial<OfflineCheckinState> = {}): OfflineCheckinState {
+  return {
+    mode: 'online',
+    queuedCount: 0,
+    syncStatus: 'idle',
+    lastSyncResults: null,
+    ...overrides,
+  } as OfflineCheckinState;
+}
+
+describe('OfflineQueueIndicator', () => {
+  it('renders nothing when online with an empty queue and idle sync', () => {
+    const { container } = render(
+      <OfflineQueueIndicator state={baseState()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the offline banner when mode=offline', () => {
+    render(<OfflineQueueIndicator state={baseState({ mode: 'offline' })} />);
+    expect(screen.getByText(/offline mode/i)).toBeInTheDocument();
+  });
+
+  it('shows "1 check-in queued" (singular) when queuedCount=1', () => {
+    render(
+      <OfflineQueueIndicator
+        state={baseState({ mode: 'offline', queuedCount: 1 })}
+      />,
+    );
+    expect(screen.getByText(/1 check-in queued/)).toBeInTheDocument();
+  });
+
+  it('pluralizes when queuedCount > 1', () => {
+    render(
+      <OfflineQueueIndicator
+        state={baseState({ mode: 'offline', queuedCount: 3 })}
+      />,
+    );
+    expect(screen.getByText(/3 check-ins queued/)).toBeInTheDocument();
+  });
+
+  it('shows Send Now only when online with queued items AND onSync is provided', async () => {
+    const user = userEvent.setup();
+    const onSync = vi.fn();
+    render(
+      <OfflineQueueIndicator
+        state={baseState({ queuedCount: 2 })}
+        onSync={onSync}
+      />,
+    );
+    const button = screen.getByRole('button', { name: /send now/i });
+    await user.click(button);
+    expect(onSync).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT show Send Now while offline', () => {
+    render(
+      <OfflineQueueIndicator
+        state={baseState({ mode: 'offline', queuedCount: 2 })}
+        onSync={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole('button', { name: /send now/i })).toBeNull();
+  });
+
+  it('renders the syncing state banner', () => {
+    render(
+      <OfflineQueueIndicator
+        state={baseState({ queuedCount: 1, syncStatus: 'syncing' })}
+      />,
+    );
+    expect(screen.getByText(/syncing check-ins/i)).toBeInTheDocument();
+  });
+
+  it('renders the success state banner with completed count', () => {
+    render(
+      <OfflineQueueIndicator
+        state={baseState({
+          syncStatus: 'success',
+          lastSyncResults: [
+            { success: true, isDuplicate: false },
+            { success: true, isDuplicate: true },
+          ] as OfflineCheckinState['lastSyncResults'],
+        })}
+      />,
+    );
+    expect(screen.getByText(/all done/i)).toBeInTheDocument();
+    expect(screen.getByText(/2 check-ins synced/i)).toBeInTheDocument();
+    // Note about duplicates is appended.
+    expect(screen.getByText(/already checked in/i)).toBeInTheDocument();
+  });
+
+  it('renders the error state banner and fires onSync from the Retry button', async () => {
+    const user = userEvent.setup();
+    const onSync = vi.fn();
+    render(
+      <OfflineQueueIndicator
+        state={baseState({ syncStatus: 'error' })}
+        onSync={onSync}
+      />,
+    );
+    expect(screen.getByText(/sync failed/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /retry/i }));
+    expect(onSync).toHaveBeenCalledOnce();
+  });
+});

--- a/src/web/src/components/checkin/__tests__/PinEntry.test.tsx
+++ b/src/web/src/components/checkin/__tests__/PinEntry.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * PinEntry tests
+ *
+ * Catches:
+ *  - Numpad clicks append digits to the PIN (capped at 6).
+ *  - Clear resets the PIN.
+ *  - Backspace removes the last digit.
+ *  - Submit disabled while pin < 4 and user hasn't edited.
+ *  - Submit shows inline validation if too short after editing.
+ *  - Successful submit fires onSubmit with the entered PIN.
+ *  - Cancel fires onCancel.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { PinEntry } from '../PinEntry';
+
+describe('PinEntry', () => {
+  it('disables Submit when pin is empty and user has not edited', () => {
+    render(<PinEntry onSubmit={vi.fn()} onCancel={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('appends numpad taps into the PIN (dots show)', async () => {
+    const user = userEvent.setup();
+    render(<PinEntry onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: '1' }));
+    await user.click(screen.getByRole('button', { name: '2' }));
+    await user.click(screen.getByRole('button', { name: '3' }));
+    await user.click(screen.getByRole('button', { name: '4' }));
+
+    const pinDisplay = screen.getByTestId('pin-display');
+    expect(pinDisplay.textContent).toMatch(/•{4}/);
+  });
+
+  it('caps PIN input at 6 digits (numpad disables after 6)', async () => {
+    const user = userEvent.setup();
+    render(<PinEntry onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+    for (let i = 0; i < 6; i++) {
+      await user.click(screen.getByRole('button', { name: '1' }));
+    }
+    // 7th click should be no-op because buttons are disabled.
+    expect(screen.getByRole('button', { name: '1' })).toBeDisabled();
+  });
+
+  it('Clear resets the PIN', async () => {
+    const user = userEvent.setup();
+    render(<PinEntry onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: '1' }));
+    await user.click(screen.getByRole('button', { name: '2' }));
+    await user.click(screen.getByRole('button', { name: 'Reset' }));
+
+    const pinDisplay = screen.getByTestId('pin-display');
+    // After reset, no • should be visible.
+    expect(pinDisplay.textContent).not.toMatch(/•/);
+  });
+
+  it('Backspace removes the last digit', async () => {
+    const user = userEvent.setup();
+    render(<PinEntry onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: '1' }));
+    await user.click(screen.getByRole('button', { name: '2' }));
+    await user.click(screen.getByRole('button', { name: /backspace/i }));
+
+    const pinDisplay = screen.getByTestId('pin-display');
+    expect((pinDisplay.textContent ?? '').match(/•/g)?.length ?? 0).toBe(1);
+  });
+
+  it('calls onSubmit with the entered pin when it is valid', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    render(<PinEntry onSubmit={onSubmit} onCancel={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: '1' }));
+    await user.click(screen.getByRole('button', { name: '2' }));
+    await user.click(screen.getByRole('button', { name: '3' }));
+    await user.click(screen.getByRole('button', { name: '4' }));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(onSubmit).toHaveBeenCalledWith('1234');
+  });
+
+  it('shows an inline validation error when Submit is clicked with too-short pin after editing', async () => {
+    const user = userEvent.setup();
+    render(<PinEntry onSubmit={vi.fn()} onCancel={vi.fn()} />);
+
+    // Force "hasEdited" via backspace click.
+    await user.click(screen.getByRole('button', { name: '1' }));
+    await user.click(screen.getByRole('button', { name: /backspace/i }));
+    await user.click(screen.getByRole('button', { name: '1' }));
+
+    // Now pin="1" with hasEdited=true — Submit is enabled but too short.
+    const submit = screen.getByRole('button', { name: 'Submit' });
+    expect(submit).not.toBeDisabled();
+    await user.click(submit);
+
+    expect(screen.getByText(/please enter at least 4 digits/i)).toBeInTheDocument();
+  });
+
+  it('fires onCancel when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+    render(<PinEntry onSubmit={vi.fn()} onCancel={onCancel} />);
+
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('displays the error prop when provided (server-side error)', () => {
+    render(<PinEntry onSubmit={vi.fn()} onCancel={vi.fn()} error="Invalid PIN" />);
+    expect(screen.getByText('Invalid PIN')).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/checkin/__tests__/RoomCapacityIndicator.test.tsx
+++ b/src/web/src/components/checkin/__tests__/RoomCapacityIndicator.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * RoomCapacityIndicator tests
+ *
+ * Catches:
+ *  - Status → colour/icon mapping regressions (FULL=red, WARNING=yellow, AVAILABLE=green).
+ *  - compact variant renders inline vs. full card.
+ *  - capacityText: "X / Y" when capacity known, "X checked in" when not.
+ *  - FULL shows overflow helper message; WARNING shows near-capacity message.
+ *  - Progress bar width is clamped to 100% when currentCount > softCapacity.
+ *  - RoomCapacityBadge emits correct colour mapping.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { CapacityStatus } from '@/services/api/types';
+import {
+  RoomCapacityBadge,
+  RoomCapacityIndicator,
+} from '../RoomCapacityIndicator';
+
+describe('RoomCapacityIndicator — status mapping', () => {
+  it('renders AVAILABLE status with green styling', () => {
+    const { container } = render(
+      <RoomCapacityIndicator
+        currentCount={3}
+        softCapacity={20}
+        hardCapacity={25}
+        status={CapacityStatus.Available}
+        locationName="Room 1"
+      />,
+    );
+    expect(screen.getByText('AVAILABLE')).toBeInTheDocument();
+    expect(container.querySelector('.bg-green-100')).not.toBeNull();
+  });
+
+  it('renders WARNING status with yellow styling and near-capacity note', () => {
+    const { container } = render(
+      <RoomCapacityIndicator
+        currentCount={18}
+        softCapacity={20}
+        hardCapacity={25}
+        status={CapacityStatus.Warning}
+        locationName="Room 1"
+      />,
+    );
+    expect(screen.getByText('WARNING')).toBeInTheDocument();
+    expect(container.querySelector('.bg-yellow-100')).not.toBeNull();
+    expect(screen.getByText(/near capacity/i)).toBeInTheDocument();
+  });
+
+  it('renders FULL status with red styling and overflow note', () => {
+    const { container } = render(
+      <RoomCapacityIndicator
+        currentCount={25}
+        softCapacity={20}
+        hardCapacity={25}
+        status={CapacityStatus.Full}
+        locationName="Room 1"
+      />,
+    );
+    expect(screen.getByText('FULL')).toBeInTheDocument();
+    expect(container.querySelector('.bg-red-100')).not.toBeNull();
+    expect(screen.getByText(/room full/i)).toBeInTheDocument();
+  });
+});
+
+describe('RoomCapacityIndicator — capacity text', () => {
+  it('shows "N / capacity" when a capacity is defined', () => {
+    render(
+      <RoomCapacityIndicator
+        currentCount={5}
+        softCapacity={10}
+        hardCapacity={12}
+        status={CapacityStatus.Available}
+        locationName="Room 2"
+      />,
+    );
+    expect(screen.getByText('5 / 12')).toBeInTheDocument();
+  });
+
+  it('falls back to softCapacity when hardCapacity is absent', () => {
+    render(
+      <RoomCapacityIndicator
+        currentCount={5}
+        softCapacity={10}
+        status={CapacityStatus.Available}
+        locationName="Room 2"
+      />,
+    );
+    expect(screen.getByText('5 / 10')).toBeInTheDocument();
+  });
+
+  it('shows "N checked in" when no capacity is known', () => {
+    render(
+      <RoomCapacityIndicator
+        currentCount={5}
+        status={CapacityStatus.Available}
+        locationName="Open Room"
+      />,
+    );
+    expect(screen.getByText('5 checked in')).toBeInTheDocument();
+  });
+
+  it('renders the percentageFull value in parentheses when provided', () => {
+    render(
+      <RoomCapacityIndicator
+        currentCount={15}
+        softCapacity={20}
+        status={CapacityStatus.Warning}
+        percentageFull={75}
+        locationName="x"
+      />,
+    );
+    expect(screen.getByText('(75%)')).toBeInTheDocument();
+  });
+});
+
+describe('RoomCapacityIndicator — compact', () => {
+  it('renders an inline pill with status icon', () => {
+    const { container } = render(
+      <RoomCapacityIndicator
+        currentCount={5}
+        softCapacity={10}
+        status={CapacityStatus.Available}
+        locationName="Room"
+        compact
+      />,
+    );
+    const pill = container.firstChild as HTMLElement;
+    expect(pill.className).toMatch(/inline-flex/);
+    expect(pill.className).toMatch(/bg-green-100/);
+  });
+
+  it('hides the capacity text when showDetails=false (compact)', () => {
+    render(
+      <RoomCapacityIndicator
+        currentCount={5}
+        softCapacity={10}
+        status={CapacityStatus.Available}
+        locationName="Room"
+        compact
+        showDetails={false}
+      />,
+    );
+    expect(screen.queryByText('5 / 10')).toBeNull();
+  });
+});
+
+describe('RoomCapacityIndicator — progress bar', () => {
+  it('clamps the progress bar width at 100% when over soft capacity', () => {
+    const { container } = render(
+      <RoomCapacityIndicator
+        currentCount={50}
+        softCapacity={20}
+        status={CapacityStatus.Full}
+        locationName="Room"
+      />,
+    );
+    const bar = container.querySelector(
+      '[style*="width:"]',
+    ) as HTMLElement | null;
+    expect(bar).not.toBeNull();
+    // Should clamp to 100%, not 250%.
+    expect(bar!.style.width).toBe('100%');
+  });
+
+  it('uses red fill colour when FULL', () => {
+    const { container } = render(
+      <RoomCapacityIndicator
+        currentCount={20}
+        softCapacity={20}
+        status={CapacityStatus.Full}
+        locationName="Room"
+      />,
+    );
+    expect(container.querySelector('.bg-red-600')).not.toBeNull();
+  });
+
+  it('uses yellow fill colour when WARNING', () => {
+    const { container } = render(
+      <RoomCapacityIndicator
+        currentCount={15}
+        softCapacity={20}
+        status={CapacityStatus.Warning}
+        locationName="Room"
+      />,
+    );
+    expect(container.querySelector('.bg-yellow-500')).not.toBeNull();
+  });
+});
+
+describe('RoomCapacityBadge', () => {
+  it('emits green styling for Available', () => {
+    const { container } = render(
+      <RoomCapacityBadge
+        status={CapacityStatus.Available}
+        currentCount={3}
+        capacity={10}
+      />,
+    );
+    expect(container.firstChild).toHaveClass('bg-green-100');
+    expect(screen.getByText('3/10')).toBeInTheDocument();
+  });
+
+  it('emits yellow styling for Warning', () => {
+    const { container } = render(
+      <RoomCapacityBadge status={CapacityStatus.Warning} currentCount={8} capacity={10} />,
+    );
+    expect(container.firstChild).toHaveClass('bg-yellow-100');
+  });
+
+  it('emits red styling for Full', () => {
+    const { container } = render(
+      <RoomCapacityBadge status={CapacityStatus.Full} currentCount={10} capacity={10} />,
+    );
+    expect(container.firstChild).toHaveClass('bg-red-100');
+  });
+
+  it('omits the capacity portion when no capacity is provided', () => {
+    render(<RoomCapacityBadge status={CapacityStatus.Available} currentCount={4} />);
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/checkin/__tests__/SecurityCodeVerify.test.tsx
+++ b/src/web/src/components/checkin/__tests__/SecurityCodeVerify.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * SecurityCodeVerify tests
+ *
+ * Catches:
+ *  - Person name is displayed (context for the user).
+ *  - Correct code fires onVerified after the constant-time delay.
+ *  - Wrong code shows an error rather than calling onVerified.
+ *  - Cancel fires onCancel.
+ */
+import { act, render, screen, fireEvent } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { SecurityCodeVerify } from '../SecurityCodeVerify';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('SecurityCodeVerify', () => {
+  it('shows the person name for context', () => {
+    render(
+      <SecurityCodeVerify
+        expectedCode="1234"
+        personName="Billy Smith"
+        onVerified={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('Billy Smith')).toBeInTheDocument();
+  });
+
+  it('fires onVerified when the correct code is entered', () => {
+    vi.useFakeTimers();
+    const onVerified = vi.fn();
+
+    render(
+      <SecurityCodeVerify
+        expectedCode="1234"
+        personName="A"
+        onVerified={onVerified}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    // Use fireEvent to avoid userEvent's awaited scheduling interacting with
+    // fake timers. fireEvent dispatches synchronously, which is fine here.
+    fireEvent.click(screen.getByRole('button', { name: '1' }));
+    fireEvent.click(screen.getByRole('button', { name: '2' }));
+    fireEvent.click(screen.getByRole('button', { name: '3' }));
+    fireEvent.click(screen.getByRole('button', { name: '4' }));
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(onVerified).toHaveBeenCalledOnce();
+  });
+
+  it('shows an error when the code is incorrect (does not call onVerified)', () => {
+    vi.useFakeTimers();
+    const onVerified = vi.fn();
+
+    render(
+      <SecurityCodeVerify
+        expectedCode="1234"
+        personName="A"
+        onVerified={onVerified}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '9' }));
+    fireEvent.click(screen.getByRole('button', { name: '9' }));
+    fireEvent.click(screen.getByRole('button', { name: '9' }));
+    fireEvent.click(screen.getByRole('button', { name: '9' }));
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(onVerified).not.toHaveBeenCalled();
+    expect(screen.getByText(/incorrect security code/i)).toBeInTheDocument();
+  });
+
+  it('Cancel fires onCancel', () => {
+    const onCancel = vi.fn();
+    render(
+      <SecurityCodeVerify
+        expectedCode="1234"
+        personName="A"
+        onVerified={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('Clear button resets the entry and re-enables digit buttons', () => {
+    render(
+      <SecurityCodeVerify
+        expectedCode="1234"
+        personName="A"
+        onVerified={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: '1' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+
+    // After clear, "1" should still be enabled.
+    expect(screen.getByRole('button', { name: '1' })).not.toBeDisabled();
+  });
+});

--- a/src/web/src/components/communication/__tests__/MessageTypeToggle.test.tsx
+++ b/src/web/src/components/communication/__tests__/MessageTypeToggle.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * MessageTypeToggle tests
+ *
+ * Catches:
+ *  - The currently selected option has primary background (visible state).
+ *  - Clicking the other option fires onChange with that value.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { MessageTypeToggle } from '../MessageTypeToggle';
+
+describe('MessageTypeToggle', () => {
+  it('marks Email as active when value=Email', () => {
+    render(<MessageTypeToggle value="Email" onChange={vi.fn()} />);
+    const emailBtn = screen.getByRole('button', { name: /email/i });
+    const smsBtn = screen.getByRole('button', { name: /sms/i });
+    expect(emailBtn.className).toMatch(/bg-primary-600/);
+    expect(smsBtn.className).not.toMatch(/bg-primary-600/);
+  });
+
+  it('marks SMS as active when value=Sms', () => {
+    render(<MessageTypeToggle value="Sms" onChange={vi.fn()} />);
+    const emailBtn = screen.getByRole('button', { name: /email/i });
+    const smsBtn = screen.getByRole('button', { name: /sms/i });
+    expect(smsBtn.className).toMatch(/bg-primary-600/);
+    expect(emailBtn.className).not.toMatch(/bg-primary-600/);
+  });
+
+  it('fires onChange with the clicked option', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<MessageTypeToggle value="Email" onChange={onChange} />);
+    await user.click(screen.getByRole('button', { name: /sms/i }));
+    expect(onChange).toHaveBeenCalledWith('Sms');
+  });
+});

--- a/src/web/src/components/communication/__tests__/RecipientStatusBadge.test.tsx
+++ b/src/web/src/components/communication/__tests__/RecipientStatusBadge.test.tsx
@@ -1,0 +1,29 @@
+/**
+ * RecipientStatusBadge tests
+ *
+ * Catches status → colour mapping regressions (Pending/Delivered/Failed/Opened)
+ * and the unknown-status fallback.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { RecipientStatusBadge } from '../RecipientStatusBadge';
+
+const cases: Array<[string, string]> = [
+  ['Pending', 'bg-blue-100'],
+  ['Delivered', 'bg-green-100'],
+  ['Failed', 'bg-red-100'],
+  ['Opened', 'bg-purple-100'],
+];
+
+describe('RecipientStatusBadge', () => {
+  it.each(cases)('maps %s status to the expected colour class', (status, cls) => {
+    const { container } = render(<RecipientStatusBadge status={status} />);
+    expect(container.firstChild).toHaveClass(cls);
+    expect(screen.getByText(status)).toBeInTheDocument();
+  });
+
+  it('falls back to gray styling for unknown statuses', () => {
+    const { container } = render(<RecipientStatusBadge status="Unknown" />);
+    expect(container.firstChild).toHaveClass('bg-gray-100');
+  });
+});

--- a/src/web/src/components/giving/__tests__/BatchStatusBadge.test.tsx
+++ b/src/web/src/components/giving/__tests__/BatchStatusBadge.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * BatchStatusBadge tests
+ *
+ * Catches:
+ *  - Status → colour mapping (Open=green, Closed=gray, Posted=blue).
+ *  - Unknown status falls back to the gray default.
+ *  - Status text renders.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { BatchStatusBadge } from '../BatchStatusBadge';
+
+describe('BatchStatusBadge', () => {
+  it('maps Open status to green styling', () => {
+    const { container } = render(<BatchStatusBadge status="Open" />);
+    expect(container.firstChild).toHaveClass('bg-green-100');
+    expect(screen.getByText('Open')).toBeInTheDocument();
+  });
+
+  it('maps Closed status to gray styling', () => {
+    const { container } = render(<BatchStatusBadge status="Closed" />);
+    expect(container.firstChild).toHaveClass('bg-gray-100');
+  });
+
+  it('maps Posted status to blue styling', () => {
+    const { container } = render(<BatchStatusBadge status="Posted" />);
+    expect(container.firstChild).toHaveClass('bg-blue-100');
+  });
+
+  it('falls back to gray for unknown statuses', () => {
+    const { container } = render(<BatchStatusBadge status="Mystery" />);
+    expect(container.firstChild).toHaveClass('bg-gray-100');
+  });
+});

--- a/src/web/src/components/giving/__tests__/BatchSummaryCard.test.tsx
+++ b/src/web/src/components/giving/__tests__/BatchSummaryCard.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * BatchSummaryCard tests
+ *
+ * Catches:
+ *  - Currency format uses $0.00; dash for undefined.
+ *  - Variance colour: red (negative), green (positive), gray (zero).
+ *  - Balance indicator text: "Balanced" vs "Unbalanced".
+ *  - Action button visibility keyed to status:
+ *    * Closed → "Open" button
+ *    * Open → "Close" button
+ *    * Posted → "Posted batches cannot be modified" text
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { BatchSummaryCard } from '../BatchSummaryCard';
+import type { BatchSummaryDto, ContributionBatchDto } from '@/types/giving';
+
+function makeBatch(overrides: Partial<ContributionBatchDto> = {}): ContributionBatchDto {
+  return {
+    idKey: 'B1',
+    name: 'Sunday Batch',
+    batchDate: '2026-01-01T00:00:00Z',
+    status: 'Open',
+    controlAmount: 100,
+    controlItemCount: 10,
+    createdDateTime: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeSummary(overrides: Partial<BatchSummaryDto> = {}): BatchSummaryDto {
+  return {
+    idKey: 'B1',
+    name: 'Sunday Batch',
+    status: 'Open',
+    controlAmount: 100,
+    controlItemCount: 10,
+    actualAmount: 100,
+    contributionCount: 10,
+    variance: 0,
+    isBalanced: true,
+    ...overrides,
+  };
+}
+
+describe('BatchSummaryCard', () => {
+  it('shows "Balanced" when summary.isBalanced=true', () => {
+    render(
+      <BatchSummaryCard
+        batch={makeBatch()}
+        summary={makeSummary({ isBalanced: true })}
+        onOpen={vi.fn()}
+        onClose={vi.fn()}
+        isOpenPending={false}
+        isClosePending={false}
+      />,
+    );
+    expect(screen.getByText('Balanced')).toBeInTheDocument();
+  });
+
+  it('shows "Unbalanced" when summary.isBalanced=false', () => {
+    render(
+      <BatchSummaryCard
+        batch={makeBatch()}
+        summary={makeSummary({ isBalanced: false, variance: -5 })}
+        onOpen={vi.fn()}
+        onClose={vi.fn()}
+        isOpenPending={false}
+        isClosePending={false}
+      />,
+    );
+    expect(screen.getByText('Unbalanced')).toBeInTheDocument();
+  });
+
+  it('renders Close button for status=Open and fires onClose', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <BatchSummaryCard
+        batch={makeBatch({ status: 'Open' })}
+        summary={makeSummary({ status: 'Open' })}
+        onOpen={vi.fn()}
+        onClose={onClose}
+        isOpenPending={false}
+        isClosePending={false}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Close' }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('renders Open button for status=Closed and fires onOpen', async () => {
+    const user = userEvent.setup();
+    const onOpen = vi.fn();
+    render(
+      <BatchSummaryCard
+        batch={makeBatch({ status: 'Closed' })}
+        summary={makeSummary({ status: 'Closed' })}
+        onOpen={onOpen}
+        onClose={vi.fn()}
+        isOpenPending={false}
+        isClosePending={false}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: 'Open' }));
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+
+  it('renders the locked message for status=Posted (no buttons)', () => {
+    render(
+      <BatchSummaryCard
+        batch={makeBatch({ status: 'Posted' })}
+        summary={makeSummary({ status: 'Posted' })}
+        onOpen={vi.fn()}
+        onClose={vi.fn()}
+        isOpenPending={false}
+        isClosePending={false}
+      />,
+    );
+    expect(screen.getByText(/posted batches cannot be modified/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^open$/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^close$/i })).toBeNull();
+  });
+
+  it('formats currency amounts with $0.00', () => {
+    render(
+      <BatchSummaryCard
+        batch={makeBatch({ controlAmount: 123.45 })}
+        summary={makeSummary({ actualAmount: 99.5, variance: -23.95 })}
+        onOpen={vi.fn()}
+        onClose={vi.fn()}
+        isOpenPending={false}
+        isClosePending={false}
+      />,
+    );
+    expect(screen.getByText('$123.45')).toBeInTheDocument();
+    expect(screen.getByText('$99.50')).toBeInTheDocument();
+  });
+
+  it('shows a dash when control amount is undefined', () => {
+    render(
+      <BatchSummaryCard
+        batch={makeBatch({ controlAmount: undefined, controlItemCount: undefined })}
+        summary={makeSummary({ actualAmount: 0, variance: 0 })}
+        onOpen={vi.fn()}
+        onClose={vi.fn()}
+        isOpenPending={false}
+        isClosePending={false}
+      />,
+    );
+    // At least one "-" rendered for control amount.
+    const dashes = screen.getAllByText('-');
+    expect(dashes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('shows loading text on the Close button when isClosePending=true', () => {
+    render(
+      <BatchSummaryCard
+        batch={makeBatch({ status: 'Open' })}
+        summary={makeSummary()}
+        onOpen={vi.fn()}
+        onClose={vi.fn()}
+        isOpenPending={false}
+        isClosePending
+      />,
+    );
+    expect(screen.getByText('Closing...')).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/groups/__tests__/GroupFilters.test.tsx
+++ b/src/web/src/components/groups/__tests__/GroupFilters.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * GroupFilters tests
+ *
+ * Catches:
+ *  - onFiltersChange receives the correct shape for each control (search,
+ *    campus, dayOfWeek, timeOfDay, hasOpenings).
+ *  - Empty string → undefined conversion preserves `omit filter` semantics.
+ *  - Clear Filters button visibility is driven by `hasActiveFilters`.
+ *  - Campus options come from the query result.
+ *  - dayOfWeek=0 (Sunday) correctly registers — regression category: numeric 0
+ *    can be falsy and easily lost.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/api/reference', () => ({
+  getCampuses: vi.fn(),
+}));
+import { getCampuses } from '@/services/api/reference';
+import { GroupFilters } from '../GroupFilters';
+
+function wrap(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+beforeEach(() => {
+  (getCampuses as ReturnType<typeof vi.fn>).mockResolvedValue([
+    { idKey: 'CAM1', name: 'Main Campus' },
+    { idKey: 'CAM2', name: 'North Campus' },
+  ]);
+});
+
+describe('GroupFilters', () => {
+  it('hides Clear Filters button when no filter is active', () => {
+    wrap(<GroupFilters filters={{}} onFiltersChange={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /clear filters/i })).toBeNull();
+  });
+
+  it('shows Clear Filters button when at least one filter is active', () => {
+    wrap(<GroupFilters filters={{ searchTerm: 'abc' }} onFiltersChange={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /clear filters/i })).toBeInTheDocument();
+  });
+
+  it('emits searchTerm through onFiltersChange', async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    wrap(<GroupFilters filters={{}} onFiltersChange={onFiltersChange} />);
+    await user.type(screen.getByLabelText(/search groups/i), 'a');
+    expect(onFiltersChange).toHaveBeenCalled();
+    expect(onFiltersChange.mock.lastCall?.[0].searchTerm).toBe('a');
+  });
+
+  it('emits undefined for searchTerm when cleared', async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    wrap(
+      <GroupFilters filters={{ searchTerm: 'abc' }} onFiltersChange={onFiltersChange} />,
+    );
+    const input = screen.getByLabelText(/search groups/i) as HTMLInputElement;
+    await user.clear(input);
+    expect(onFiltersChange.mock.lastCall?.[0].searchTerm).toBeUndefined();
+  });
+
+  it('emits numeric dayOfWeek=0 (Sunday) through onFiltersChange', async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    wrap(<GroupFilters filters={{}} onFiltersChange={onFiltersChange} />);
+    await user.selectOptions(screen.getByLabelText(/day of week/i), '0');
+    expect(onFiltersChange.mock.lastCall?.[0].dayOfWeek).toBe(0);
+  });
+
+  it('emits dayOfWeek=undefined when "Any Day" is picked', async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    wrap(
+      <GroupFilters filters={{ dayOfWeek: 1 }} onFiltersChange={onFiltersChange} />,
+    );
+    await user.selectOptions(screen.getByLabelText(/day of week/i), '');
+    expect(onFiltersChange.mock.lastCall?.[0].dayOfWeek).toBeUndefined();
+  });
+
+  it('emits hasOpenings=true when the checkbox is ticked', async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    wrap(<GroupFilters filters={{}} onFiltersChange={onFiltersChange} />);
+    await user.click(screen.getByRole('checkbox'));
+    expect(onFiltersChange.mock.lastCall?.[0].hasOpenings).toBe(true);
+  });
+
+  it('emits hasOpenings=undefined when the checkbox is unchecked', async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    // Start with hasOpenings=true so the checkbox renders checked.
+    wrap(
+      <GroupFilters filters={{ hasOpenings: true }} onFiltersChange={onFiltersChange} />,
+    );
+    await user.click(screen.getByRole('checkbox'));
+    expect(onFiltersChange.mock.lastCall?.[0].hasOpenings).toBeUndefined();
+  });
+
+  it('clears all filters when Clear Filters is clicked', async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    wrap(
+      <GroupFilters
+        filters={{ searchTerm: 'x', dayOfWeek: 3 }}
+        onFiltersChange={onFiltersChange}
+      />,
+    );
+    await user.click(screen.getByRole('button', { name: /clear filters/i }));
+    expect(onFiltersChange).toHaveBeenLastCalledWith({});
+  });
+});

--- a/src/web/src/components/groups/__tests__/PendingRequestsBadge.test.tsx
+++ b/src/web/src/components/groups/__tests__/PendingRequestsBadge.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * PendingRequestsBadge tests
+ *
+ * Catches:
+ *  - Hidden when count=0 (silent state).
+ *  - Renders the number for reasonable counts.
+ *  - Caps display at "99+" for overflow counts.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PendingRequestsBadge } from '../PendingRequestsBadge';
+
+describe('PendingRequestsBadge', () => {
+  it('renders nothing when count is 0', () => {
+    const { container } = render(<PendingRequestsBadge count={0} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('displays the numeric count when between 1 and 99', () => {
+    render(<PendingRequestsBadge count={7} />);
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('caps display at 99+ for very large counts', () => {
+    render(<PendingRequestsBadge count={150} />);
+    expect(screen.getByText('99+')).toBeInTheDocument();
+    expect(screen.queryByText('150')).toBeNull();
+  });
+
+  it('displays exactly "99" at the boundary', () => {
+    render(<PendingRequestsBadge count={99} />);
+    expect(screen.getByText('99')).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/notifications/__tests__/NotificationItem.test.tsx
+++ b/src/web/src/components/notifications/__tests__/NotificationItem.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * NotificationItem tests
+ *
+ * Catches:
+ *  - Clicking an unread notification calls onMarkAsRead + optional onClick.
+ *  - Clicking a read notification does NOT call onMarkAsRead.
+ *  - Delete button calls onDelete and stops click propagation.
+ *  - Unread notifications show the "New" badge; read ones do not.
+ *  - Border-left colour depends on notificationType (regression category:
+ *    missing type → wrong visual indicator).
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { NotificationItem } from '../NotificationItem';
+import { NotificationType, type NotificationDto } from '@/types/notification';
+
+function notif(overrides: Partial<NotificationDto> = {}): NotificationDto {
+  return {
+    idKey: 'N1',
+    guid: '00000000-0000-0000-0000-000000000001',
+    notificationType: NotificationType.CheckinAlert,
+    title: 'Hello',
+    message: 'World',
+    isRead: false,
+    readDateTime: null,
+    actionUrl: null,
+    metadataJson: null,
+    createdDateTime: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('NotificationItem', () => {
+  it('marks unread notification as read on click', async () => {
+    const user = userEvent.setup();
+    const onMarkAsRead = vi.fn();
+    const onClick = vi.fn();
+
+    render(
+      <NotificationItem
+        notification={notif({ isRead: false })}
+        onMarkAsRead={onMarkAsRead}
+        onDelete={vi.fn()}
+        onClick={onClick}
+      />,
+    );
+
+    await user.click(screen.getByText('Hello'));
+    expect(onMarkAsRead).toHaveBeenCalledWith('N1');
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('does NOT call onMarkAsRead for already-read notification', async () => {
+    const user = userEvent.setup();
+    const onMarkAsRead = vi.fn();
+
+    render(
+      <NotificationItem
+        notification={notif({ isRead: true })}
+        onMarkAsRead={onMarkAsRead}
+        onDelete={vi.fn()}
+      />,
+    );
+
+    await user.click(screen.getByText('Hello'));
+    expect(onMarkAsRead).not.toHaveBeenCalled();
+  });
+
+  it('delete button calls onDelete without triggering the outer click handler', async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+    const onMarkAsRead = vi.fn();
+
+    render(
+      <NotificationItem
+        notification={notif({ isRead: false })}
+        onMarkAsRead={onMarkAsRead}
+        onDelete={onDelete}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', { name: /delete notification/i }));
+    expect(onDelete).toHaveBeenCalledWith('N1');
+    // stopPropagation prevents the outer click from firing the mark-as-read path.
+    expect(onMarkAsRead).not.toHaveBeenCalled();
+  });
+
+  it('shows "New" badge for unread notifications', () => {
+    render(
+      <NotificationItem
+        notification={notif({ isRead: false })}
+        onMarkAsRead={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('New')).toBeInTheDocument();
+  });
+
+  it('hides "New" badge for read notifications', () => {
+    render(
+      <NotificationItem
+        notification={notif({ isRead: true })}
+        onMarkAsRead={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText('New')).toBeNull();
+  });
+
+  it.each([
+    [NotificationType.CheckinAlert, 'border-l-blue-500'],
+    [NotificationType.CommunicationStatus, 'border-l-purple-500'],
+    [NotificationType.SystemAlert, 'border-l-yellow-500'],
+    [NotificationType.MembershipRequest, 'border-l-green-500'],
+    [NotificationType.FollowUp, 'border-l-orange-500'],
+  ])('renders correct border for type %i', (type, expectedClass) => {
+    const { container } = render(
+      <NotificationItem
+        notification={notif({ notificationType: type, isRead: false })}
+        onMarkAsRead={vi.fn()}
+        onDelete={vi.fn()}
+      />,
+    );
+    expect(container.querySelector(`.${expectedClass}`)).not.toBeNull();
+  });
+});

--- a/src/web/src/components/profile/__tests__/FamilySection.test.tsx
+++ b/src/web/src/components/profile/__tests__/FamilySection.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * FamilySection tests
+ *
+ * Catches:
+ *  - Empty-state rendering with friendly message.
+ *  - One FamilyMemberCard is rendered per member.
+ *  - Grid heading renders for non-empty list.
+ */
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it } from 'vitest';
+import { FamilySection } from '../FamilySection';
+import type { FamilyMemberDto } from '@/types/profile';
+
+function renderWithClient(ui: React.ReactNode) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>);
+}
+
+function member(overrides: Partial<FamilyMemberDto> = {}): FamilyMemberDto {
+  return {
+    idKey: 'M1',
+    firstName: 'Alice',
+    lastName: 'Smith',
+    fullName: 'Alice Smith',
+    gender: 'Female',
+    phoneNumbers: [],
+    familyRole: 'Adult',
+    canEdit: true,
+    hasCriticalAllergies: false,
+    ...overrides,
+  };
+}
+
+describe('FamilySection', () => {
+  it('renders empty-state when no members', () => {
+    renderWithClient(<FamilySection members={[]} />);
+    expect(screen.getByText(/no family members found/i)).toBeInTheDocument();
+  });
+
+  it('renders the heading when members are present', () => {
+    renderWithClient(<FamilySection members={[member()]} />);
+    expect(screen.getByRole('heading', { name: /your family/i })).toBeInTheDocument();
+  });
+
+  it('renders one card per member', () => {
+    renderWithClient(
+      <FamilySection
+        members={[
+          member({ idKey: 'M1', fullName: 'Alice Smith' }),
+          member({ idKey: 'M2', fullName: 'Bob Smith' }),
+        ]}
+      />,
+    );
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+    expect(screen.getByText('Bob Smith')).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/profile/__tests__/InvolvementSummary.test.tsx
+++ b/src/web/src/components/profile/__tests__/InvolvementSummary.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * InvolvementSummary tests
+ *
+ * Catches:
+ *  - Attendance counts render.
+ *  - Empty groups state with Browse Groups link.
+ *  - Group list renders name, type, role, and joined date.
+ *  - Invalid/missing joinedDate falls back to "N/A".
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { InvolvementSummary } from '../InvolvementSummary';
+import type { MyInvolvementDto } from '@/types/profile';
+
+function involvement(overrides: Partial<MyInvolvementDto> = {}): MyInvolvementDto {
+  return {
+    groups: [],
+    recentAttendanceCount: 0,
+    totalGroupsCount: 0,
+    ...overrides,
+  };
+}
+
+describe('InvolvementSummary', () => {
+  it('renders attendance and total counts', () => {
+    render(
+      <InvolvementSummary
+        involvement={involvement({ recentAttendanceCount: 12, totalGroupsCount: 3 })}
+      />,
+    );
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('shows empty-state for no groups with Browse Groups link', () => {
+    render(<InvolvementSummary involvement={involvement()} />);
+    expect(screen.getByText(/not a member of any groups yet/i)).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /browse groups/i });
+    expect(link).toHaveAttribute('href', '/groups');
+  });
+
+  it('renders group name, type, role, and joined date', () => {
+    render(
+      <InvolvementSummary
+        involvement={involvement({
+          totalGroupsCount: 1,
+          groups: [
+            {
+              idKey: 'G1',
+              groupName: 'Bible Study',
+              groupTypeName: 'Small Group',
+              role: 'Member',
+              isLeader: false,
+              // Use noon UTC so the local-tz conversion does not flip the day.
+              joinedDate: '2026-01-15T12:00:00Z',
+            },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText('Bible Study')).toBeInTheDocument();
+    expect(screen.getByText('Small Group')).toBeInTheDocument();
+    expect(screen.getByText('Member')).toBeInTheDocument();
+    // Date format like "Jan 15, 2026" — loose match tolerates tz differences.
+    expect(screen.getByText(/jan \d+, 2026/i)).toBeInTheDocument();
+  });
+
+  it('falls back to N/A for invalid joinedDate', () => {
+    render(
+      <InvolvementSummary
+        involvement={involvement({
+          totalGroupsCount: 1,
+          groups: [
+            {
+              idKey: 'G1',
+              groupName: 'G',
+              groupTypeName: 'T',
+              role: 'R',
+              isLeader: false,
+              joinedDate: 'not-a-date',
+            },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/pwa/__tests__/InstallPrompt.test.tsx
+++ b/src/web/src/components/pwa/__tests__/InstallPrompt.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * InstallPrompt tests
+ *
+ * Catches:
+ *  - Hidden until the beforeinstallprompt event fires.
+ *  - Shows install copy after the event is received.
+ *  - Install button calls the captured prompt() and then hides on "accepted".
+ *  - Dismiss button hides without calling prompt.
+ */
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { InstallPrompt } from '../InstallPrompt';
+
+function fireBeforeInstall(
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>,
+): ReturnType<typeof vi.fn> {
+  const promptMock = vi.fn().mockResolvedValue(undefined);
+  const event: Event & { prompt?: unknown; userChoice?: unknown } = new Event(
+    'beforeinstallprompt',
+  );
+  (event as unknown as { prompt: typeof promptMock }).prompt = promptMock;
+  (event as unknown as { userChoice: typeof userChoice }).userChoice = userChoice;
+
+  act(() => {
+    window.dispatchEvent(event);
+  });
+
+  return promptMock;
+}
+
+describe('InstallPrompt', () => {
+  it('is hidden until beforeinstallprompt fires', () => {
+    render(<InstallPrompt />);
+    expect(screen.queryByText(/install check-in app/i)).toBeNull();
+  });
+
+  it('shows the install banner after beforeinstallprompt fires', () => {
+    render(<InstallPrompt />);
+    fireBeforeInstall(Promise.resolve({ outcome: 'accepted' }));
+    expect(screen.getByText(/install check-in app/i)).toBeInTheDocument();
+  });
+
+  it('calls prompt() and hides the banner when install is accepted', async () => {
+    const user = userEvent.setup();
+    render(<InstallPrompt />);
+    const promptMock = fireBeforeInstall(
+      Promise.resolve({ outcome: 'accepted' }),
+    );
+
+    await user.click(screen.getByRole('button', { name: /^install$/i }));
+    expect(promptMock).toHaveBeenCalled();
+
+    // Banner should be hidden after acceptance.
+    await screen.findByText(/install check-in app/i, {}, { timeout: 0 }).catch(() => {});
+    expect(screen.queryByText(/install check-in app/i)).toBeNull();
+  });
+
+  it('hides the banner when Not Now is clicked (no prompt call)', async () => {
+    const user = userEvent.setup();
+    render(<InstallPrompt />);
+    const promptMock = fireBeforeInstall(
+      Promise.resolve({ outcome: 'accepted' }),
+    );
+
+    await user.click(screen.getByRole('button', { name: /not now/i }));
+    expect(screen.queryByText(/install check-in app/i)).toBeNull();
+    expect(promptMock).not.toHaveBeenCalled();
+  });
+
+  it('dismiss X button hides the banner', async () => {
+    const user = userEvent.setup();
+    render(<InstallPrompt />);
+    fireBeforeInstall(Promise.resolve({ outcome: 'accepted' }));
+
+    await user.click(screen.getByRole('button', { name: /dismiss install prompt/i }));
+    expect(screen.queryByText(/install check-in app/i)).toBeNull();
+  });
+});

--- a/src/web/src/components/pwa/__tests__/OfflineIndicator.test.tsx
+++ b/src/web/src/components/pwa/__tests__/OfflineIndicator.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * OfflineIndicator tests
+ *
+ * Catches:
+ *  - Renders nothing when online and never was offline.
+ *  - Renders offline banner when navigator.onLine goes false.
+ *  - Renders "Back online" banner after going offline then online.
+ *  - role="status" + aria-live="polite" preserved (screen readers rely on this).
+ */
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { OfflineIndicator } from '../OfflineIndicator';
+
+function setOnline(value: boolean) {
+  Object.defineProperty(navigator, 'onLine', {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+beforeEach(() => {
+  setOnline(true);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('OfflineIndicator', () => {
+  it('renders nothing when online and never went offline', () => {
+    setOnline(true);
+    render(<OfflineIndicator />);
+    expect(screen.queryByTestId('offline-indicator')).toBeNull();
+  });
+
+  it('renders offline banner when the browser goes offline', () => {
+    setOnline(true);
+    render(<OfflineIndicator />);
+
+    act(() => {
+      setOnline(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    const banner = screen.getByTestId('offline-indicator');
+    expect(banner).toBeInTheDocument();
+    expect(banner.getAttribute('role')).toBe('status');
+    expect(banner.getAttribute('aria-live')).toBe('polite');
+    expect(banner.textContent).toMatch(/offline/i);
+  });
+
+  it('shows "Back online" banner after recovering from offline', () => {
+    setOnline(true);
+    render(<OfflineIndicator />);
+
+    // Go offline first.
+    act(() => {
+      setOnline(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+    expect(screen.getByTestId('offline-indicator').textContent).toMatch(/offline/i);
+
+    // Now come back online.
+    act(() => {
+      setOnline(true);
+      window.dispatchEvent(new Event('online'));
+    });
+
+    const banner = screen.getByTestId('offline-indicator');
+    expect(banner.textContent).toMatch(/back online/i);
+  });
+
+  it('removes the "Back online" banner after the 3-second timeout', () => {
+    vi.useFakeTimers();
+    setOnline(true);
+    render(<OfflineIndicator />);
+
+    act(() => {
+      setOnline(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    act(() => {
+      setOnline(true);
+      window.dispatchEvent(new Event('online'));
+    });
+
+    expect(screen.getByTestId('offline-indicator').textContent).toMatch(/back online/i);
+
+    act(() => {
+      vi.advanceTimersByTime(3100);
+    });
+
+    expect(screen.queryByTestId('offline-indicator')).toBeNull();
+  });
+});

--- a/src/web/src/components/pwa/__tests__/PWAUpdatePrompt.test.tsx
+++ b/src/web/src/components/pwa/__tests__/PWAUpdatePrompt.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * PWAUpdatePrompt tests
+ *
+ * Catches:
+ *  - Hidden until needRefresh=true.
+ *  - Shows the "Update Now" and "Later" buttons when visible.
+ *  - onUpdate fires when the user confirms the update.
+ *  - Later button dismisses the banner.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { PWAUpdatePrompt } from '../PWAUpdatePrompt';
+
+describe('PWAUpdatePrompt', () => {
+  it('is hidden when needRefresh=false', () => {
+    render(<PWAUpdatePrompt onUpdate={vi.fn()} needRefresh={false} />);
+    expect(screen.queryByTestId('pwa-update-prompt')).toBeNull();
+  });
+
+  it('shows when needRefresh becomes true', () => {
+    render(<PWAUpdatePrompt onUpdate={vi.fn()} needRefresh />);
+    expect(screen.getByTestId('pwa-update-prompt')).toBeInTheDocument();
+    expect(screen.getByText(/new version available/i)).toBeInTheDocument();
+  });
+
+  it('fires onUpdate when Update Now is clicked', async () => {
+    const user = userEvent.setup();
+    const onUpdate = vi.fn();
+    render(<PWAUpdatePrompt onUpdate={onUpdate} needRefresh />);
+
+    await user.click(screen.getByRole('button', { name: /update now/i }));
+    expect(onUpdate).toHaveBeenCalledOnce();
+  });
+
+  it('dismisses the banner when Later is clicked', async () => {
+    const user = userEvent.setup();
+    render(<PWAUpdatePrompt onUpdate={vi.fn()} needRefresh />);
+
+    expect(screen.getByTestId('pwa-update-prompt')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /later/i }));
+    expect(screen.queryByTestId('pwa-update-prompt')).toBeNull();
+  });
+});

--- a/src/web/src/components/ui/__tests__/AccessibleSelect.test.tsx
+++ b/src/web/src/components/ui/__tests__/AccessibleSelect.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * AccessibleSelect tests
+ *
+ * Catches:
+ *  - Label is associated via htmlFor (a11y + Playwright getByLabel).
+ *  - Native select + custom listbox both render options (required for Playwright
+ *    .selectOption() AND getByRole('option')).
+ *  - Clicking an option in the custom listbox calls onChange + closes.
+ *  - Escape key closes the dropdown.
+ *  - Error message renders with red styling.
+ *  - Clicking outside the component closes the dropdown.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { AccessibleSelect } from '../AccessibleSelect';
+
+const options = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Bravo' },
+];
+
+describe('AccessibleSelect', () => {
+  it('renders the label associated to the select via htmlFor', () => {
+    render(
+      <AccessibleSelect
+        label="Pick"
+        value="a"
+        options={options}
+        onChange={() => {}}
+      />,
+    );
+    const label = screen.getByText('Pick');
+    const select = screen.getByLabelText('Pick');
+    expect(label).toBeInTheDocument();
+    expect(select).toBeInTheDocument();
+  });
+
+  it('selecting an option via the native select calls onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <AccessibleSelect value="a" options={options} onChange={onChange} />,
+    );
+    const native = screen.getByRole('combobox') as HTMLSelectElement;
+    await user.selectOptions(native, 'b');
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('clicking a custom listbox option calls onChange with the chosen value', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const onBlur = vi.fn();
+    const { container } = render(
+      <AccessibleSelect
+        value="a"
+        options={options}
+        onChange={onChange}
+        onBlur={onBlur}
+      />,
+    );
+
+    // Open by clicking the native select (mousedown toggles the DOM dropdown).
+    const native = container.querySelector('select')!;
+    await user.click(native);
+
+    const bravoOption = screen.getByRole('option', { name: 'Bravo' });
+    await user.click(bravoOption);
+
+    expect(onChange).toHaveBeenCalledWith('b');
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  it('marks the current value as aria-selected in the custom listbox', () => {
+    render(<AccessibleSelect value="b" options={options} onChange={() => {}} />);
+    const selected = screen.getByRole('option', { name: 'Bravo' });
+    expect(selected.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('renders an error message and applies red border styling', () => {
+    const { container } = render(
+      <AccessibleSelect
+        value="a"
+        options={options}
+        onChange={() => {}}
+        error="Required"
+      />,
+    );
+    expect(screen.getByText('Required')).toBeInTheDocument();
+    expect(container.querySelector('.border-red-500')).not.toBeNull();
+  });
+
+  it('closes the dropdown when the Escape key is pressed on the select', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <AccessibleSelect value="a" options={options} onChange={() => {}} />,
+    );
+    const native = container.querySelector('select')!;
+    await user.click(native);
+
+    // Listbox is visible (does not have the `hidden` class).
+    const listboxOpen = container.querySelector('[role="listbox"]')!;
+    expect(listboxOpen.className).not.toMatch(/hidden/);
+
+    native.focus();
+    await user.keyboard('{Escape}');
+
+    const listboxAfter = container.querySelector('[role="listbox"]')!;
+    expect(listboxAfter.className).toMatch(/hidden/);
+  });
+});

--- a/src/web/src/components/ui/__tests__/ConfirmDialog.test.tsx
+++ b/src/web/src/components/ui/__tests__/ConfirmDialog.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * ConfirmDialog tests
+ *
+ * Catches:
+ *  - Renders nothing when isOpen=false (prevents stray modals in tests).
+ *  - role="dialog" + aria-modal="true" + aria-labelledby (accessibility regressions).
+ *  - Confirm / Cancel callbacks fire on clicks.
+ *  - Escape key closes the dialog but NOT while isLoading.
+ *  - Backdrop click closes the dialog.
+ *  - Loading state disables the cancel button.
+ *  - Variant changes the confirm button styling.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ConfirmDialog } from '../ConfirmDialog';
+
+function renderDialog(overrides: Partial<Parameters<typeof ConfirmDialog>[0]> = {}) {
+  const onClose = vi.fn();
+  const onConfirm = vi.fn();
+  render(
+    <ConfirmDialog
+      isOpen
+      onClose={onClose}
+      onConfirm={onConfirm}
+      title="Delete user?"
+      description="This cannot be undone."
+      {...overrides}
+    />,
+  );
+  return { onClose, onConfirm };
+}
+
+describe('ConfirmDialog', () => {
+  it('renders nothing when isOpen is false', () => {
+    render(
+      <ConfirmDialog
+        isOpen={false}
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        title="hidden"
+      />,
+    );
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders with dialog role and aria attributes', () => {
+    renderDialog();
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.getAttribute('aria-modal')).toBe('true');
+    expect(dialog.getAttribute('aria-labelledby')).toBe('dialog-title');
+    expect(dialog.getAttribute('aria-describedby')).toBe('dialog-description');
+  });
+
+  it('omits aria-describedby when no description provided', () => {
+    render(
+      <ConfirmDialog
+        isOpen
+        onClose={vi.fn()}
+        onConfirm={vi.fn()}
+        title="No desc"
+      />,
+    );
+    expect(screen.getByRole('dialog').getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('fires onConfirm when the confirm button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onConfirm } = renderDialog({ confirmLabel: 'Delete' });
+    await user.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('fires onClose when the cancel button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderDialog({ cancelLabel: 'Cancel' });
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('closes on Escape key when not loading', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderDialog();
+    await user.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT close on Escape while loading', async () => {
+    const user = userEvent.setup();
+    const { onClose } = renderDialog({ isLoading: true });
+    await user.keyboard('{Escape}');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('disables the cancel button while loading', () => {
+    renderDialog({ isLoading: true, cancelLabel: 'Cancel' });
+    const cancelButton = screen.getByRole('button', { name: 'Cancel' });
+    expect(cancelButton).toBeDisabled();
+  });
+
+  it('applies danger styling to the confirm button by default', () => {
+    renderDialog({ confirmLabel: 'Delete' });
+    const confirm = screen.getByRole('button', { name: 'Delete' });
+    expect(confirm.className).toMatch(/bg-red-600/);
+  });
+
+  it('applies warning styling when variant="warning"', () => {
+    renderDialog({ variant: 'warning', confirmLabel: 'Proceed' });
+    const confirm = screen.getByRole('button', { name: 'Proceed' });
+    expect(confirm.className).toMatch(/bg-yellow-600/);
+  });
+
+  it('applies info styling when variant="info"', () => {
+    renderDialog({ variant: 'info', confirmLabel: 'Ok' });
+    const confirm = screen.getByRole('button', { name: 'Ok' });
+    expect(confirm.className).toMatch(/bg-blue-600/);
+  });
+});

--- a/src/web/src/components/ui/__tests__/EmptyState.test.tsx
+++ b/src/web/src/components/ui/__tests__/EmptyState.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * EmptyState tests
+ *
+ * Catches:
+ *  - Title always renders at h3 level.
+ *  - Description is optional (absent when not provided).
+ *  - Action button only renders when provided, clicking fires the callback.
+ *  - Custom icon overrides the default inbox icon.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { EmptyState } from '../EmptyState';
+
+describe('EmptyState', () => {
+  it('renders the title as a heading', () => {
+    render(<EmptyState title="No items" />);
+    expect(screen.getByRole('heading', { level: 3, name: 'No items' })).toBeInTheDocument();
+  });
+
+  it('omits description when not provided', () => {
+    const { container } = render(<EmptyState title="No items" />);
+    expect(container.querySelectorAll('p')).toHaveLength(0);
+  });
+
+  it('renders the description when provided', () => {
+    render(<EmptyState title="No items" description="Try again" />);
+    expect(screen.getByText('Try again')).toBeInTheDocument();
+  });
+
+  it('does not render an action button when no action is provided', () => {
+    render(<EmptyState title="No items" />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('renders the action button and fires onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <EmptyState
+        title="No items"
+        action={{ label: 'Create one', onClick }}
+      />,
+    );
+    const btn = screen.getByRole('button', { name: 'Create one' });
+    await user.click(btn);
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('uses a custom icon when provided (default inbox icon is replaced)', () => {
+    const CustomIcon = () => <svg data-testid="custom-icon" />;
+    render(<EmptyState title="t" icon={<CustomIcon />} />);
+    expect(screen.getByTestId('custom-icon')).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/ui/__tests__/ErrorState.test.tsx
+++ b/src/web/src/components/ui/__tests__/ErrorState.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * ErrorState tests
+ *
+ * Catches:
+ *  - Heading uses red-600 text colour (distinct from EmptyState which is neutral).
+ *  - Message renders only when provided.
+ *  - Retry button only shows when onRetry is provided and triggers the callback.
+ *  - Default error icon renders when no custom icon is passed.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { ErrorState } from '../ErrorState';
+
+describe('ErrorState', () => {
+  it('renders the title as a heading using error styling', () => {
+    render(<ErrorState title="Boom" />);
+    const heading = screen.getByRole('heading', { level: 3, name: 'Boom' });
+    expect(heading).toBeInTheDocument();
+    expect(heading.className).toMatch(/text-red-600/);
+  });
+
+  it('renders the message when provided', () => {
+    render(<ErrorState title="Boom" message="details" />);
+    expect(screen.getByText('details')).toBeInTheDocument();
+  });
+
+  it('omits the message node when not provided', () => {
+    const { container } = render(<ErrorState title="Boom" />);
+    expect(container.querySelectorAll('p')).toHaveLength(0);
+  });
+
+  it('does not render a retry button when onRetry is absent', () => {
+    render(<ErrorState title="Boom" />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('renders the retry button and fires onRetry when clicked', async () => {
+    const user = userEvent.setup();
+    const onRetry = vi.fn();
+    render(<ErrorState title="Boom" onRetry={onRetry} />);
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('renders a custom icon in place of the default error icon', () => {
+    render(
+      <ErrorState title="Boom" icon={<svg data-testid="custom-error-icon" />} />,
+    );
+    expect(screen.getByTestId('custom-error-icon')).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/ui/__tests__/Input.test.tsx
+++ b/src/web/src/components/ui/__tests__/Input.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Input tests
+ *
+ * Catches:
+ *  - Label text renders next to the input.
+ *  - Error message renders as text and applies the invalid styling class.
+ *  - forwardRef works (calling code needs this for focus / react-hook-form).
+ *  - User keystrokes propagate to the onChange prop (no swallowed events).
+ *  - Disabled state blocks input.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef, useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { Input } from '../Input';
+
+describe('Input', () => {
+  it('renders the label text when provided', () => {
+    render(<Input label="Email" />);
+    expect(screen.getByText('Email')).toBeInTheDocument();
+  });
+
+  it('omits the label node entirely when no label prop is passed', () => {
+    const { container } = render(<Input placeholder="anon" />);
+    expect(container.querySelector('label')).toBeNull();
+  });
+
+  it('renders the error message and marks the field with error styling', () => {
+    render(<Input label="Email" error="Required" placeholder="x" />);
+    expect(screen.getByText('Required')).toBeInTheDocument();
+    const input = screen.getByRole('textbox');
+    expect(input.className).toMatch(/border-red-500/);
+  });
+
+  it('applies neutral border styling when no error is present', () => {
+    render(<Input label="Email" placeholder="x" />);
+    const input = screen.getByRole('textbox');
+    expect(input.className).toMatch(/border-gray-300/);
+  });
+
+  it('forwards the ref to the underlying input element', () => {
+    const ref = createRef<HTMLInputElement>();
+    render(<Input ref={ref} label="f" />);
+    expect(ref.current).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it('propagates user keystrokes to onChange', async () => {
+    const user = userEvent.setup();
+
+    function Controlled() {
+      const [v, setV] = useState('');
+      return <Input label="Name" value={v} onChange={(e) => setV(e.target.value)} />;
+    }
+
+    render(<Controlled />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    await user.type(input, 'abc');
+    expect(input.value).toBe('abc');
+  });
+
+  it('calls onChange for each keystroke', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Input label="x" onChange={onChange} />);
+    await user.type(screen.getByRole('textbox'), 'ab');
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('respects the disabled prop', async () => {
+    const user = userEvent.setup();
+    render(<Input label="x" disabled />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+    await user.type(input, 'abc');
+    expect(input.value).toBe('');
+  });
+});

--- a/src/web/src/components/ui/__tests__/Loading.test.tsx
+++ b/src/web/src/components/ui/__tests__/Loading.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Loading tests
+ *
+ * Catches:
+ *  - Default variant is the spinner role=status.
+ *  - `variant` switches to dots or skeleton (different visuals, same a11y affordance).
+ *  - `aria-busy="true"` is set on the wrapper (screen readers rely on this).
+ *  - Optional text renders with an aria-live region.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Loading } from '../Loading';
+
+describe('Loading', () => {
+  it('renders a spinner with role="status" by default', () => {
+    render(<Loading />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('wraps the variant in an aria-busy="true" container', () => {
+    const { container } = render(<Loading />);
+    const busy = container.querySelector('[aria-busy="true"]');
+    expect(busy).not.toBeNull();
+  });
+
+  it('renders the dots variant with role="status"', () => {
+    render(<Loading variant="dots" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders the skeleton variant with role="status"', () => {
+    render(<Loading variant="skeleton" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('renders the optional text with an aria-live polite region', () => {
+    render(<Loading text="Loading data..." />);
+    const text = screen.getByText('Loading data...');
+    expect(text).toBeInTheDocument();
+    expect(text.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('does not render any text node when text is omitted', () => {
+    render(<Loading />);
+    expect(screen.queryByText(/Loading data/)).toBeNull();
+  });
+
+  it('respects the size prop on the spinner', () => {
+    const { container } = render(<Loading size="lg" />);
+    // large spinner => w-12 h-12 class.
+    expect(container.querySelector('.w-12.h-12')).not.toBeNull();
+  });
+});

--- a/src/web/src/components/ui/__tests__/PhoneInput.test.tsx
+++ b/src/web/src/components/ui/__tests__/PhoneInput.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * PhoneInput tests
+ *
+ * Catches:
+ *  - Digits-only output contract: onChange always receives digits, not the formatted string.
+ *  - Progressive formatting as the user types (3 → 6 → 10 digits).
+ *  - Caps at 10 digits even when the user types more.
+ *  - Strips non-digit input characters.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { PhoneInput } from '../PhoneInput';
+
+function Controlled({ onChange }: { onChange?: (v: string) => void }) {
+  const [v, setV] = useState('');
+  return (
+    <PhoneInput
+      label="Phone"
+      value={v}
+      onChange={(next) => {
+        setV(next);
+        onChange?.(next);
+      }}
+    />
+  );
+}
+
+describe('PhoneInput', () => {
+  it('formats progressively and emits digits-only values', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Controlled onChange={onChange} />);
+
+    const input = screen.getByPlaceholderText('(555) 123-4567') as HTMLInputElement;
+
+    await user.type(input, '5551234567');
+
+    // Last emitted value is digits-only, 10 chars.
+    expect(onChange).toHaveBeenLastCalledWith('5551234567');
+    // Displayed value is formatted.
+    expect(input.value).toBe('(555) 123-4567');
+  });
+
+  it('formats after 3 digits as "(XXX) "', async () => {
+    const user = userEvent.setup();
+    render(<Controlled />);
+    const input = screen.getByPlaceholderText('(555) 123-4567') as HTMLInputElement;
+    await user.type(input, '555');
+    expect(input.value).toBe('555');
+    await user.type(input, '1');
+    expect(input.value).toBe('(555) 1');
+  });
+
+  it('formats after 6 digits as "(XXX) XXX-"', async () => {
+    const user = userEvent.setup();
+    render(<Controlled />);
+    const input = screen.getByPlaceholderText('(555) 123-4567') as HTMLInputElement;
+    await user.type(input, '555123');
+    expect(input.value).toBe('(555) 123');
+    await user.type(input, '4');
+    expect(input.value).toBe('(555) 123-4');
+  });
+
+  it('caps input at 10 digits (extra characters ignored)', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Controlled onChange={onChange} />);
+    const input = screen.getByPlaceholderText('(555) 123-4567') as HTMLInputElement;
+
+    await user.type(input, '55512345679999');
+    expect(input.value).toBe('(555) 123-4567');
+    expect(onChange).toHaveBeenLastCalledWith('5551234567');
+  });
+
+  it('strips non-digit characters from input', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Controlled onChange={onChange} />);
+    const input = screen.getByPlaceholderText('(555) 123-4567') as HTMLInputElement;
+
+    await user.type(input, 'abc555-def');
+    expect(onChange).toHaveBeenLastCalledWith('555');
+    expect(input.value).toBe('555');
+  });
+
+  it('renders with tel input type and a placeholder', () => {
+    render(<Controlled />);
+    const input = screen.getByPlaceholderText('(555) 123-4567') as HTMLInputElement;
+    expect(input.type).toBe('tel');
+    expect(input.placeholder).toBe('(555) 123-4567');
+  });
+});

--- a/src/web/src/components/ui/__tests__/Select.test.tsx
+++ b/src/web/src/components/ui/__tests__/Select.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Select tests
+ *
+ * Catches:
+ *  - Options are rendered from the options prop (missing entries = user can't pick).
+ *  - Label/ref wiring (accessibility + react-hook-form integration).
+ *  - Error message renders and triggers invalid styling.
+ *  - onChange fires with selected value.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { createRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { Select } from '../Select';
+
+const options = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Bravo' },
+  { value: 'c', label: 'Charlie' },
+];
+
+describe('Select', () => {
+  it('renders all options from the options prop', () => {
+    render(<Select label="Pick" options={options} defaultValue="a" onChange={() => {}} />);
+    expect(screen.getByRole('option', { name: 'Alpha' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Bravo' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Charlie' })).toBeInTheDocument();
+  });
+
+  it('wires up a visible label to the underlying select', () => {
+    render(<Select label="Choose" options={options} defaultValue="a" onChange={() => {}} />);
+    expect(screen.getByText('Choose')).toBeInTheDocument();
+  });
+
+  it('fires onChange with the selected value', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Select label="Pick" options={options} defaultValue="a" onChange={onChange} />,
+    );
+    const select = screen.getByRole('combobox') as HTMLSelectElement;
+    await user.selectOptions(select, 'b');
+    expect(select.value).toBe('b');
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('applies error styling and renders the error message', () => {
+    render(
+      <Select
+        label="Pick"
+        options={options}
+        defaultValue="a"
+        onChange={() => {}}
+        error="Required"
+      />,
+    );
+    expect(screen.getByText('Required')).toBeInTheDocument();
+    expect(screen.getByRole('combobox').className).toMatch(/border-red-500/);
+  });
+
+  it('forwards the ref to the underlying select element', () => {
+    const ref = createRef<HTMLSelectElement>();
+    render(
+      <Select
+        ref={ref}
+        label="Pick"
+        options={options}
+        defaultValue="a"
+        onChange={() => {}}
+      />,
+    );
+    expect(ref.current).toBeInstanceOf(HTMLSelectElement);
+  });
+});

--- a/src/web/src/components/ui/__tests__/Skeleton.test.tsx
+++ b/src/web/src/components/ui/__tests__/Skeleton.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Skeleton tests
+ *
+ * Catches:
+ *  - role="status" + aria-label exposed for assistive tech (catches a11y regression).
+ *  - Variant controls the rounding class (rounded / rounded-full / rounded-lg).
+ *  - width/height props render as px when numeric and pass-through when string.
+ *  - Skeleton.Text multi-line mode renders `lines` placeholders.
+ *  - Skeleton.Avatar uses circular variant.
+ *  - Skeleton.Card composes rectangle + text blocks.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Skeleton } from '../Skeleton';
+
+describe('Skeleton', () => {
+  it('renders with role="status" and an aria-label', () => {
+    render(<Skeleton />);
+    const el = screen.getByRole('status');
+    expect(el.getAttribute('aria-label')).toBe('Loading content');
+  });
+
+  it('applies the rectangular rounding by default', () => {
+    const { container } = render(<Skeleton />);
+    expect(container.firstChild).toHaveClass('rounded-lg');
+  });
+
+  it('applies the text rounding for variant="text"', () => {
+    const { container } = render(<Skeleton variant="text" />);
+    expect(container.firstChild).toHaveClass('rounded');
+  });
+
+  it('applies the circular rounding for variant="circular"', () => {
+    const { container } = render(<Skeleton variant="circular" />);
+    expect(container.firstChild).toHaveClass('rounded-full');
+  });
+
+  it('converts numeric width/height to pixel values', () => {
+    const { container } = render(<Skeleton width={100} height={40} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe('100px');
+    expect(el.style.height).toBe('40px');
+  });
+
+  it('passes string width through unchanged', () => {
+    const { container } = render(<Skeleton width="75%" />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe('75%');
+  });
+});
+
+describe('Skeleton.Text', () => {
+  it('renders a single placeholder when lines=1', () => {
+    const { container } = render(<Skeleton.Text />);
+    // One status element for a single line.
+    expect(container.querySelectorAll('[role="status"]')).toHaveLength(1);
+  });
+
+  it('renders one placeholder per line when lines>1', () => {
+    const { container } = render(<Skeleton.Text lines={3} />);
+    expect(container.querySelectorAll('[role="status"]')).toHaveLength(3);
+  });
+});
+
+describe('Skeleton.Avatar', () => {
+  it('uses the circular variant', () => {
+    const { container } = render(<Skeleton.Avatar />);
+    expect(container.firstChild).toHaveClass('rounded-full');
+  });
+
+  it('applies the size prop as both width and height in pixels', () => {
+    const { container } = render(<Skeleton.Avatar size={32} />);
+    const el = container.firstChild as HTMLElement;
+    expect(el.style.width).toBe('32px');
+    expect(el.style.height).toBe('32px');
+  });
+});
+
+describe('Skeleton.Card', () => {
+  it('renders multiple placeholders (rectangle plus text lines)', () => {
+    const { container } = render(<Skeleton.Card />);
+    expect(container.querySelectorAll('[role="status"]').length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/web/src/components/ui/__tests__/Toast.test.tsx
+++ b/src/web/src/components/ui/__tests__/Toast.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Toast component tests
+ *
+ * Catches:
+ *  - ToastContainer exposes an aria-live polite region (screen readers).
+ *  - Each toast is rendered with role="alert".
+ *  - All four variants (success/error/warning/info) render with distinct styling.
+ *  - Close button has an accessible name and removes the toast on click.
+ *  - Auto-dismiss begins hide animation before the duration elapses.
+ */
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ToastProvider, useToast } from '../../../contexts/ToastContext';
+import { ToastContainer } from '../Toast';
+
+function Seeder({
+  variant,
+  duration,
+}: {
+  variant: 'success' | 'error' | 'warning' | 'info';
+  duration?: number;
+}) {
+  const { addToast } = useToast();
+  return (
+    <button
+      onClick={() =>
+        addToast({
+          title: `${variant} title`,
+          message: `${variant} msg`,
+          variant,
+          duration,
+        })
+      }
+    >
+      seed-{variant}
+    </button>
+  );
+}
+
+function renderWithProvider(ui: React.ReactNode) {
+  return render(
+    <ToastProvider>
+      {ui}
+      <ToastContainer />
+    </ToastProvider>,
+  );
+}
+
+describe('ToastContainer', () => {
+  it('exposes the container as an aria-live polite region', () => {
+    renderWithProvider(<Seeder variant="info" />);
+    const region = document.querySelector('[aria-live="polite"]');
+    expect(region).not.toBeNull();
+  });
+
+  it('renders nothing visible when there are no toasts', () => {
+    renderWithProvider(<Seeder variant="info" />);
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});
+
+describe('Toast render per variant', () => {
+  beforeEach(() => {
+    // Real timers — we test auto-dismiss separately.
+    vi.useRealTimers();
+  });
+
+  it('renders a success toast as role="alert"', async () => {
+    const user = userEvent.setup();
+    renderWithProvider(<Seeder variant="success" />);
+    await user.click(screen.getByRole('button', { name: 'seed-success' }));
+    const alert = await screen.findByRole('alert');
+    expect(alert).toBeInTheDocument();
+    expect(alert.className).toMatch(/bg-green-50/);
+  });
+
+  it('renders an error toast with red styling', async () => {
+    const user = userEvent.setup();
+    renderWithProvider(<Seeder variant="error" />);
+    await user.click(screen.getByRole('button', { name: 'seed-error' }));
+    const alert = await screen.findByRole('alert');
+    expect(alert.className).toMatch(/bg-red-50/);
+  });
+
+  it('renders a warning toast with yellow styling', async () => {
+    const user = userEvent.setup();
+    renderWithProvider(<Seeder variant="warning" />);
+    await user.click(screen.getByRole('button', { name: 'seed-warning' }));
+    expect((await screen.findByRole('alert')).className).toMatch(/bg-yellow-50/);
+  });
+
+  it('renders an info toast with blue styling', async () => {
+    const user = userEvent.setup();
+    renderWithProvider(<Seeder variant="info" />);
+    await user.click(screen.getByRole('button', { name: 'seed-info' }));
+    expect((await screen.findByRole('alert')).className).toMatch(/bg-blue-50/);
+  });
+});
+
+describe('Toast close interactions', () => {
+  it('renders a dismiss button with an accessible name', async () => {
+    const user = userEvent.setup();
+    renderWithProvider(<Seeder variant="info" />);
+    await user.click(screen.getByRole('button', { name: 'seed-info' }));
+    expect(
+      await screen.findByRole('button', { name: /dismiss notification/i }),
+    ).toBeInTheDocument();
+  });
+
+  it('removes the toast on dismiss click (after animation delay)', async () => {
+    const user = userEvent.setup();
+
+    renderWithProvider(<Seeder variant="info" />);
+    await user.click(screen.getByRole('button', { name: 'seed-info' }));
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: /dismiss notification/i }));
+
+    // Wait out the 200ms animation + buffer.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 400));
+    });
+
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});

--- a/src/web/src/contexts/__tests__/AuthContext.test.tsx
+++ b/src/web/src/contexts/__tests__/AuthContext.test.tsx
@@ -1,0 +1,357 @@
+/**
+ * AuthContext tests
+ *
+ * Covers:
+ *  - Hook guard rail (throws outside provider)
+ *  - Initial state from localStorage (no token, valid token, expired token)
+ *  - login success path (calls API, persists user, flips state)
+ *  - login failure path (clears state, preserves error message, rethrows)
+ *  - logout (calls API with refresh token, always clears local state)
+ *  - logout with missing refresh token (skips API call, still clears state)
+ *  - refreshAuth success (new tokens stored via setTokens)
+ *  - refreshAuth failure (clears tokens/user, resets state)
+ *  - refreshAuth with no refresh token (flips loading off without calling API)
+ */
+
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { AuthProvider, useAuthContext } from '../AuthContext';
+
+// Mock the API module so tests don't hit network.
+vi.mock('../../services/api', () => {
+  return {
+    authApi: {
+      login: vi.fn(),
+      logout: vi.fn(),
+      refresh: vi.fn(),
+    },
+    setTokens: vi.fn(),
+    clearTokens: vi.fn(),
+    getRefreshToken: vi.fn(),
+  };
+});
+
+import * as apiModule from '../../services/api';
+
+const { authApi, setTokens, clearTokens, getRefreshToken } = apiModule as unknown as {
+  authApi: {
+    login: ReturnType<typeof vi.fn>;
+    logout: ReturnType<typeof vi.fn>;
+    refresh: ReturnType<typeof vi.fn>;
+  };
+  setTokens: ReturnType<typeof vi.fn>;
+  clearTokens: ReturnType<typeof vi.fn>;
+  getRefreshToken: ReturnType<typeof vi.fn>;
+};
+
+const USER_STORAGE_KEY = 'koinon_user';
+const ACCESS_TOKEN_KEY = 'koinon_access_token';
+
+function fakeUser(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    idKey: 'USR1',
+    userName: 'alice',
+    fullName: 'Alice Example',
+    email: 'alice@example.test',
+    personIdKey: 'PER1',
+    isSystemAdmin: false,
+    ...overrides,
+  };
+}
+
+// Build a JWT whose `exp` claim is `secondsFromNow` seconds from the current time.
+function makeJwt(secondsFromNow: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString(
+    'base64url',
+  );
+  const payload = Buffer.from(
+    JSON.stringify({ sub: 'alice', exp: Math.floor(Date.now() / 1000) + secondsFromNow }),
+  ).toString('base64url');
+  return `${header}.${payload}.signature`;
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('useAuthContext', () => {
+  it('throws if used outside AuthProvider', () => {
+    // Silence the expected React error boundary log.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useAuthContext())).toThrow(
+      /useAuthContext must be used within AuthProvider/,
+    );
+    spy.mockRestore();
+  });
+});
+
+describe('AuthProvider initial state', () => {
+  it('defaults to unauthenticated when no token present', () => {
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it('starts authenticated when access token is still valid', () => {
+    localStorage.setItem(ACCESS_TOKEN_KEY, makeJwt(3600));
+    const storedUser = fakeUser();
+    localStorage.setItem(USER_STORAGE_KEY, JSON.stringify(storedUser));
+
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.user).toEqual(storedUser);
+  });
+
+  it('starts loading and attempts refresh when token is expired', async () => {
+    localStorage.setItem(ACCESS_TOKEN_KEY, makeJwt(-60));
+    getRefreshToken.mockReturnValue('refresh-abc');
+    authApi.refresh.mockResolvedValue({
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+    });
+
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+
+    // Initial synchronous state: loading until the effect resolves.
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(authApi.refresh).toHaveBeenCalledWith('refresh-abc');
+    expect(setTokens).toHaveBeenCalledWith('new-access', 'new-refresh');
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('treats a malformed token as no token (unauthenticated, not loading)', () => {
+    localStorage.setItem(ACCESS_TOKEN_KEY, 'not-a-jwt');
+    // Token is present but invalid → loading branch triggers a refresh attempt,
+    // but with no refresh token the provider should settle to loading=false.
+    getRefreshToken.mockReturnValue(null);
+
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+
+    // The malformed token triggers the "expired token" path → loading initially true,
+    // then cleared by refreshAuth when there is no refresh token.
+    return waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+});
+
+describe('AuthProvider.login', () => {
+  it('authenticates and persists user on success', async () => {
+    const user = fakeUser({ userName: 'bob' });
+    authApi.login.mockResolvedValue({
+      accessToken: 'a',
+      refreshToken: 'r',
+      user,
+    });
+
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+
+    await act(async () => {
+      await result.current.login({ email: 'bob', password: 'pw' });
+    });
+
+    expect(authApi.login).toHaveBeenCalledWith({ email: 'bob', password: 'pw' });
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user).toEqual(user);
+    expect(result.current.error).toBeNull();
+    expect(localStorage.getItem(USER_STORAGE_KEY)).toBe(JSON.stringify(user));
+  });
+
+  it('records error message and rethrows on login failure', async () => {
+    authApi.login.mockRejectedValue(new Error('bad creds'));
+
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await result.current.login({ email: 'bob', password: 'wrong' });
+      } catch (e) {
+        caught = e;
+      }
+    });
+
+    expect((caught as Error)?.message).toBe('bad creds');
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(result.current.error).toBe('bad creds');
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('uses a fallback message when the login error is not an Error instance', async () => {
+    authApi.login.mockRejectedValue('network down');
+
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+
+    await act(async () => {
+      try {
+        await result.current.login({ email: 'bob', password: 'x' });
+      } catch {
+        /* ignore — we're checking the state mutation */
+      }
+    });
+
+    expect(result.current.error).toBe('Login failed');
+  });
+});
+
+describe('AuthProvider.logout', () => {
+  it('calls the API with the refresh token and clears local state', async () => {
+    getRefreshToken.mockReturnValue('refresh-abc');
+    authApi.logout.mockResolvedValue(undefined);
+
+    // Seed authenticated state via login.
+    authApi.login.mockResolvedValue({
+      accessToken: 'a',
+      refreshToken: 'r',
+      user: fakeUser(),
+    });
+
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+    await act(async () => {
+      await result.current.login({ email: 'a', password: 'b' });
+    });
+    expect(result.current.isAuthenticated).toBe(true);
+
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(authApi.logout).toHaveBeenCalledWith('refresh-abc');
+    expect(clearTokens).toHaveBeenCalled();
+    expect(localStorage.getItem(USER_STORAGE_KEY)).toBeNull();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  it('still clears state when the logout API call fails', async () => {
+    getRefreshToken.mockReturnValue('refresh-abc');
+    authApi.logout.mockRejectedValue(new Error('server down'));
+    authApi.login.mockResolvedValue({
+      accessToken: 'a',
+      refreshToken: 'r',
+      user: fakeUser(),
+    });
+
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+    await act(async () => {
+      await result.current.login({ email: 'a', password: 'b' });
+    });
+
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await result.current.logout();
+      } catch (e) {
+        caught = e;
+      }
+    });
+
+    expect((caught as Error)?.message).toBe('server down');
+    expect(clearTokens).toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+
+  it('skips the API call entirely when no refresh token is present', async () => {
+    getRefreshToken.mockReturnValue(null);
+
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+    await act(async () => {
+      await result.current.logout();
+    });
+
+    expect(authApi.logout).not.toHaveBeenCalled();
+    expect(clearTokens).toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(false);
+  });
+});
+
+describe('AuthProvider.refreshAuth', () => {
+  it('stores rotated tokens and keeps the existing user', async () => {
+    getRefreshToken.mockReturnValue('refresh-abc');
+    authApi.refresh.mockResolvedValue({
+      accessToken: 'new-access',
+      refreshToken: 'new-refresh',
+    });
+
+    // Seed authenticated state so we can verify user is preserved across refresh.
+    const seededUser = fakeUser({ userName: 'carol' });
+    authApi.login.mockResolvedValue({
+      accessToken: 'a',
+      refreshToken: 'r',
+      user: seededUser,
+    });
+
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+    await act(async () => {
+      await result.current.login({ email: 'carol', password: 'pw' });
+    });
+
+    await act(async () => {
+      await result.current.refreshAuth();
+    });
+
+    expect(authApi.refresh).toHaveBeenCalledWith('refresh-abc');
+    expect(setTokens).toHaveBeenCalledWith('new-access', 'new-refresh');
+    expect(result.current.user).toEqual(seededUser); // preserved
+    expect(result.current.isAuthenticated).toBe(true);
+  });
+
+  it('clears tokens and user when refresh fails', async () => {
+    getRefreshToken.mockReturnValue('refresh-abc');
+    authApi.refresh.mockRejectedValue(new Error('expired'));
+
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+
+    await act(async () => {
+      await result.current.refreshAuth();
+    });
+
+    expect(clearTokens).toHaveBeenCalled();
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  it('no-ops quickly when there is no refresh token', async () => {
+    getRefreshToken.mockReturnValue(null);
+
+    const { result } = renderHook(() => useAuthContext(), { wrapper });
+
+    await act(async () => {
+      await result.current.refreshAuth();
+    });
+
+    expect(authApi.refresh).not.toHaveBeenCalled();
+    expect(result.current.isLoading).toBe(false);
+  });
+});
+
+describe('AuthProvider rendering', () => {
+  it('exposes context to children via useAuthContext', () => {
+    function Probe() {
+      const ctx = useAuthContext();
+      return <div data-testid="auth-state">{String(ctx.isAuthenticated)}</div>;
+    }
+
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+    expect(screen.getByTestId('auth-state').textContent).toBe('false');
+  });
+});

--- a/src/web/src/contexts/__tests__/ToastContext.test.tsx
+++ b/src/web/src/contexts/__tests__/ToastContext.test.tsx
@@ -1,0 +1,194 @@
+/**
+ * ToastContext tests
+ *
+ * Covers:
+ *  - Hook guard (throws when used outside provider)
+ *  - addToast + removeToast basic lifecycle
+ *  - Auto-dismiss via `duration` with fake timers
+ *  - Variant helpers (success/error/warning/info) set correct variant
+ *  - Variant helpers apply default durations unique per variant
+ *  - Unmount cleanup cancels pending auto-dismiss timers (no state-update leak)
+ */
+
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { ToastProvider, useToast } from '../ToastContext';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ToastProvider>{children}</ToastProvider>;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useToast hook', () => {
+  it('throws when used outside ToastProvider', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => renderHook(() => useToast())).toThrow(
+      /useToast must be used within a ToastProvider/,
+    );
+    spy.mockRestore();
+  });
+});
+
+describe('ToastProvider.addToast / removeToast', () => {
+  it('adds toasts with unique auto-generated ids', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast({ title: 't1', message: 'm1', variant: 'info' });
+      result.current.addToast({ title: 't2', message: 'm2', variant: 'info' });
+    });
+
+    expect(result.current.toasts).toHaveLength(2);
+    const [a, b] = result.current.toasts;
+    expect(a.id).not.toBe(b.id);
+    expect(a.variant).toBe('info');
+  });
+
+  it('removes a toast by id', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast({ title: 'hello', message: 'world', variant: 'info' });
+    });
+    const id = result.current.toasts[0].id;
+
+    act(() => {
+      result.current.removeToast(id);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it('does nothing when removeToast is given an unknown id', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast({ title: 'x', message: 'y', variant: 'info' });
+    });
+    const before = [...result.current.toasts];
+
+    act(() => {
+      result.current.removeToast('nope');
+    });
+    expect(result.current.toasts).toEqual(before);
+  });
+});
+
+describe('ToastProvider auto-dismiss', () => {
+  it('auto-dismisses after the requested duration', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast({
+        title: 'gone',
+        message: 'bye',
+        variant: 'info',
+        duration: 1000,
+      });
+    });
+    expect(result.current.toasts).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(999);
+    });
+    expect(result.current.toasts).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(2);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it('does not auto-dismiss when duration is omitted', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast({ title: 'sticky', message: 'stays', variant: 'info' });
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current.toasts).toHaveLength(1);
+  });
+});
+
+describe('ToastProvider variant helpers', () => {
+  it('success helper applies success variant and a default duration', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.success('ok', 'done');
+    });
+    expect(result.current.toasts[0].variant).toBe('success');
+    expect(result.current.toasts[0].duration).toBeGreaterThan(0);
+  });
+
+  it('error helper applies error variant and a default duration', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    act(() => {
+      result.current.error('boom', 'oops');
+    });
+    expect(result.current.toasts[0].variant).toBe('error');
+  });
+
+  it('warning helper applies warning variant', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    act(() => {
+      result.current.warning('careful', 'maybe');
+    });
+    expect(result.current.toasts[0].variant).toBe('warning');
+  });
+
+  it('info helper applies info variant', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+    act(() => {
+      result.current.info('fyi', 'heads up');
+    });
+    expect(result.current.toasts[0].variant).toBe('info');
+  });
+
+  it('custom duration passed to a helper overrides the default', () => {
+    const { result } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.success('custom', 'dur', 500);
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(499);
+    });
+    expect(result.current.toasts).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(2);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+  });
+});
+
+describe('ToastProvider cleanup', () => {
+  it('clears pending auto-dismiss timers on unmount (no late state updates)', () => {
+    const { result, unmount } = renderHook(() => useToast(), { wrapper });
+
+    act(() => {
+      result.current.addToast({
+        title: 'x',
+        message: 'y',
+        variant: 'info',
+        duration: 5000,
+      });
+    });
+
+    unmount();
+    // If timers weren't cleaned up, this would fire on a dead component.
+    expect(() => vi.advanceTimersByTime(10_000)).not.toThrow();
+  });
+});

--- a/src/web/vitest.config.ts
+++ b/src/web/vitest.config.ts
@@ -31,17 +31,17 @@ export default defineConfig({
         'src/vite-env.d.ts',
       ],
       thresholds: {
-        // Honest-denominator floor. Previous config excluded ~81% of the FE
-        // (pages, components, features, contexts, api, layouts, printing,
-        // errorTracking) from the denominator and enforced 70/70/70/60 against
-        // only ~16% of the codebase. Those exclusions have been restored to
-        // the coverage measurement; the threshold here is the honest achieved
-        // floor (lines 10.87, statements 10.90, functions 7.17, branches 7.45)
-        // minus a small buffer. Raise as real coverage grows.
-        lines: 9,
-        statements: 9,
-        functions: 6,
-        branches: 6,
+        // Honest-denominator floor. Wave 2 (#498) added tests for contexts,
+        // UI primitives, data-display components, and check-in flows against
+        // the full honest denominator. No new exclusions were added — every
+        // point of movement comes from real tests. Achieved floor:
+        //   lines 18.21, statements 18.23, functions 14.27, branches 15.33
+        // Thresholds set just below the achieved number (small buffer so
+        // minor churn does not break CI). Raise further in wave 3.
+        lines: 17,
+        statements: 17,
+        functions: 13,
+        branches: 14,
         // Critical path: offline services must stay well tested.
         // These are higher than the global floor because offline queue bugs
         // cause silent check-in data loss.


### PR DESCRIPTION
## Summary

Wave 2 of #498. Raises honest global coverage floor from **10.87% → 18.21% lines** by adding unit tests against real components. **No exclusions were added** — every point of movement comes from testing code that was previously at 0%.

#498 remains open. Wave 2 landed below the original 25% target; see "What wave 3 needs" below for why and what's next.

## Coverage — before / after (honest denominator)

| Metric      | Before (PR #675) | After (this PR) | Δ       |
|-------------|------------------|-----------------|---------|
| Lines       | 10.87 %          | **18.21 %**     | +7.34   |
| Statements  | 10.90 %          | **18.23 %**     | +7.33   |
| Functions   |  7.17 %          | **14.27 %**     | +7.10   |
| Branches    |  7.45 %          | **15.33 %**     | +7.88   |

Offline services tier held at **83.76 %** lines (no regression).

## Per-bucket outcomes (new test targets)

### Bucket A — Contexts & providers

| File                          | Before | After   |
|-------------------------------|--------|---------|
| `contexts/AuthContext.tsx`    | 0 %    | 97.18 % |
| `contexts/ToastContext.tsx`   | 0 %    | 100 %   |

### Bucket B — UI primitives (`components/ui/*`)

| File                      | Before | After    |
|---------------------------|--------|----------|
| `AccessibleSelect.tsx`    | 0 %    | 72.41 %  |
| `ConfirmDialog.tsx`       | 0 %    | 71.79 %  |
| `EmptyState.tsx`          | 0 %    | 100 %    |
| `ErrorState.tsx`          | 0 %    | 100 %    |
| `Input.tsx`               | 0 %    | 100 %    |
| `Loading.tsx`             | 0 %    | 100 %    |
| `PhoneInput.tsx`          | 0 %    | 100 %    |
| `Select.tsx`              | 0 %    | 100 %    |
| `Skeleton.tsx`            | 0 %    | 100 %    |
| `Toast.tsx`               | 0 %    | 85.71 %  |
| UI folder subtotal        | 2.75 % | **84.82 %** |

### Bucket C — Data-display & flows

Check-in: CheckoutFlow, FamilyQrCard, FamilySearch, KioskLayout, OfflineQueueIndicator, PinEntry, RoomCapacityIndicator, SecurityCodeVerify.  
Admin: Breadcrumb, CampusCard, GroupTypeCard, QuickActions, RecentBatches, RecentCommunications, StatCard, Summary cards, UpcomingSchedules, PersonCard, FamilyMemberCard.  
Auth: LoginForm, ProtectedRoute.  
Giving: BatchStatusBadge, BatchSummaryCard.  
Groups: GroupFilters, PendingRequestsBadge.  
Comms: MessageTypeToggle, RecipientStatusBadge.  
Notifications: NotificationItem.  
PWA: InstallPrompt, OfflineIndicator, PWAUpdatePrompt.  
Profile: FamilySection, InvolvementSummary.  
Other: ErrorBoundary, LocationPicker.

Folder moves:
- `components/checkin/` 11.53 % → **22.22 %**
- `components/pwa/` 0 % → **98.03 %**
- `components/notifications/` 0 % → **26.19 %**

## What each test file catches (regression categories)

| File                           | Catches                                                                 |
|--------------------------------|-------------------------------------------------------------------------|
| `AuthContext.test.tsx`         | Token refresh / localStorage persistence / provider guard rail          |
| `ToastContext.test.tsx`        | Auto-dismiss timers, unmount leak, variant → duration mapping           |
| `Input/Select/PhoneInput.test` | Controlled value round-trip, error styling, forwardRef, format masking  |
| `ConfirmDialog.test.tsx`       | Escape-key handling, loading lockout, variant button colour             |
| `Toast.test.tsx`               | `role="alert"` + `aria-live` polite region (a11y regressions)           |
| `RoomCapacityIndicator.test`   | Status → colour mapping + progress bar clamp at 100 %                    |
| `FamilyMemberList` (existing)  | Check-in selection keys                                                 |
| `CheckoutFlow.test.tsx`        | Multi-step state machine + security-code verification flow              |
| `PinEntry/SecurityCodeVerify`  | Numpad wiring + constant-time verification delay                         |
| `GroupFilters.test.tsx`        | `dayOfWeek=0` not lost as falsy (numeric-zero regression category)       |
| `NotificationItem.test.tsx`    | Border colour per type + delete `stopPropagation`                        |
| `ErrorBoundary.test.tsx`       | Renders children / fallback / custom fallback, reports to errorTracking  |
| `LocationPicker.test.tsx`      | Campus-gated query, inactive filter, sort, error branch                  |
| `ProtectedRoute.test.tsx`      | Redirects unauthenticated / preserves `from` / respects `redirectTo`     |
| `LoginForm.test.tsx`           | 400/401 → inline error (no toast), other → handleError, loading label    |
| `BatchSummaryCard.test.tsx`    | Status → button visibility, variance colour, currency format             |
| `RecentBatches / *Comms*`      | Status → colour, row cap at 5, link hrefs                                |

## Threshold bump

`src/web/vitest.config.ts` (exclusion list untouched):

| Threshold   | Before | After |
|-------------|--------|-------|
| lines       | 9      | **17** |
| statements  | 9      | **17** |
| functions   | 6      | **13** |
| branches    | 6      | **14** |

Offline services tier remains at 80/80/85/50.

## Test counts

- 47 new test files (on top of the 31 wave-1 files).
- Tests: **478 → 687** (all passing).
- TypeScript: `npx tsc --noEmit` — 0 errors.
- Backend: `dotnet build` — green.

## Honest statement: #498 is still NOT at 50 %

Wave 2 landed below the original 25 % wave target. Root cause: the remaining 0 % code is concentrated in admin pages and large modal components that are **not good unit-test targets**:

- `CheckinPage.tsx` (866 LOC)
- `KioskFamilyRegistration.tsx` (664 LOC)
- `NotesSection.tsx` (482 LOC)
- `AuditLogsPage.tsx` (254 LOC), `DefinedTypesPage.tsx` (602 LOC), `RolesPage.tsx` (708 LOC), etc.
- `RecipientBuilder.tsx` (318 LOC), `CommunicationComposer.tsx` (411 LOC), `EmailComposer.tsx` (171 LOC)
- `MergeWizard.tsx` (494 LOC), `ProfileEditor.tsx` (215 LOC)

These pages lean on TanStack Query + React Router + forms and are better covered by E2E tests (already in place via Playwright). Shoehorning them into unit tests would require mocking `> 5` modules per test — brittle by design.

## What wave 3 should tackle

1. **Hooks tier** (`src/hooks/*`) is at **8.43 %** lines. Most are TanStack Query wrappers — straightforward to test with MSW or direct mock of `queryFn`.
2. **`services/api/*`** is at **51.55 %** — a focused push to 80 % + adds meaningful coverage.
3. **Simple pages** (`FamiliesPage`, `PeoplePage`, `GroupsPage`) are mostly composition and could hit 50–70 % with router + QueryClient wrappers.
4. **Remaining `components/admin/*` and `components/settings/*` Section components** — similar shape to what this PR tested in `admin/dashboard`.

Realistic honest target after wave 3: **35–45 %** lines. Getting the final stretch to 50 % will likely require either (a) accepting the exclusion of a handful of pure-JSX page shells that are 100 % E2E-covered, or (b) adding a separate page-level integration test harness. That's a design decision, not a unit-test problem.

**#498 stays open.**

## Test plan

- [x] `docker run node:20-alpine npx vitest run --coverage` — meets the new threshold (18.23 / 15.33 / 14.27 / 18.21).
- [x] `npx tsc --noEmit` — 0 errors.
- [x] `dotnet build` — green.
- [x] `git diff --stat` — exclusively new test files + one-line threshold bump.
- [x] CI will re-run coverage on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)