### PR TITLE
test(frontend): wave 3 — hooks + services/api (#498)

### DIFF
--- a/src/web/src/features/admin/defined-types/__tests__/api.test.ts
+++ b/src/web/src/features/admin/defined-types/__tests__/api.test.ts
@@ -1,0 +1,100 @@
+/**
+ * features/admin/defined-types/api.ts — defined-types admin API.
+ * Pattern: mock ./client; assert URL + HTTP method + envelope unwrapping.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/services/api/client', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+}));
+
+import * as client from '@/services/api/client';
+import {
+  createDefinedValue,
+  deleteDefinedValue,
+  getDefinedType,
+  getDefinedTypes,
+  reorderDefinedValues,
+  updateDefinedValue,
+} from '../api';
+
+const mockGet = vi.mocked(client.get);
+const mockPost = vi.mocked(client.post);
+const mockPut = vi.mocked(client.put);
+const mockDel = vi.mocked(client.del);
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPost.mockReset();
+  mockPut.mockReset();
+  mockDel.mockReset();
+});
+
+describe('defined-types api', () => {
+  it('getDefinedTypes unwraps envelope', async () => {
+    mockGet.mockResolvedValueOnce({ data: [{ idKey: 'dt1' }] } as never);
+    const out = await getDefinedTypes();
+    expect(mockGet).toHaveBeenCalledWith('/defined-types');
+    expect(out).toEqual([{ idKey: 'dt1' }]);
+  });
+
+  it('getDefinedType unwraps envelope', async () => {
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'dt1' } } as never);
+    await getDefinedType('dt1');
+    expect(mockGet).toHaveBeenCalledWith('/defined-types/dt1');
+  });
+
+  it('createDefinedValue posts to type-scoped URL', async () => {
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'v1' } } as never);
+    await createDefinedValue('dt1', {
+      value: 'Active',
+      description: 'd',
+      order: 1,
+    });
+    expect(mockPost).toHaveBeenCalledWith('/defined-types/dt1/values', {
+      value: 'Active',
+      description: 'd',
+      order: 1,
+    });
+  });
+
+  it('updateDefinedValue puts to value-scoped URL', async () => {
+    mockPut.mockResolvedValueOnce({ data: { idKey: 'v1' } } as never);
+    await updateDefinedValue('v1', {
+      value: 'Inactive',
+      order: 1,
+      isActive: false,
+    });
+    expect(mockPut).toHaveBeenCalledWith('/defined-types/values/v1', {
+      value: 'Inactive',
+      order: 1,
+      isActive: false,
+    });
+  });
+
+  it('deleteDefinedValue deletes value-scoped URL', async () => {
+    mockDel.mockResolvedValueOnce(undefined as never);
+    await deleteDefinedValue('v1');
+    expect(mockDel).toHaveBeenCalledWith('/defined-types/values/v1');
+  });
+
+  it('reorderDefinedValues posts to /reorder with items payload', async () => {
+    mockPost.mockResolvedValueOnce(undefined as never);
+    await reorderDefinedValues('dt1', {
+      items: [
+        { idKey: 'v1', order: 0 },
+        { idKey: 'v2', order: 1 },
+      ],
+    });
+    expect(mockPost).toHaveBeenCalledWith('/defined-types/dt1/values/reorder', {
+      items: [
+        { idKey: 'v1', order: 0 },
+        { idKey: 'v2', order: 1 },
+      ],
+    });
+  });
+});

--- a/src/web/src/features/admin/defined-types/__tests__/hooks.test.tsx
+++ b/src/web/src/features/admin/defined-types/__tests__/hooks.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * features/admin/defined-types/hooks.ts
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('../api', () => ({
+  getDefinedTypes: vi.fn(),
+  getDefinedType: vi.fn(),
+  createDefinedValue: vi.fn(),
+  updateDefinedValue: vi.fn(),
+  deleteDefinedValue: vi.fn(),
+  reorderDefinedValues: vi.fn(),
+}));
+
+import * as api from '../api';
+import {
+  useCreateDefinedValue,
+  useDefinedType,
+  useDefinedTypes,
+  useDeleteDefinedValue,
+  useReorderDefinedValues,
+  useUpdateDefinedValue,
+} from '../hooks';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('queries', () => {
+  it('useDefinedTypes fetches list', async () => {
+    vi.mocked(api.getDefinedTypes).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useDefinedTypes());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getDefinedTypes).toHaveBeenCalled();
+  });
+
+  it('useDefinedType fetches detail', async () => {
+    vi.mocked(api.getDefinedType).mockResolvedValueOnce({ idKey: 'dt1' } as never);
+    const { result } = renderHookWithQuery(() => useDefinedType('dt1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getDefinedType).toHaveBeenCalledWith('dt1');
+  });
+});
+
+describe('mutations invalidate detail for the parent type', () => {
+  it('create invalidates the type detail', async () => {
+    vi.mocked(api.createDefinedValue).mockResolvedValueOnce({ idKey: 'v1' } as never);
+    const { result, client } = renderHookWithQuery(() => useCreateDefinedValue());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({
+        typeIdKey: 'dt1',
+        request: { value: 'X', order: 1 } as never,
+      });
+    });
+    expect(api.createDefinedValue).toHaveBeenCalledWith('dt1', {
+      value: 'X',
+      order: 1,
+    });
+    // The key factory is: ['defined-types','detail','dt1']
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['defined-types', 'detail', 'dt1'] });
+  });
+
+  it('update invalidates parent type detail', async () => {
+    vi.mocked(api.updateDefinedValue).mockResolvedValueOnce({ idKey: 'v1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateDefinedValue());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({
+        valueIdKey: 'v1',
+        typeIdKey: 'dt1',
+        request: { value: 'X', order: 1, isActive: true } as never,
+      });
+    });
+    expect(api.updateDefinedValue).toHaveBeenCalledWith('v1', {
+      value: 'X',
+      order: 1,
+      isActive: true,
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['defined-types', 'detail', 'dt1'] });
+  });
+
+  it('delete invalidates parent type detail', async () => {
+    vi.mocked(api.deleteDefinedValue).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useDeleteDefinedValue());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ valueIdKey: 'v1', typeIdKey: 'dt1' });
+    });
+    expect(api.deleteDefinedValue).toHaveBeenCalledWith('v1');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['defined-types', 'detail', 'dt1'] });
+  });
+
+  it('reorder invalidates parent type detail', async () => {
+    vi.mocked(api.reorderDefinedValues).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useReorderDefinedValues());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    const items = { items: [{ idKey: 'v1', order: 0 }] };
+    await act(async () => {
+      await result.current.mutateAsync({ typeIdKey: 'dt1', request: items });
+    });
+    expect(api.reorderDefinedValues).toHaveBeenCalledWith('dt1', items);
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['defined-types', 'detail', 'dt1'] });
+  });
+});

--- a/src/web/src/features/authorized-pickup/__tests__/api.test.ts
+++ b/src/web/src/features/authorized-pickup/__tests__/api.test.ts
@@ -1,0 +1,120 @@
+/**
+ * features/authorized-pickup/api.ts tests.
+ * This module returns bodies directly (no `{ data: ... }` unwrap).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/services/api/client', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+}));
+
+import * as client from '@/services/api/client';
+import {
+  addAuthorizedPickup,
+  AuthorizationLevel,
+  autoPopulateFamilyMembers,
+  deleteAuthorizedPickup,
+  getAuthorizedPickups,
+  getPickupHistory,
+  PickupRelationship,
+  recordPickup,
+  updateAuthorizedPickup,
+  verifyPickup,
+} from '../api';
+
+const mockGet = vi.mocked(client.get);
+const mockPost = vi.mocked(client.post);
+const mockPut = vi.mocked(client.put);
+const mockDel = vi.mocked(client.del);
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPost.mockReset();
+  mockPut.mockReset();
+  mockDel.mockReset();
+});
+
+describe('authorized-pickup api (features tier)', () => {
+  it('getAuthorizedPickups (no envelope)', async () => {
+    mockGet.mockResolvedValueOnce([{ idKey: 'ap1' }] as never);
+    const out = await getAuthorizedPickups('c1');
+    expect(mockGet).toHaveBeenCalledWith('/people/c1/authorized-pickups');
+    expect(out).toEqual([{ idKey: 'ap1' }]);
+  });
+
+  it('addAuthorizedPickup posts', async () => {
+    mockPost.mockResolvedValueOnce({ idKey: 'ap1' } as never);
+    await addAuthorizedPickup('c1', {
+      name: 'Bob',
+      relationship: PickupRelationship.Parent,
+      authorizationLevel: AuthorizationLevel.Always,
+    });
+    const [url, body] = mockPost.mock.calls[0];
+    expect(url).toBe('/people/c1/authorized-pickups');
+    expect(body).toMatchObject({
+      name: 'Bob',
+      relationship: PickupRelationship.Parent,
+      authorizationLevel: AuthorizationLevel.Always,
+    });
+  });
+
+  it('updateAuthorizedPickup puts', async () => {
+    mockPut.mockResolvedValueOnce({ idKey: 'ap1' } as never);
+    await updateAuthorizedPickup('ap1', { isActive: false });
+    expect(mockPut).toHaveBeenCalledWith('/authorized-pickups/ap1', {
+      isActive: false,
+    });
+  });
+
+  it('deleteAuthorizedPickup deletes', async () => {
+    mockDel.mockResolvedValueOnce(undefined as never);
+    await deleteAuthorizedPickup('ap1');
+    expect(mockDel).toHaveBeenCalledWith('/authorized-pickups/ap1');
+  });
+
+  it('autoPopulateFamilyMembers posts without body', async () => {
+    mockPost.mockResolvedValueOnce({ message: 'ok', count: 0, pickups: [] } as never);
+    await autoPopulateFamilyMembers('c1');
+    expect(mockPost).toHaveBeenCalledWith(
+      '/people/c1/authorized-pickups/auto-populate'
+    );
+  });
+
+  it('verifyPickup posts to /checkin/verify-pickup', async () => {
+    mockPost.mockResolvedValueOnce({ isAuthorized: true } as never);
+    const req = {
+      attendanceIdKey: 'a1',
+      pickupPersonName: 'X',
+      securityCode: '1234',
+    };
+    await verifyPickup(req);
+    expect(mockPost).toHaveBeenCalledWith('/checkin/verify-pickup', req);
+  });
+
+  it('recordPickup posts to /checkin/record-pickup', async () => {
+    mockPost.mockResolvedValueOnce({ idKey: 'log1' } as never);
+    const req = {
+      attendanceIdKey: 'a1',
+      wasAuthorized: true,
+      supervisorOverride: false,
+    };
+    await recordPickup(req);
+    expect(mockPost).toHaveBeenCalledWith('/checkin/record-pickup', req);
+  });
+
+  it('getPickupHistory with/without date range', async () => {
+    mockGet.mockResolvedValueOnce([] as never);
+    await getPickupHistory('c1');
+    expect(mockGet).toHaveBeenCalledWith('/people/c1/pickup-history');
+
+    mockGet.mockResolvedValueOnce([] as never);
+    await getPickupHistory('c1', '2024-01-01', '2024-02-01');
+    const url = mockGet.mock.calls.at(-1)?.[0] as string;
+    expect(url).toContain('fromDate=2024-01-01');
+    expect(url).toContain('toDate=2024-02-01');
+  });
+});

--- a/src/web/src/features/authorized-pickup/__tests__/hooks.test.tsx
+++ b/src/web/src/features/authorized-pickup/__tests__/hooks.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * features/authorized-pickup/hooks.ts
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('../api', () => ({
+  getAuthorizedPickups: vi.fn(),
+  addAuthorizedPickup: vi.fn(),
+  updateAuthorizedPickup: vi.fn(),
+  deleteAuthorizedPickup: vi.fn(),
+  autoPopulateFamilyMembers: vi.fn(),
+  verifyPickup: vi.fn(),
+  recordPickup: vi.fn(),
+  getPickupHistory: vi.fn(),
+}));
+
+import * as api from '../api';
+import {
+  useAddAuthorizedPickup,
+  useAuthorizedPickups,
+  useAutoPopulateFamilyMembers,
+  useDeleteAuthorizedPickup,
+  usePickupHistory,
+  useRecordPickup,
+  useUpdateAuthorizedPickup,
+  useVerifyPickup,
+} from '../hooks';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useAuthorizedPickups', () => {
+  it('fetches by childIdKey', async () => {
+    vi.mocked(api.getAuthorizedPickups).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useAuthorizedPickups('c1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getAuthorizedPickups).toHaveBeenCalledWith('c1');
+  });
+});
+
+describe('usePickupHistory', () => {
+  it('forwards date filters', async () => {
+    vi.mocked(api.getPickupHistory).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() =>
+      usePickupHistory('c1', '2024-01-01', '2024-02-01')
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getPickupHistory).toHaveBeenCalledWith(
+      'c1',
+      '2024-01-01',
+      '2024-02-01'
+    );
+  });
+});
+
+describe('CRUD mutations invalidate the child-scoped list', () => {
+  it('add invalidates', async () => {
+    vi.mocked(api.addAuthorizedPickup).mockResolvedValueOnce({ childIdKey: 'c1' } as never);
+    const { result, client } = renderHookWithQuery(() => useAddAuthorizedPickup());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ childIdKey: 'c1', request: {} as never });
+    });
+    expect(inv).toHaveBeenCalledWith({
+      queryKey: ['authorized-pickups', 'list', 'c1'],
+    });
+  });
+
+  it('update invalidates by returned childIdKey', async () => {
+    vi.mocked(api.updateAuthorizedPickup).mockResolvedValueOnce({
+      idKey: 'ap1',
+      childIdKey: 'c1',
+    } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateAuthorizedPickup());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({
+        pickupIdKey: 'ap1',
+        request: { isActive: true } as never,
+      });
+    });
+    expect(inv).toHaveBeenCalledWith({
+      queryKey: ['authorized-pickups', 'list', 'c1'],
+    });
+  });
+
+  it('delete uses the provided childIdKey for invalidation', async () => {
+    vi.mocked(api.deleteAuthorizedPickup).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useDeleteAuthorizedPickup());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ pickupIdKey: 'ap1', childIdKey: 'c1' });
+    });
+    expect(api.deleteAuthorizedPickup).toHaveBeenCalledWith('ap1');
+    expect(inv).toHaveBeenCalledWith({
+      queryKey: ['authorized-pickups', 'list', 'c1'],
+    });
+  });
+
+  it('autoPopulate invalidates child-scoped list', async () => {
+    vi.mocked(api.autoPopulateFamilyMembers).mockResolvedValueOnce({
+      message: 'ok',
+      count: 1,
+      pickups: [],
+    } as never);
+    const { result, client } = renderHookWithQuery(() => useAutoPopulateFamilyMembers());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('c1');
+    });
+    expect(inv).toHaveBeenCalledWith({
+      queryKey: ['authorized-pickups', 'list', 'c1'],
+    });
+  });
+});
+
+describe('useVerifyPickup / useRecordPickup', () => {
+  it('verifyPickup is a plain mutation', async () => {
+    vi.mocked(api.verifyPickup).mockResolvedValueOnce({ isAuthorized: true } as never);
+    const { result } = renderHookWithQuery(() => useVerifyPickup());
+    await act(async () => {
+      await result.current.mutateAsync({
+        attendanceIdKey: 'a1',
+        securityCode: '1234',
+      } as never);
+    });
+    expect(api.verifyPickup).toHaveBeenCalled();
+  });
+
+  it('recordPickup invalidates all pickup history', async () => {
+    vi.mocked(api.recordPickup).mockResolvedValueOnce({ idKey: 'log1' } as never);
+    const { result, client } = renderHookWithQuery(() => useRecordPickup());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({
+        attendanceIdKey: 'a1',
+        wasAuthorized: true,
+        supervisorOverride: false,
+      } as never);
+    });
+    expect(inv).toHaveBeenCalledWith({
+      queryKey: ['authorized-pickups', 'history'],
+    });
+  });
+});

--- a/src/web/src/features/followups/__tests__/api.test.ts
+++ b/src/web/src/features/followups/__tests__/api.test.ts
@@ -1,0 +1,67 @@
+/**
+ * features/followups/api.ts tests.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/services/api/client', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+}));
+
+import * as client from '@/services/api/client';
+import {
+  assignFollowUp,
+  FollowUpStatus,
+  getFollowUp,
+  getPendingFollowUps,
+  updateFollowUpStatus,
+} from '../api';
+
+const mockGet = vi.mocked(client.get);
+const mockPut = vi.mocked(client.put);
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPut.mockReset();
+});
+
+describe('followups api', () => {
+  it('getPendingFollowUps without assignee', async () => {
+    mockGet.mockResolvedValueOnce({ data: [] } as never);
+    await getPendingFollowUps();
+    expect(mockGet).toHaveBeenCalledWith('/followups/pending');
+  });
+
+  it('getPendingFollowUps appends assignedToIdKey', async () => {
+    mockGet.mockResolvedValueOnce({ data: [] } as never);
+    await getPendingFollowUps('u1');
+    expect(mockGet).toHaveBeenLastCalledWith('/followups/pending?assignedToIdKey=u1');
+  });
+
+  it('getFollowUp unwraps envelope', async () => {
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'f1' } } as never);
+    const out = await getFollowUp('f1');
+    expect(mockGet).toHaveBeenCalledWith('/followups/f1');
+    expect(out).toEqual({ idKey: 'f1' });
+  });
+
+  it('updateFollowUpStatus sends status + notes as body', async () => {
+    mockPut.mockResolvedValueOnce({ data: { idKey: 'f1' } } as never);
+    await updateFollowUpStatus('f1', FollowUpStatus.Connected, 'note');
+    expect(mockPut).toHaveBeenCalledWith('/followups/f1/status', {
+      status: FollowUpStatus.Connected,
+      notes: 'note',
+    });
+  });
+
+  it('assignFollowUp sends assignedToIdKey body, no return unwrap', async () => {
+    mockPut.mockResolvedValueOnce(undefined as never);
+    await assignFollowUp('f1', 'u1');
+    expect(mockPut).toHaveBeenCalledWith('/followups/f1/assign', {
+      assignedToIdKey: 'u1',
+    });
+  });
+});

--- a/src/web/src/features/followups/__tests__/hooks.test.tsx
+++ b/src/web/src/features/followups/__tests__/hooks.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * features/followups/hooks.ts
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('../api', () => ({
+  getPendingFollowUps: vi.fn(),
+  getFollowUp: vi.fn(),
+  updateFollowUpStatus: vi.fn(),
+  assignFollowUp: vi.fn(),
+  FollowUpStatus: { Pending: 0, Completed: 1 },
+}));
+
+import * as api from '../api';
+import {
+  useAssignFollowUp,
+  useFollowUp,
+  usePendingFollowUps,
+  useUpdateFollowUpStatus,
+} from '../hooks';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('queries', () => {
+  it('usePendingFollowUps without assignee', async () => {
+    vi.mocked(api.getPendingFollowUps).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => usePendingFollowUps());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getPendingFollowUps).toHaveBeenCalledWith(undefined);
+  });
+
+  it('usePendingFollowUps with assignee', async () => {
+    vi.mocked(api.getPendingFollowUps).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => usePendingFollowUps('u1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getPendingFollowUps).toHaveBeenCalledWith('u1');
+  });
+
+  it('useFollowUp fetches by idKey', async () => {
+    vi.mocked(api.getFollowUp).mockResolvedValueOnce({ idKey: 'f1' } as never);
+    const { result } = renderHookWithQuery(() => useFollowUp('f1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getFollowUp).toHaveBeenCalledWith('f1');
+  });
+});
+
+describe('useUpdateFollowUpStatus', () => {
+  it('sets detail cache and invalidates all followups', async () => {
+    const updated = { idKey: 'f1', status: 1 };
+    vi.mocked(api.updateFollowUpStatus).mockResolvedValueOnce(updated as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateFollowUpStatus());
+    const setData = vi.spyOn(client, 'setQueryData');
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 'f1', status: 1, notes: 'n' } as never);
+    });
+    expect(api.updateFollowUpStatus).toHaveBeenCalledWith('f1', 1, 'n');
+    expect(setData).toHaveBeenCalledWith(['followups', 'detail', 'f1'], updated);
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['followups'] });
+  });
+});
+
+describe('useAssignFollowUp', () => {
+  it('invalidates all followups', async () => {
+    vi.mocked(api.assignFollowUp).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useAssignFollowUp());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 'f1', assignedToIdKey: 'u1' });
+    });
+    expect(api.assignFollowUp).toHaveBeenCalledWith('f1', 'u1');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['followups'] });
+  });
+});

--- a/src/web/src/features/pager/__tests__/api.test.ts
+++ b/src/web/src/features/pager/__tests__/api.test.ts
@@ -1,0 +1,82 @@
+/**
+ * features/pager/api.ts tests.
+ * Note: unlike services/api/pager.ts, this module returns the body directly
+ * (no `{ data: ... }` unwrap) for all endpoints.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@/services/api/client', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+}));
+
+import * as client from '@/services/api/client';
+import {
+  getNextPagerNumber,
+  getPageHistory,
+  PagerMessageType,
+  searchPagers,
+  sendPage,
+} from '../api';
+
+const mockGet = vi.mocked(client.get);
+const mockPost = vi.mocked(client.post);
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPost.mockReset();
+});
+
+describe('pager api (features/pager)', () => {
+  it('searchPagers without args => /pager/search', async () => {
+    mockGet.mockResolvedValueOnce([] as never);
+    await searchPagers();
+    expect(mockGet).toHaveBeenCalledWith('/pager/search');
+  });
+
+  it('searchPagers with searchTerm + date', async () => {
+    mockGet.mockResolvedValueOnce([] as never);
+    await searchPagers('Smith', '2024-01-01');
+    const url = mockGet.mock.calls[0][0] as string;
+    expect(url).toContain('/pager/search?');
+    expect(url).toContain('searchTerm=Smith');
+    expect(url).toContain('date=2024-01-01');
+  });
+
+  it('sendPage posts payload', async () => {
+    mockPost.mockResolvedValueOnce({ idKey: 'm1' } as never);
+    await sendPage({
+      pagerNumber: '7',
+      messageType: PagerMessageType.PickupNeeded,
+    });
+    expect(mockPost).toHaveBeenCalledWith('/pager/send', {
+      pagerNumber: '7',
+      messageType: PagerMessageType.PickupNeeded,
+    });
+  });
+
+  it('getPageHistory without date', async () => {
+    mockGet.mockResolvedValueOnce({} as never);
+    await getPageHistory(7);
+    expect(mockGet).toHaveBeenCalledWith('/pager/7/history');
+  });
+
+  it('getPageHistory with date', async () => {
+    mockGet.mockResolvedValueOnce({} as never);
+    await getPageHistory(7, '2024-01-01');
+    expect(mockGet).toHaveBeenLastCalledWith('/pager/7/history?date=2024-01-01');
+  });
+
+  it('getNextPagerNumber with/without campus', async () => {
+    mockGet.mockResolvedValueOnce(42 as never);
+    expect(await getNextPagerNumber()).toBe(42);
+    expect(mockGet).toHaveBeenCalledWith('/pager/next-number');
+
+    mockGet.mockResolvedValueOnce(43 as never);
+    await getNextPagerNumber('c1');
+    expect(mockGet).toHaveBeenLastCalledWith('/pager/next-number?campusId=c1');
+  });
+});

--- a/src/web/src/features/pager/__tests__/hooks.test.tsx
+++ b/src/web/src/features/pager/__tests__/hooks.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * features/pager/hooks.ts
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('../api', () => ({
+  searchPagers: vi.fn(),
+  getPageHistory: vi.fn(),
+  sendPage: vi.fn(),
+  PagerMessageType: { PickupNeeded: 'PickupNeeded' },
+}));
+
+import * as api from '../api';
+import { usePageHistory, usePagerSearch, useSendPage } from '../hooks';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('usePagerSearch', () => {
+  it('fires even without searchTerm (always enabled)', async () => {
+    vi.mocked(api.searchPagers).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => usePagerSearch());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.searchPagers).toHaveBeenCalledWith(undefined, undefined);
+  });
+
+  it('forwards searchTerm + date', async () => {
+    vi.mocked(api.searchPagers).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() =>
+      usePagerSearch('Smith', '2024-01-01')
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.searchPagers).toHaveBeenCalledWith('Smith', '2024-01-01');
+  });
+});
+
+describe('usePageHistory', () => {
+  it('idle when pagerNumber is null', () => {
+    const { result } = renderHookWithQuery(() => usePageHistory(null));
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with pagerNumber', async () => {
+    vi.mocked(api.getPageHistory).mockResolvedValueOnce({
+      pagerNumber: 7,
+    } as never);
+    const { result } = renderHookWithQuery(() => usePageHistory(7, '2024-01-01'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getPageHistory).toHaveBeenCalledWith(7, '2024-01-01');
+  });
+});
+
+describe('useSendPage', () => {
+  it('invalidates all pager keys on success', async () => {
+    vi.mocked(api.sendPage).mockResolvedValueOnce({} as never);
+    const { result, client } = renderHookWithQuery(() => useSendPage());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({
+        pagerNumber: '7',
+        messageType: 'PickupNeeded',
+      } as never);
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['pagers'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useAnalytics.test.tsx
+++ b/src/web/src/hooks/__tests__/useAnalytics.test.tsx
@@ -1,0 +1,71 @@
+/**
+ * useAnalytics hook module.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+
+vi.mock('@/services/api/analytics', () => ({
+  getAttendanceAnalytics: vi.fn(),
+  getAttendanceTrends: vi.fn(),
+  getAttendanceByGroup: vi.fn(),
+  getTodaysFirstTimeVisitors: vi.fn(),
+  getFirstTimeVisitorsByDateRange: vi.fn(),
+}));
+
+import * as api from '@/services/api/analytics';
+import {
+  useAttendanceAnalytics,
+  useAttendanceByGroup,
+  useAttendanceTrends,
+  useFirstTimeVisitorsByDateRange,
+  useTodaysFirstTimeVisitors,
+} from '../useAnalytics';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+const params = { startDate: '2024-01-01', endDate: '2024-02-01' };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('analytics queries', () => {
+  it('useAttendanceAnalytics forwards params', async () => {
+    vi.mocked(api.getAttendanceAnalytics).mockResolvedValueOnce({} as never);
+    const { result } = renderHookWithQuery(() => useAttendanceAnalytics(params));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getAttendanceAnalytics).toHaveBeenCalledWith(params);
+  });
+
+  it('useAttendanceTrends forwards params', async () => {
+    vi.mocked(api.getAttendanceTrends).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useAttendanceTrends(params));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getAttendanceTrends).toHaveBeenCalledWith(params);
+  });
+
+  it('useAttendanceByGroup forwards params', async () => {
+    vi.mocked(api.getAttendanceByGroup).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useAttendanceByGroup(params));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getAttendanceByGroup).toHaveBeenCalledWith(params);
+  });
+
+  it('useTodaysFirstTimeVisitors optional campus', async () => {
+    vi.mocked(api.getTodaysFirstTimeVisitors).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useTodaysFirstTimeVisitors('c1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getTodaysFirstTimeVisitors).toHaveBeenCalledWith('c1');
+  });
+
+  it('useFirstTimeVisitorsByDateRange forwards args', async () => {
+    vi.mocked(api.getFirstTimeVisitorsByDateRange).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() =>
+      useFirstTimeVisitorsByDateRange('2024-01-01', '2024-02-01', 'c1')
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getFirstTimeVisitorsByDateRange).toHaveBeenCalledWith(
+      '2024-01-01',
+      '2024-02-01',
+      'c1'
+    );
+  });
+});

--- a/src/web/src/hooks/__tests__/useAuditLogs.test.tsx
+++ b/src/web/src/hooks/__tests__/useAuditLogs.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * useAuditLogs hook module. The export mutation triggers a DOM download
+ * side-effect; we stub the URL helpers and anchor click to verify the
+ * filename shape per format.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/auditLogApi', () => ({
+  searchAuditLogs: vi.fn(),
+  getEntityAuditHistory: vi.fn(),
+  exportAuditLogs: vi.fn(),
+}));
+
+import * as api from '@/services/api/auditLogApi';
+import {
+  useAuditLogs,
+  useEntityAuditHistory,
+  useExportAuditLogs,
+} from '../useAuditLogs';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useAuditLogs', () => {
+  it('forwards params to api', async () => {
+    vi.mocked(api.searchAuditLogs).mockResolvedValueOnce({ data: [] } as never);
+    const { result } = renderHookWithQuery(() =>
+      useAuditLogs({ entityType: 'Person', page: 1 })
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.searchAuditLogs).toHaveBeenCalledWith({
+      entityType: 'Person',
+      page: 1,
+    });
+  });
+});
+
+describe('useEntityAuditHistory', () => {
+  it('idle unless BOTH entityType and idKey present', () => {
+    const a = renderHookWithQuery(() => useEntityAuditHistory(undefined, 'p1')).result;
+    const b = renderHookWithQuery(() => useEntityAuditHistory('Person', undefined)).result;
+    expect(a.current.fetchStatus).toBe('idle');
+    expect(b.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires when both present', async () => {
+    vi.mocked(api.getEntityAuditHistory).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() =>
+      useEntityAuditHistory('Person', 'p1')
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getEntityAuditHistory).toHaveBeenCalledWith('Person', 'p1');
+  });
+});
+
+describe('useExportAuditLogs', () => {
+  it('downloads a CSV file with date-stamped name', async () => {
+    const blob = new Blob(['csv'], { type: 'text/csv' });
+    vi.mocked(api.exportAuditLogs).mockResolvedValueOnce(blob as never);
+
+    const createURL = vi
+      .spyOn(window.URL, 'createObjectURL')
+      .mockReturnValue('blob:url');
+    const revokeURL = vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => {});
+    const clickSpy = vi.fn();
+    const originalClick = HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click = clickSpy;
+
+    try {
+      const { result } = renderHookWithQuery(() => useExportAuditLogs());
+      await act(async () => {
+        await result.current.mutateAsync({ format: 'Csv' } as never);
+      });
+      expect(api.exportAuditLogs).toHaveBeenCalled();
+      expect(createURL).toHaveBeenCalledWith(blob);
+      expect(clickSpy).toHaveBeenCalled();
+      expect(revokeURL).toHaveBeenCalledWith('blob:url');
+    } finally {
+      HTMLAnchorElement.prototype.click = originalClick;
+      createURL.mockRestore();
+      revokeURL.mockRestore();
+    }
+  });
+
+  it('selects extension based on format', async () => {
+    const blob = new Blob(['x']);
+    vi.mocked(api.exportAuditLogs).mockResolvedValue(blob as never);
+
+    const createURL = vi
+      .spyOn(window.URL, 'createObjectURL')
+      .mockReturnValue('blob:url');
+    const revokeURL = vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => {});
+    const originalClick = HTMLAnchorElement.prototype.click;
+
+    // Track download attributes set on anchors
+    const downloadNames: string[] = [];
+    const setAttr = HTMLAnchorElement.prototype.setAttribute;
+    // Not all anchors use setAttribute for download; intercept via click instead
+    HTMLAnchorElement.prototype.click = function () {
+      downloadNames.push((this as HTMLAnchorElement).download);
+    };
+
+    try {
+      const { result } = renderHookWithQuery(() => useExportAuditLogs());
+      await act(async () => {
+        await result.current.mutateAsync({ format: 'Json' } as never);
+      });
+      await act(async () => {
+        await result.current.mutateAsync({ format: 'Excel' } as never);
+      });
+      await act(async () => {
+        // Default: no format
+        await result.current.mutateAsync({} as never);
+      });
+      expect(downloadNames[0]).toMatch(/\.json$/);
+      expect(downloadNames[1]).toMatch(/\.xlsx$/);
+      expect(downloadNames[2]).toMatch(/\.csv$/); // defaults to Csv
+    } finally {
+      HTMLAnchorElement.prototype.click = originalClick;
+      HTMLAnchorElement.prototype.setAttribute = setAttr;
+      createURL.mockRestore();
+      revokeURL.mockRestore();
+    }
+  });
+});

--- a/src/web/src/hooks/__tests__/useAuth.test.tsx
+++ b/src/web/src/hooks/__tests__/useAuth.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * useAuth / useUser / useIsAuthenticated — thin re-exports of AuthContext.
+ *
+ * We stub `useAuthContext` at the context module so the tests only exercise
+ * the hook forwarding logic (not AuthContext itself, which has its own tests).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const mockUseAuthContext = vi.fn();
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuthContext: () => mockUseAuthContext(),
+}));
+
+import { useAuth, useIsAuthenticated, useUser } from '../useAuth';
+
+beforeEach(() => {
+  mockUseAuthContext.mockReset();
+});
+
+describe('useAuth', () => {
+  it('returns the whole context value', () => {
+    const ctx = {
+      user: { idKey: 'u' },
+      isAuthenticated: true,
+      isLoading: false,
+      error: null,
+      login: vi.fn(),
+      logout: vi.fn(),
+      refreshAuth: vi.fn(),
+    };
+    mockUseAuthContext.mockReturnValue(ctx);
+    const { result } = renderHook(() => useAuth());
+    expect(result.current).toBe(ctx);
+  });
+});
+
+describe('useUser', () => {
+  it('returns the user from context', () => {
+    mockUseAuthContext.mockReturnValue({ user: { idKey: 'u1' } });
+    const { result } = renderHook(() => useUser());
+    expect(result.current).toEqual({ idKey: 'u1' });
+  });
+
+  it('returns null when not authenticated', () => {
+    mockUseAuthContext.mockReturnValue({ user: null });
+    const { result } = renderHook(() => useUser());
+    expect(result.current).toBeNull();
+  });
+});
+
+describe('useIsAuthenticated', () => {
+  it('returns only isAuthenticated+isLoading (not the full user)', () => {
+    mockUseAuthContext.mockReturnValue({
+      isAuthenticated: true,
+      isLoading: false,
+      user: { idKey: 'u1' },
+    });
+    const { result } = renderHook(() => useIsAuthenticated());
+    expect(result.current).toEqual({ isAuthenticated: true, isLoading: false });
+    expect(result.current).not.toHaveProperty('user');
+  });
+});

--- a/src/web/src/hooks/__tests__/useCampuses.test.tsx
+++ b/src/web/src/hooks/__tests__/useCampuses.test.tsx
@@ -1,0 +1,127 @@
+/**
+ * useCampuses / useCampus / useCreateCampus / useUpdateCampus / useDeleteCampus.
+ *
+ * These hooks are thin TanStack Query wrappers around `services/api/campuses`.
+ * The behaviors worth locking in are:
+ *   - Queries execute on mount and eventually resolve with the mock value.
+ *   - `useCampus(idKey)` is idle (disabled) until an idKey is supplied.
+ *   - Mutations call through to the right API function with the right args.
+ *   - After a mutation resolves, invalidation happens at the `['campuses']`
+ *     key so downstream lists refetch.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/campuses', () => ({
+  getCampuses: vi.fn(),
+  getCampus: vi.fn(),
+  createCampus: vi.fn(),
+  updateCampus: vi.fn(),
+  deleteCampus: vi.fn(),
+}));
+
+import * as campusesApi from '@/services/api/campuses';
+import {
+  useCampus,
+  useCampuses,
+  useCreateCampus,
+  useDeleteCampus,
+  useUpdateCampus,
+} from '../useCampuses';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+const getCampusesMock = vi.mocked(campusesApi.getCampuses);
+const getCampusMock = vi.mocked(campusesApi.getCampus);
+const createCampusMock = vi.mocked(campusesApi.createCampus);
+const updateCampusMock = vi.mocked(campusesApi.updateCampus);
+const deleteCampusMock = vi.mocked(campusesApi.deleteCampus);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useCampuses', () => {
+  it('fetches campuses with includeInactive=false by default', async () => {
+    getCampusesMock.mockResolvedValueOnce([{ idKey: 'c1', name: 'Main' }] as never);
+    const { result } = renderHookWithQuery(() => useCampuses());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getCampusesMock).toHaveBeenCalledWith(false);
+    expect(result.current.data).toEqual([{ idKey: 'c1', name: 'Main' }]);
+  });
+
+  it('passes includeInactive=true when requested', async () => {
+    getCampusesMock.mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useCampuses(true));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getCampusesMock).toHaveBeenCalledWith(true);
+  });
+
+  it('surfaces fetch errors as isError', async () => {
+    getCampusesMock.mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHookWithQuery(() => useCampuses());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as Error).message).toBe('boom');
+  });
+});
+
+describe('useCampus', () => {
+  it('is disabled when idKey is undefined', () => {
+    const { result } = renderHookWithQuery(() => useCampus(undefined));
+    // react-query v5: disabled queries have fetchStatus='idle', status='pending'
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getCampusMock).not.toHaveBeenCalled();
+  });
+
+  it('executes when idKey is provided', async () => {
+    getCampusMock.mockResolvedValueOnce({ idKey: 'c1' } as never);
+    const { result } = renderHookWithQuery(() => useCampus('c1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getCampusMock).toHaveBeenCalledWith('c1');
+  });
+});
+
+describe('useCreateCampus', () => {
+  it('calls createCampus and invalidates campuses list', async () => {
+    createCampusMock.mockResolvedValueOnce({ idKey: 'new' } as never);
+    const { result, client } = renderHookWithQuery(() => useCreateCampus());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'North' } as never);
+    });
+
+    expect(createCampusMock).toHaveBeenCalledWith({ name: 'North' });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['campuses'] });
+  });
+});
+
+describe('useUpdateCampus', () => {
+  it('forwards idKey + request and invalidates', async () => {
+    updateCampusMock.mockResolvedValueOnce({ idKey: 'c1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateCampus());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 'c1', request: { name: 'x' } as never });
+    });
+
+    expect(updateCampusMock).toHaveBeenCalledWith('c1', { name: 'x' });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['campuses'] });
+  });
+});
+
+describe('useDeleteCampus', () => {
+  it('deletes by idKey and invalidates', async () => {
+    deleteCampusMock.mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useDeleteCampus());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+
+    await act(async () => {
+      await result.current.mutateAsync('c1');
+    });
+
+    expect(deleteCampusMock).toHaveBeenCalledWith('c1');
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['campuses'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useCheckin.test.tsx
+++ b/src/web/src/hooks/__tests__/useCheckin.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * useCheckin hooks (kiosk-side). Paired with the services/api/checkin tests.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/checkin', () => ({
+  getCheckinConfiguration: vi.fn(),
+  searchFamiliesForCheckin: vi.fn(),
+  getCheckinOpportunities: vi.fn(),
+  recordAttendance: vi.fn(),
+  checkout: vi.fn(),
+  getLabels: vi.fn(),
+}));
+
+import * as checkinApi from '@/services/api/checkin';
+import {
+  useCheckinConfiguration,
+  useCheckinOpportunities,
+  useCheckinSearch,
+  useCheckout,
+  useLabels,
+  useRecordAttendance,
+} from '../useCheckin';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useCheckinConfiguration', () => {
+  it('forwards params', async () => {
+    vi.mocked(checkinApi.getCheckinConfiguration).mockResolvedValueOnce({} as never);
+    const { result } = renderHookWithQuery(() => useCheckinConfiguration({ kioskId: 'k1' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(checkinApi.getCheckinConfiguration).toHaveBeenCalledWith({ kioskId: 'k1' });
+  });
+});
+
+describe('useCheckinSearch', () => {
+  it('idle when searchValue is empty', () => {
+    const { result } = renderHookWithQuery(() => useCheckinSearch());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('idle when searchValue shorter than 2 chars', () => {
+    const { result } = renderHookWithQuery(() => useCheckinSearch('a'));
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires when searchValue has enough chars', async () => {
+    vi.mocked(checkinApi.searchFamiliesForCheckin).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useCheckinSearch('jo', 'Name'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(checkinApi.searchFamiliesForCheckin).toHaveBeenCalledWith({
+      searchValue: 'jo',
+      searchType: 'Name',
+    });
+  });
+});
+
+describe('useCheckinOpportunities', () => {
+  it('idle without familyIdKey', () => {
+    const { result } = renderHookWithQuery(() => useCheckinOpportunities());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with familyIdKey', async () => {
+    vi.mocked(checkinApi.getCheckinOpportunities).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useCheckinOpportunities('f1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(checkinApi.getCheckinOpportunities).toHaveBeenCalledWith('f1', {});
+  });
+});
+
+describe('useRecordAttendance', () => {
+  it('calls api and invalidates opportunities on success', async () => {
+    vi.mocked(checkinApi.recordAttendance).mockResolvedValueOnce({ results: [] } as never);
+    const { result, client } = renderHookWithQuery(() => useRecordAttendance());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    const items = [{ personIdKey: 'p1', groupIdKey: 'g1', locationIdKey: 'l1' }] as never;
+    await act(async () => {
+      await result.current.mutateAsync(items);
+    });
+    expect(checkinApi.recordAttendance).toHaveBeenCalledWith(items);
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['checkin', 'opportunities'] });
+  });
+});
+
+describe('useCheckout', () => {
+  it('calls api and invalidates', async () => {
+    vi.mocked(checkinApi.checkout).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useCheckout());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('a1');
+    });
+    expect(checkinApi.checkout).toHaveBeenCalledWith('a1');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['checkin', 'opportunities'] });
+  });
+});
+
+describe('useLabels', () => {
+  it('idle without attendanceIdKey', () => {
+    const { result } = renderHookWithQuery(() => useLabels());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with attendanceIdKey', async () => {
+    vi.mocked(checkinApi.getLabels).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useLabels('a1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(checkinApi.getLabels).toHaveBeenCalledWith('a1', {});
+  });
+});

--- a/src/web/src/hooks/__tests__/useCheckinOperations.test.tsx
+++ b/src/web/src/hooks/__tests__/useCheckinOperations.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * useCheckinOperations hooks: live dashboard query + toggle mutation (#482).
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/checkinOperations', () => ({
+  getCheckinOperationsDashboard: vi.fn(),
+  toggleCheckinOperationsRoom: vi.fn(),
+}));
+
+import * as api from '@/services/api/checkinOperations';
+import {
+  CHECKIN_OPS_POLL_INTERVAL_MS,
+  CHECKIN_OPS_QUERY_KEY,
+  useCheckinOperationsDashboard,
+  useToggleCheckinOperationsRoom,
+} from '../useCheckinOperations';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useCheckinOperationsDashboard', () => {
+  it('polls constants are stable', () => {
+    expect(CHECKIN_OPS_POLL_INTERVAL_MS).toBe(5000);
+    expect(CHECKIN_OPS_QUERY_KEY).toEqual(['checkin-operations', 'dashboard']);
+  });
+
+  it('fetches dashboard by default (enabled=true)', async () => {
+    vi.mocked(api.getCheckinOperationsDashboard).mockResolvedValueOnce({
+      rooms: [],
+      attendees: [],
+      summary: { totalCheckedIn: 0, currentlyPresent: 0, checkedOut: 0 },
+      generatedAt: 'now',
+    } as never);
+    const { result } = renderHookWithQuery(() => useCheckinOperationsDashboard());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getCheckinOperationsDashboard).toHaveBeenCalled();
+  });
+
+  it('is idle when enabled=false', () => {
+    const { result } = renderHookWithQuery(() => useCheckinOperationsDashboard(false));
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(api.getCheckinOperationsDashboard).not.toHaveBeenCalled();
+  });
+});
+
+describe('useToggleCheckinOperationsRoom', () => {
+  it('invalidates dashboard query on success', async () => {
+    vi.mocked(api.toggleCheckinOperationsRoom).mockResolvedValueOnce({
+      locationIdKey: 'l1',
+      isOpen: false,
+    } as never);
+    const { result, client } = renderHookWithQuery(() =>
+      useToggleCheckinOperationsRoom()
+    );
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('l1');
+    });
+    expect(api.toggleCheckinOperationsRoom).toHaveBeenCalledWith('l1');
+    expect(inv).toHaveBeenCalledWith({ queryKey: CHECKIN_OPS_QUERY_KEY });
+  });
+});

--- a/src/web/src/hooks/__tests__/useCommunicationPreferences.test.tsx
+++ b/src/web/src/hooks/__tests__/useCommunicationPreferences.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * useCommunicationPreferences + the single/bulk update mutations.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/communications', () => ({
+  getCommunicationPreferences: vi.fn(),
+  updateCommunicationPreference: vi.fn(),
+  bulkUpdateCommunicationPreferences: vi.fn(),
+}));
+
+import * as api from '@/services/api/communications';
+import {
+  useBulkUpdateCommunicationPreferences,
+  useCommunicationPreferences,
+  useUpdateCommunicationPreference,
+} from '../useCommunicationPreferences';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useCommunicationPreferences', () => {
+  it('idle without personIdKey', () => {
+    const { result } = renderHookWithQuery(() => useCommunicationPreferences());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with personIdKey', async () => {
+    vi.mocked(api.getCommunicationPreferences).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useCommunicationPreferences('p1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getCommunicationPreferences).toHaveBeenCalledWith('p1');
+  });
+});
+
+describe('useUpdateCommunicationPreference', () => {
+  it('calls api and invalidates per-person key', async () => {
+    vi.mocked(api.updateCommunicationPreference).mockResolvedValueOnce({} as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateCommunicationPreference());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({
+        personIdKey: 'p1',
+        type: 'Email',
+        request: { optIn: false } as never,
+      });
+    });
+    expect(api.updateCommunicationPreference).toHaveBeenCalledWith(
+      'p1',
+      'Email',
+      { optIn: false }
+    );
+    expect(inv).toHaveBeenCalledWith({
+      queryKey: ['communication-preferences', 'p1'],
+    });
+  });
+});
+
+describe('useBulkUpdateCommunicationPreferences', () => {
+  it('calls api and invalidates per-person key', async () => {
+    vi.mocked(api.bulkUpdateCommunicationPreferences).mockResolvedValueOnce([] as never);
+    const { result, client } = renderHookWithQuery(() =>
+      useBulkUpdateCommunicationPreferences()
+    );
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({
+        personIdKey: 'p1',
+        request: { preferences: [] } as never,
+      });
+    });
+    expect(api.bulkUpdateCommunicationPreferences).toHaveBeenCalledWith('p1', {
+      preferences: [],
+    });
+    expect(inv).toHaveBeenCalledWith({
+      queryKey: ['communication-preferences', 'p1'],
+    });
+  });
+});

--- a/src/web/src/hooks/__tests__/useCommunicationTemplates.test.tsx
+++ b/src/web/src/hooks/__tests__/useCommunicationTemplates.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * useCommunicationTemplates — list/detail/CRUD with onError invalidation.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/communicationTemplates', () => ({
+  getCommunicationTemplates: vi.fn(),
+  getCommunicationTemplate: vi.fn(),
+  createCommunicationTemplate: vi.fn(),
+  updateCommunicationTemplate: vi.fn(),
+  deleteCommunicationTemplate: vi.fn(),
+}));
+
+import * as api from '@/services/api/communicationTemplates';
+import {
+  useCommunicationTemplate,
+  useCommunicationTemplates,
+  useCreateCommunicationTemplate,
+  useDeleteCommunicationTemplate,
+  useUpdateCommunicationTemplate,
+} from '../useCommunicationTemplates';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useCommunicationTemplates', () => {
+  it('forwards params', async () => {
+    vi.mocked(api.getCommunicationTemplates).mockResolvedValueOnce({ data: [] } as never);
+    const { result } = renderHookWithQuery(() => useCommunicationTemplates({ page: 2 }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getCommunicationTemplates).toHaveBeenCalledWith({ page: 2 });
+  });
+});
+
+describe('useCommunicationTemplate', () => {
+  it('idle without idKey', () => {
+    const { result } = renderHookWithQuery(() => useCommunicationTemplate());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with idKey', async () => {
+    vi.mocked(api.getCommunicationTemplate).mockResolvedValueOnce({ idKey: 't1' } as never);
+    const { result } = renderHookWithQuery(() => useCommunicationTemplate('t1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getCommunicationTemplate).toHaveBeenCalledWith('t1');
+  });
+});
+
+describe('mutations invalidate on success AND on error', () => {
+  it('create invalidates on success', async () => {
+    vi.mocked(api.createCommunicationTemplate).mockResolvedValueOnce({ idKey: 't1' } as never);
+    const { result, client } = renderHookWithQuery(() => useCreateCommunicationTemplate());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'N' } as never);
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['communication-templates'] });
+  });
+
+  it('create invalidates on error', async () => {
+    vi.mocked(api.createCommunicationTemplate).mockRejectedValueOnce(new Error('boom'));
+    const { result, client } = renderHookWithQuery(() => useCreateCommunicationTemplate());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ name: 'N' } as never);
+      } catch {
+        /* expected */
+      }
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['communication-templates'] });
+  });
+
+  it('update invalidates list + specific on success', async () => {
+    vi.mocked(api.updateCommunicationTemplate).mockResolvedValueOnce({ idKey: 't1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateCommunicationTemplate());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 't1', request: { name: 'X' } as never });
+    });
+    expect(api.updateCommunicationTemplate).toHaveBeenCalledWith('t1', { name: 'X' });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['communication-templates', 't1'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['communication-templates'] });
+  });
+
+  it('update invalidates list on error', async () => {
+    vi.mocked(api.updateCommunicationTemplate).mockRejectedValueOnce(new Error('nope'));
+    const { result, client } = renderHookWithQuery(() => useUpdateCommunicationTemplate());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({ idKey: 't1', request: { name: 'X' } as never });
+      } catch {
+        /* expected */
+      }
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['communication-templates'] });
+  });
+
+  it('delete invalidates on success and on error', async () => {
+    vi.mocked(api.deleteCommunicationTemplate).mockResolvedValueOnce(undefined as never);
+    const ok = renderHookWithQuery(() => useDeleteCommunicationTemplate());
+    const invOk = vi.spyOn(ok.client, 'invalidateQueries');
+    await act(async () => {
+      await ok.result.current.mutateAsync('t1');
+    });
+    expect(invOk).toHaveBeenCalledWith({ queryKey: ['communication-templates'] });
+
+    vi.mocked(api.deleteCommunicationTemplate).mockRejectedValueOnce(new Error('boom'));
+    const bad = renderHookWithQuery(() => useDeleteCommunicationTemplate());
+    const invBad = vi.spyOn(bad.client, 'invalidateQueries');
+    await act(async () => {
+      try {
+        await bad.result.current.mutateAsync('t1');
+      } catch {
+        /* expected */
+      }
+    });
+    expect(invBad).toHaveBeenCalledWith({ queryKey: ['communication-templates'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useCommunications.test.tsx
+++ b/src/web/src/hooks/__tests__/useCommunications.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * useCommunications + related hooks.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/communications', () => ({
+  getCommunication: vi.fn(),
+  getCommunications: vi.fn(),
+  createCommunication: vi.fn(),
+  sendCommunication: vi.fn(),
+  scheduleCommunication: vi.fn(),
+  cancelSchedule: vi.fn(),
+  getMergeFields: vi.fn(),
+  previewCommunication: vi.fn(),
+}));
+
+import * as api from '@/services/api/communications';
+import {
+  useCancelSchedule,
+  useCommunication,
+  useCommunications,
+  useCreateCommunication,
+  useMergeFields,
+  usePreviewCommunication,
+  useScheduleCommunication,
+  useSendCommunication,
+} from '../useCommunications';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useCommunication / useCommunications / useMergeFields', () => {
+  it('useCommunication idle without idKey, fires with', async () => {
+    const idle = renderHookWithQuery(() => useCommunication()).result;
+    expect(idle.current.fetchStatus).toBe('idle');
+
+    vi.mocked(api.getCommunication).mockResolvedValueOnce({ idKey: 'c1' } as never);
+    const { result } = renderHookWithQuery(() => useCommunication('c1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getCommunication).toHaveBeenCalledWith('c1');
+  });
+
+  it('useCommunications forwards params', async () => {
+    vi.mocked(api.getCommunications).mockResolvedValueOnce({ data: [] } as never);
+    const { result } = renderHookWithQuery(() => useCommunications({ page: 2 }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getCommunications).toHaveBeenCalledWith({ page: 2 });
+  });
+
+  it('useMergeFields fetches once', async () => {
+    vi.mocked(api.getMergeFields).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useMergeFields());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+describe('mutations invalidate communications', () => {
+  it('create invalidates communications', async () => {
+    vi.mocked(api.createCommunication).mockResolvedValueOnce({ idKey: 'c1' } as never);
+    const { result, client } = renderHookWithQuery(() => useCreateCommunication());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ subject: 'S' } as never);
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['communications'] });
+  });
+
+  it('send invalidates specific + list', async () => {
+    vi.mocked(api.sendCommunication).mockResolvedValueOnce({ idKey: 'c1' } as never);
+    const { result, client } = renderHookWithQuery(() => useSendCommunication());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('c1');
+    });
+    expect(api.sendCommunication).toHaveBeenCalledWith('c1');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['communications', 'c1'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['communications'] });
+  });
+
+  it('schedule invalidates specific + list', async () => {
+    vi.mocked(api.scheduleCommunication).mockResolvedValueOnce({ idKey: 'c1' } as never);
+    const { result, client } = renderHookWithQuery(() => useScheduleCommunication());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({
+        idKey: 'c1',
+        scheduledDateTime: '2024-01-01T10:00:00Z',
+      });
+    });
+    expect(api.scheduleCommunication).toHaveBeenCalledWith('c1', '2024-01-01T10:00:00Z');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['communications', 'c1'] });
+  });
+
+  it('cancelSchedule invalidates', async () => {
+    vi.mocked(api.cancelSchedule).mockResolvedValueOnce({ idKey: 'c1' } as never);
+    const { result, client } = renderHookWithQuery(() => useCancelSchedule());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('c1');
+    });
+    expect(api.cancelSchedule).toHaveBeenCalledWith('c1');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['communications', 'c1'] });
+  });
+
+  it('previewCommunication mutation calls api', async () => {
+    vi.mocked(api.previewCommunication).mockResolvedValueOnce({ body: 'x' } as never);
+    const { result } = renderHookWithQuery(() => usePreviewCommunication());
+    await act(async () => {
+      await result.current.mutateAsync({ templateIdKey: 't1' } as never);
+    });
+    expect(api.previewCommunication).toHaveBeenCalledWith({ templateIdKey: 't1' });
+  });
+});

--- a/src/web/src/hooks/__tests__/useDashboard.test.tsx
+++ b/src/web/src/hooks/__tests__/useDashboard.test.tsx
@@ -1,0 +1,34 @@
+/**
+ * useDashboardStats is a one-line TanStack Query wrapper.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+
+vi.mock('@/services/api/dashboard', () => ({
+  getDashboardStats: vi.fn(),
+}));
+
+import * as dashboardApi from '@/services/api/dashboard';
+import { useDashboardStats } from '../useDashboard';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useDashboardStats', () => {
+  it('fetches and returns stats', async () => {
+    vi.mocked(dashboardApi.getDashboardStats).mockResolvedValueOnce({
+      activeCheckins: 42,
+    } as never);
+    const { result } = renderHookWithQuery(() => useDashboardStats());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ activeCheckins: 42 });
+  });
+
+  it('surfaces errors', async () => {
+    vi.mocked(dashboardApi.getDashboardStats).mockRejectedValueOnce(new Error('boom'));
+    const { result } = renderHookWithQuery(() => useDashboardStats());
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as Error).message).toBe('boom');
+  });
+});

--- a/src/web/src/hooks/__tests__/useDefinedTypes.test.tsx
+++ b/src/web/src/hooks/__tests__/useDefinedTypes.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * useDefinedTypes / useDefinedTypeValues.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+
+vi.mock('@/services/api/reference', () => ({
+  getDefinedTypes: vi.fn(),
+  getDefinedTypeValues: vi.fn(),
+}));
+
+import * as referenceApi from '@/services/api/reference';
+import { useDefinedTypes, useDefinedTypeValues } from '../useDefinedTypes';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useDefinedTypes', () => {
+  it('calls getDefinedTypes', async () => {
+    vi.mocked(referenceApi.getDefinedTypes).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useDefinedTypes());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(referenceApi.getDefinedTypes).toHaveBeenCalled();
+  });
+});
+
+describe('useDefinedTypeValues', () => {
+  it('idle when idKeyOrGuid is undefined', () => {
+    const { result } = renderHookWithQuery(() => useDefinedTypeValues(undefined));
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(referenceApi.getDefinedTypeValues).not.toHaveBeenCalled();
+  });
+
+  it('idle for empty string', () => {
+    const { result } = renderHookWithQuery(() => useDefinedTypeValues(''));
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fetches when idKeyOrGuid is provided', async () => {
+    vi.mocked(referenceApi.getDefinedTypeValues).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useDefinedTypeValues('dt1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(referenceApi.getDefinedTypeValues).toHaveBeenCalledWith('dt1');
+  });
+});

--- a/src/web/src/hooks/__tests__/useDevices.test.tsx
+++ b/src/web/src/hooks/__tests__/useDevices.test.tsx
@@ -1,0 +1,100 @@
+/**
+ * useDevices hook module.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/devices', () => ({
+  getDevices: vi.fn(),
+  getDeviceByIdKey: vi.fn(),
+  createDevice: vi.fn(),
+  updateDevice: vi.fn(),
+  deleteDevice: vi.fn(),
+  generateKioskToken: vi.fn(),
+}));
+
+import * as api from '@/services/api/devices';
+import {
+  useCreateDevice,
+  useDeleteDevice,
+  useDevice,
+  useDevices,
+  useGenerateKioskToken,
+  useUpdateDevice,
+} from '../useDevices';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useDevices', () => {
+  it('forwards params', async () => {
+    vi.mocked(api.getDevices).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useDevices({ q: 'iPad' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getDevices).toHaveBeenCalledWith({ q: 'iPad' });
+  });
+});
+
+describe('useDevice', () => {
+  it('idle without idKey', () => {
+    const { result } = renderHookWithQuery(() => useDevice());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with idKey', async () => {
+    vi.mocked(api.getDeviceByIdKey).mockResolvedValueOnce({ idKey: 'd1' } as never);
+    const { result } = renderHookWithQuery(() => useDevice('d1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getDeviceByIdKey).toHaveBeenCalledWith('d1');
+  });
+});
+
+describe('mutations', () => {
+  it('create invalidates', async () => {
+    vi.mocked(api.createDevice).mockResolvedValueOnce({ idKey: 'd1' } as never);
+    const { result, client } = renderHookWithQuery(() => useCreateDevice());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'iPad' } as never);
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['devices'] });
+  });
+
+  it('update invalidates specific + list', async () => {
+    vi.mocked(api.updateDevice).mockResolvedValueOnce({ idKey: 'd1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateDevice());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 'd1', request: { name: 'X' } as never });
+    });
+    expect(api.updateDevice).toHaveBeenCalledWith('d1', { name: 'X' });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['devices', 'd1'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['devices'] });
+  });
+
+  it('delete invalidates', async () => {
+    vi.mocked(api.deleteDevice).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useDeleteDevice());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('d1');
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['devices'] });
+  });
+
+  it('generateKioskToken invalidates device-specific key', async () => {
+    vi.mocked(api.generateKioskToken).mockResolvedValueOnce({
+      token: 't',
+      deviceIdKey: 'd1',
+      deviceName: 'A',
+    } as never);
+    const { result, client } = renderHookWithQuery(() => useGenerateKioskToken());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('d1');
+    });
+    expect(api.generateKioskToken).toHaveBeenCalledWith('d1');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['devices', 'd1'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useFamilies.test.tsx
+++ b/src/web/src/hooks/__tests__/useFamilies.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * useFamilies and siblings: query hooks wrapping services/api/families.
+ *
+ * Guards the boundary between UI and API:
+ *   - useFamilies passes full param object through to `searchFamilies`.
+ *   - useFamily(idKey) is idle until idKey is supplied.
+ *   - Mutations (create/update/addMember/removeMember) invalidate the right
+ *     query keys so lists and detail pages refetch.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/families', () => ({
+  searchFamilies: vi.fn(),
+  getFamilyByIdKey: vi.fn(),
+  createFamily: vi.fn(),
+  updateFamily: vi.fn(),
+  addFamilyMember: vi.fn(),
+  removeFamilyMember: vi.fn(),
+}));
+
+import * as familiesApi from '@/services/api/families';
+import {
+  useAddFamilyMember,
+  useCreateFamily,
+  useFamilies,
+  useFamily,
+  useRemoveFamilyMember,
+  useUpdateFamily,
+} from '../useFamilies';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+const searchMock = vi.mocked(familiesApi.searchFamilies);
+const getMock = vi.mocked(familiesApi.getFamilyByIdKey);
+const createMock = vi.mocked(familiesApi.createFamily);
+const updateMock = vi.mocked(familiesApi.updateFamily);
+const addMemberMock = vi.mocked(familiesApi.addFamilyMember);
+const removeMemberMock = vi.mocked(familiesApi.removeFamilyMember);
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useFamilies', () => {
+  it('forwards params to searchFamilies', async () => {
+    searchMock.mockResolvedValueOnce({ data: [] } as never);
+    const params = { q: 'Smith', page: 2 };
+    const { result } = renderHookWithQuery(() => useFamilies(params));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(searchMock).toHaveBeenCalledWith(params);
+  });
+});
+
+describe('useFamily', () => {
+  it('is idle when idKey is falsy', () => {
+    const { result } = renderHookWithQuery(() => useFamily(undefined));
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getMock).not.toHaveBeenCalled();
+  });
+
+  it('executes when idKey is provided', async () => {
+    getMock.mockResolvedValueOnce({ idKey: 'f1' } as never);
+    const { result } = renderHookWithQuery(() => useFamily('f1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getMock).toHaveBeenCalledWith('f1');
+    expect(result.current.data).toEqual({ idKey: 'f1' });
+  });
+});
+
+describe('useCreateFamily', () => {
+  it('creates and invalidates families list', async () => {
+    createMock.mockResolvedValueOnce({ idKey: 'new' } as never);
+    const { result, client } = renderHookWithQuery(() => useCreateFamily());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'Smith' } as never);
+    });
+
+    expect(createMock).toHaveBeenCalledWith({ name: 'Smith' });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['families'] });
+  });
+});
+
+describe('useUpdateFamily', () => {
+  it('updates and invalidates both specific and list keys', async () => {
+    updateMock.mockResolvedValueOnce({ idKey: 'f1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateFamily());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 'f1', request: { name: 'X' } as never });
+    });
+
+    expect(updateMock).toHaveBeenCalledWith('f1', { name: 'X' });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['families', 'f1'] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['families'] });
+  });
+});
+
+describe('useAddFamilyMember', () => {
+  it('adds a member and invalidates families + people', async () => {
+    addMemberMock.mockResolvedValueOnce({ personIdKey: 'p1' } as never);
+    const { result, client } = renderHookWithQuery(() => useAddFamilyMember());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        familyIdKey: 'f1',
+        request: { personIdKey: 'p1' } as never,
+      });
+    });
+
+    expect(addMemberMock).toHaveBeenCalledWith('f1', { personIdKey: 'p1' });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['families', 'f1'] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['families'] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['people'] });
+  });
+});
+
+describe('useRemoveFamilyMember', () => {
+  it('removes a member with optional params', async () => {
+    removeMemberMock.mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useRemoveFamilyMember());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        familyIdKey: 'f1',
+        personIdKey: 'p1',
+        params: { removeFromAllGroups: true },
+      });
+    });
+
+    expect(removeMemberMock).toHaveBeenCalledWith('f1', 'p1', {
+      removeFromAllGroups: true,
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['families', 'f1'] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['people'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useGiving.test.tsx
+++ b/src/web/src/hooks/__tests__/useGiving.test.tsx
@@ -1,0 +1,300 @@
+/**
+ * useGiving hook module — the biggest hook file in the repo.
+ * Covers batches, contributions, statements, funds (admin), plus the
+ * statement-pdf download side-effect.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/giving', () => ({
+  getBatches: vi.fn(),
+  getBatch: vi.fn(),
+  getBatchSummary: vi.fn(),
+  getBatchContributions: vi.fn(),
+  getActiveFunds: vi.fn(),
+  openBatch: vi.fn(),
+  closeBatch: vi.fn(),
+  createBatch: vi.fn(),
+  addContribution: vi.fn(),
+  updateContribution: vi.fn(),
+  deleteContribution: vi.fn(),
+  getStatements: vi.fn(),
+  getStatement: vi.fn(),
+  getEligiblePeople: vi.fn(),
+  generateStatement: vi.fn(),
+  getAllFundsAdmin: vi.fn(),
+  createFund: vi.fn(),
+  updateFund: vi.fn(),
+  deactivateFund: vi.fn(),
+  downloadStatementPdf: vi.fn(),
+}));
+vi.mock('@/services/api/reference', () => ({
+  getCampuses: vi.fn(),
+}));
+
+import * as api from '@/services/api/giving';
+import * as referenceApi from '@/services/api/reference';
+import {
+  useActiveFunds,
+  useAddContribution,
+  useAdminFunds,
+  useBatch,
+  useBatchContributions,
+  useBatchSummary,
+  useBatches,
+  useCampuses,
+  useCloseBatch,
+  useCreateBatch,
+  useCreateFund,
+  useDeactivateFund,
+  useDeleteContribution,
+  useDownloadStatementPdf,
+  useEligiblePeople,
+  useGenerateStatement,
+  useOpenBatch,
+  useStatement,
+  useStatements,
+  useUpdateContribution,
+  useUpdateFund,
+} from '../useGiving';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('batch queries', () => {
+  it('useBatches forwards filter', async () => {
+    vi.mocked(api.getBatches).mockResolvedValueOnce({ data: [] } as never);
+    const { result } = renderHookWithQuery(() => useBatches({ status: 'Open' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getBatches).toHaveBeenCalledWith({ status: 'Open' });
+  });
+
+  it('useBatch idle without idKey, fires with idKey', async () => {
+    const idle = renderHookWithQuery(() => useBatch()).result;
+    expect(idle.current.fetchStatus).toBe('idle');
+
+    vi.mocked(api.getBatch).mockResolvedValueOnce({ idKey: 'b1' } as never);
+    const { result } = renderHookWithQuery(() => useBatch('b1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it('useBatchSummary / useBatchContributions both need idKey', async () => {
+    const s = renderHookWithQuery(() => useBatchSummary()).result;
+    const c = renderHookWithQuery(() => useBatchContributions()).result;
+    expect(s.current.fetchStatus).toBe('idle');
+    expect(c.current.fetchStatus).toBe('idle');
+
+    vi.mocked(api.getBatchSummary).mockResolvedValueOnce({} as never);
+    vi.mocked(api.getBatchContributions).mockResolvedValueOnce([] as never);
+
+    const s2 = renderHookWithQuery(() => useBatchSummary('b1'));
+    const c2 = renderHookWithQuery(() => useBatchContributions('b1'));
+    await waitFor(() => expect(s2.result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(c2.result.current.isSuccess).toBe(true));
+    expect(api.getBatchSummary).toHaveBeenCalledWith('b1');
+    expect(api.getBatchContributions).toHaveBeenCalledWith('b1');
+  });
+});
+
+describe('batch mutations invalidate batches', () => {
+  it('open/close/create all invalidate', async () => {
+    vi.mocked(api.openBatch).mockResolvedValueOnce({ message: '' } as never);
+    vi.mocked(api.closeBatch).mockResolvedValueOnce({ message: '' } as never);
+    vi.mocked(api.createBatch).mockResolvedValueOnce({ idKey: 'b1' } as never);
+
+    const open = renderHookWithQuery(() => useOpenBatch());
+    const close = renderHookWithQuery(() => useCloseBatch());
+    const create = renderHookWithQuery(() => useCreateBatch());
+    const invO = vi.spyOn(open.client, 'invalidateQueries');
+    const invC = vi.spyOn(close.client, 'invalidateQueries');
+    const invCr = vi.spyOn(create.client, 'invalidateQueries');
+
+    await act(async () => {
+      await open.result.current.mutateAsync('b1');
+    });
+    expect(api.openBatch).toHaveBeenCalledWith('b1');
+    expect(invO).toHaveBeenCalledWith({ queryKey: ['batches'] });
+
+    await act(async () => {
+      await close.result.current.mutateAsync('b1');
+    });
+    expect(invC).toHaveBeenCalledWith({ queryKey: ['batches'] });
+
+    await act(async () => {
+      await create.result.current.mutateAsync({ name: 'Jan' } as never);
+    });
+    expect(invCr).toHaveBeenCalledWith({ queryKey: ['batches'] });
+  });
+});
+
+describe('contribution mutations', () => {
+  it('add contribution invalidates batch contributions + summary', async () => {
+    vi.mocked(api.addContribution).mockResolvedValueOnce({ idKey: 'c1' } as never);
+    const { result, client } = renderHookWithQuery(() => useAddContribution());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({
+        batchIdKey: 'b1',
+        request: { amount: 10 } as never,
+      });
+    });
+    expect(api.addContribution).toHaveBeenCalledWith('b1', { amount: 10 });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['batches', 'b1', 'contributions'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['batches', 'b1', 'summary'] });
+  });
+
+  it('update contribution invalidates by returned batchIdKey', async () => {
+    vi.mocked(api.updateContribution).mockResolvedValueOnce({
+      idKey: 'c1',
+      batchIdKey: 'b1',
+    } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateContribution());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({
+        idKey: 'c1',
+        data: { amount: 15 } as never,
+      });
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['batches', 'b1', 'contributions'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['contributions'] });
+  });
+
+  it('delete contribution invalidates by batchIdKey variable', async () => {
+    vi.mocked(api.deleteContribution).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useDeleteContribution());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 'c1', batchIdKey: 'b1' });
+    });
+    expect(api.deleteContribution).toHaveBeenCalledWith('c1');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['batches', 'b1', 'contributions'] });
+  });
+});
+
+describe('fund hooks', () => {
+  it('useActiveFunds fetches', async () => {
+    vi.mocked(api.getActiveFunds).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useActiveFunds());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getActiveFunds).toHaveBeenCalled();
+  });
+
+  it('useAdminFunds fetches', async () => {
+    vi.mocked(api.getAllFundsAdmin).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useAdminFunds());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it('create / update / deactivate fund invalidate funds', async () => {
+    vi.mocked(api.createFund).mockResolvedValueOnce({ idKey: 'f1' } as never);
+    vi.mocked(api.updateFund).mockResolvedValueOnce({ idKey: 'f1' } as never);
+    vi.mocked(api.deactivateFund).mockResolvedValueOnce(undefined as never);
+
+    const c = renderHookWithQuery(() => useCreateFund());
+    const u = renderHookWithQuery(() => useUpdateFund());
+    const d = renderHookWithQuery(() => useDeactivateFund());
+    const invC = vi.spyOn(c.client, 'invalidateQueries');
+    const invU = vi.spyOn(u.client, 'invalidateQueries');
+    const invD = vi.spyOn(d.client, 'invalidateQueries');
+
+    await act(async () => {
+      await c.result.current.mutateAsync({ name: 'General' } as never);
+    });
+    expect(invC).toHaveBeenCalledWith({ queryKey: ['funds'] });
+
+    await act(async () => {
+      await u.result.current.mutateAsync({ idKey: 'f1', request: { name: 'X' } as never });
+    });
+    expect(api.updateFund).toHaveBeenCalledWith('f1', { name: 'X' });
+    expect(invU).toHaveBeenCalledWith({ queryKey: ['funds'] });
+
+    await act(async () => {
+      await d.result.current.mutateAsync('f1');
+    });
+    expect(invD).toHaveBeenCalledWith({ queryKey: ['funds'] });
+  });
+});
+
+describe('campus hook (for filter dropdown)', () => {
+  it('useCampuses calls reference.getCampuses', async () => {
+    vi.mocked(referenceApi.getCampuses).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useCampuses());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(referenceApi.getCampuses).toHaveBeenCalled();
+  });
+});
+
+describe('statements', () => {
+  it('useStatements defaults to page 1, pageSize 25', async () => {
+    vi.mocked(api.getStatements).mockResolvedValueOnce({ data: [] } as never);
+    const { result } = renderHookWithQuery(() => useStatements());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getStatements).toHaveBeenCalledWith(1, 25);
+  });
+
+  it('useStatement idle without idKey, fires with', async () => {
+    const idle = renderHookWithQuery(() => useStatement()).result;
+    expect(idle.current.fetchStatus).toBe('idle');
+
+    vi.mocked(api.getStatement).mockResolvedValueOnce({ idKey: 'st1' } as never);
+    const { result } = renderHookWithQuery(() => useStatement('st1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getStatement).toHaveBeenCalledWith('st1');
+  });
+
+  it('useEligiblePeople disabled unless both startDate+endDate present', () => {
+    const none = renderHookWithQuery(() => useEligiblePeople('', '')).result;
+    expect(none.current.fetchStatus).toBe('idle');
+  });
+
+  it('useEligiblePeople fires with both dates', async () => {
+    vi.mocked(api.getEligiblePeople).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() =>
+      useEligiblePeople('2024-01-01', '2024-02-01', 25)
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getEligiblePeople).toHaveBeenCalledWith('2024-01-01', '2024-02-01', 25);
+  });
+
+  it('useGenerateStatement invalidates statements', async () => {
+    vi.mocked(api.generateStatement).mockResolvedValueOnce({ idKey: 'st1' } as never);
+    const { result, client } = renderHookWithQuery(() => useGenerateStatement());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ startDate: 'a', endDate: 'b' } as never);
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['statements'] });
+  });
+});
+
+describe('useDownloadStatementPdf', () => {
+  it('creates an anchor, clicks it, and revokes the URL', async () => {
+    const blob = new Blob(['%PDF'], { type: 'application/pdf' });
+    vi.mocked(api.downloadStatementPdf).mockResolvedValueOnce(blob as never);
+
+    const createURL = vi
+      .spyOn(window.URL, 'createObjectURL')
+      .mockReturnValue('blob:url');
+    const revokeURL = vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => {});
+    const clickSpy = vi.fn();
+    const originalClick = HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click = clickSpy;
+
+    try {
+      const { result } = renderHookWithQuery(() => useDownloadStatementPdf());
+      await act(async () => {
+        await result.current.mutateAsync('st1');
+      });
+      expect(api.downloadStatementPdf).toHaveBeenCalledWith('st1');
+      expect(createURL).toHaveBeenCalledWith(blob);
+      expect(clickSpy).toHaveBeenCalled();
+      expect(revokeURL).toHaveBeenCalledWith('blob:url');
+    } finally {
+      HTMLAnchorElement.prototype.click = originalClick;
+      createURL.mockRestore();
+      revokeURL.mockRestore();
+    }
+  });
+});

--- a/src/web/src/hooks/__tests__/useGlobalSearch.test.tsx
+++ b/src/web/src/hooks/__tests__/useGlobalSearch.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * useGlobalSearch — debounced search + recent-searches localStorage state.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, waitFor } from '@testing-library/react';
+
+vi.mock('@/services/api/search', () => ({
+  globalSearch: vi.fn(),
+}));
+
+import * as searchApi from '@/services/api/search';
+import { useGlobalSearch } from '../useGlobalSearch';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+const RECENT_KEY = 'koinon:recent-searches';
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  localStorage.clear();
+});
+
+describe('useGlobalSearch initial state', () => {
+  it('starts empty with page=1 and no recent searches', () => {
+    const { result } = renderHookWithQuery(() => useGlobalSearch());
+    expect(result.current.query).toBe('');
+    expect(result.current.page).toBe(1);
+    expect(result.current.results).toEqual([]);
+    expect(result.current.recentSearches).toEqual([]);
+  });
+
+  it('hydrates recent searches from localStorage on mount', () => {
+    localStorage.setItem(RECENT_KEY, JSON.stringify(['alice', 'bob']));
+    const { result } = renderHookWithQuery(() => useGlobalSearch());
+    expect(result.current.recentSearches).toEqual(['alice', 'bob']);
+  });
+});
+
+describe('useGlobalSearch — search gating', () => {
+  it('does not search for queries shorter than 2 chars', async () => {
+    const { result } = renderHookWithQuery(() => useGlobalSearch());
+    act(() => {
+      result.current.setQuery('a');
+    });
+    // Give debounce time to resolve — we use real timers here; 350ms is enough.
+    await new Promise((r) => setTimeout(r, 350));
+    expect(searchApi.globalSearch).not.toHaveBeenCalled();
+  });
+
+  it('searches with debounced query (>=2 chars)', async () => {
+    vi.mocked(searchApi.globalSearch).mockResolvedValue({
+      results: [{ idKey: 'x' }],
+      totalCount: 1,
+      categoryCounts: {},
+      pageSize: 20,
+    } as never);
+
+    const { result } = renderHookWithQuery(() => useGlobalSearch());
+    act(() => {
+      result.current.setQuery('jo');
+    });
+
+    await waitFor(() => {
+      expect(searchApi.globalSearch).toHaveBeenCalledWith(
+        expect.objectContaining({
+          query: 'jo',
+          pageNumber: 1,
+          pageSize: 20,
+        })
+      );
+    });
+    await waitFor(() => expect(result.current.results).toHaveLength(1));
+  });
+
+  it('resets page to 1 when query changes', async () => {
+    vi.mocked(searchApi.globalSearch).mockResolvedValue({
+      results: [],
+      totalCount: 0,
+      categoryCounts: {},
+      pageSize: 20,
+    } as never);
+    const { result } = renderHookWithQuery(() => useGlobalSearch());
+
+    act(() => {
+      result.current.setQuery('jo');
+    });
+    await waitFor(() => expect(searchApi.globalSearch).toHaveBeenCalled());
+    act(() => {
+      result.current.setPage(3);
+    });
+    expect(result.current.page).toBe(3);
+    // Changing the query resets page back to 1.
+    act(() => {
+      result.current.setQuery('jack');
+    });
+    await waitFor(() => expect(result.current.page).toBe(1));
+  });
+});
+
+describe('useGlobalSearch — recent searches', () => {
+  it('adds successful search to recent searches (newest first, deduped)', async () => {
+    vi.mocked(searchApi.globalSearch).mockResolvedValue({
+      results: [],
+      totalCount: 0,
+      categoryCounts: {},
+      pageSize: 20,
+    } as never);
+    const { result } = renderHookWithQuery(() => useGlobalSearch());
+
+    act(() => {
+      result.current.setQuery('alpha');
+    });
+    await waitFor(() =>
+      expect(result.current.recentSearches).toContain('alpha')
+    );
+
+    act(() => {
+      result.current.setQuery('beta');
+    });
+    await waitFor(() => expect(result.current.recentSearches[0]).toBe('beta'));
+
+    // Re-search 'alpha' — should bubble to front without duplication.
+    act(() => {
+      result.current.setQuery('alpha');
+    });
+    await waitFor(() => expect(result.current.recentSearches[0]).toBe('alpha'));
+    expect(
+      result.current.recentSearches.filter((s) => s === 'alpha')
+    ).toHaveLength(1);
+  });
+
+  it('clearRecentSearches wipes both state and localStorage', () => {
+    localStorage.setItem(RECENT_KEY, JSON.stringify(['x']));
+    const { result } = renderHookWithQuery(() => useGlobalSearch());
+    expect(result.current.recentSearches).toEqual(['x']);
+    act(() => {
+      result.current.clearRecentSearches();
+    });
+    expect(result.current.recentSearches).toEqual([]);
+    expect(localStorage.getItem(RECENT_KEY)).toBeNull();
+  });
+
+  it('addToRecentSearches directly adds a manual entry (>=2 chars)', () => {
+    const { result } = renderHookWithQuery(() => useGlobalSearch());
+    act(() => {
+      result.current.addToRecentSearches('smith');
+    });
+    expect(result.current.recentSearches).toContain('smith');
+    // 1-char entries are rejected.
+    act(() => {
+      result.current.addToRecentSearches('x');
+    });
+    expect(result.current.recentSearches).not.toContain('x');
+  });
+});
+
+describe('useGlobalSearch — category filter', () => {
+  it('resets page when category changes', async () => {
+    vi.mocked(searchApi.globalSearch).mockResolvedValue({
+      results: [],
+      totalCount: 0,
+      categoryCounts: {},
+      pageSize: 20,
+    } as never);
+    const { result } = renderHookWithQuery(() => useGlobalSearch());
+    act(() => {
+      result.current.setQuery('smith');
+    });
+    await waitFor(() => expect(searchApi.globalSearch).toHaveBeenCalled());
+    act(() => {
+      result.current.setPage(2);
+    });
+    expect(result.current.page).toBe(2);
+    act(() => {
+      result.current.setCategory('People');
+    });
+    await waitFor(() => expect(result.current.page).toBe(1));
+  });
+});

--- a/src/web/src/hooks/__tests__/useGroupTypes.test.tsx
+++ b/src/web/src/hooks/__tests__/useGroupTypes.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * useGroupTypes admin hooks.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/groupTypes', () => ({
+  getGroupTypes: vi.fn(),
+  getGroupType: vi.fn(),
+  createGroupType: vi.fn(),
+  updateGroupType: vi.fn(),
+  archiveGroupType: vi.fn(),
+  getGroupsByType: vi.fn(),
+}));
+
+import * as api from '@/services/api/groupTypes';
+import {
+  useArchiveGroupType,
+  useCreateGroupType,
+  useGroupType,
+  useGroupTypes,
+  useGroupsByType,
+  useUpdateGroupType,
+} from '../useGroupTypes';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useGroupTypes', () => {
+  it('defaults includeArchived to false', async () => {
+    vi.mocked(api.getGroupTypes).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useGroupTypes());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getGroupTypes).toHaveBeenCalledWith(false);
+  });
+
+  it('passes true when requested', async () => {
+    vi.mocked(api.getGroupTypes).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useGroupTypes(true));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getGroupTypes).toHaveBeenCalledWith(true);
+  });
+});
+
+describe('useGroupType', () => {
+  it('idle without idKey', () => {
+    const { result } = renderHookWithQuery(() => useGroupType());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with idKey', async () => {
+    vi.mocked(api.getGroupType).mockResolvedValueOnce({ idKey: 'gt1' } as never);
+    const { result } = renderHookWithQuery(() => useGroupType('gt1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getGroupType).toHaveBeenCalledWith('gt1');
+  });
+});
+
+describe('useGroupsByType', () => {
+  it('idle without idKey', () => {
+    const { result } = renderHookWithQuery(() => useGroupsByType());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with idKey', async () => {
+    vi.mocked(api.getGroupsByType).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useGroupsByType('gt1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getGroupsByType).toHaveBeenCalledWith('gt1');
+  });
+});
+
+describe('create / update / archive', () => {
+  it('create invalidates', async () => {
+    vi.mocked(api.createGroupType).mockResolvedValueOnce({ idKey: 'gt1' } as never);
+    const { result, client } = renderHookWithQuery(() => useCreateGroupType());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'N' } as never);
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['group-types'] });
+  });
+
+  it('update invalidates', async () => {
+    vi.mocked(api.updateGroupType).mockResolvedValueOnce({ idKey: 'gt1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateGroupType());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 'gt1', request: { name: 'X' } as never });
+    });
+    expect(api.updateGroupType).toHaveBeenCalledWith('gt1', { name: 'X' });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['group-types'] });
+  });
+
+  it('archive invalidates', async () => {
+    vi.mocked(api.archiveGroupType).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useArchiveGroupType());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('gt1');
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['group-types'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useGroups.test.tsx
+++ b/src/web/src/hooks/__tests__/useGroups.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * useGroups + related hooks.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/groups', () => ({
+  searchGroups: vi.fn(),
+  getGroupByIdKey: vi.fn(),
+  getChildGroups: vi.fn(),
+  createGroup: vi.fn(),
+  updateGroup: vi.fn(),
+  deleteGroup: vi.fn(),
+  getGroupSchedules: vi.fn(),
+  addGroupSchedule: vi.fn(),
+  removeGroupSchedule: vi.fn(),
+  getGroupAttendanceHistory: vi.fn(),
+  getGroupAttendanceDetail: vi.fn(),
+}));
+
+import * as groupsApi from '@/services/api/groups';
+import {
+  useAddGroupSchedule,
+  useChildGroups,
+  useCreateGroup,
+  useDeleteGroup,
+  useGroup,
+  useGroupAttendanceDetail,
+  useGroupAttendanceHistory,
+  useGroupSchedules,
+  useGroups,
+  useRemoveGroupSchedule,
+  useUpdateGroup,
+} from '../useGroups';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useGroups / useGroup / useChildGroups', () => {
+  it('list search forwards params', async () => {
+    vi.mocked(groupsApi.searchGroups).mockResolvedValueOnce({ data: [] } as never);
+    const { result } = renderHookWithQuery(() => useGroups({ q: 'x' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(groupsApi.searchGroups).toHaveBeenCalledWith({ q: 'x' });
+  });
+
+  it('useGroup is idle without idKey', () => {
+    const { result } = renderHookWithQuery(() => useGroup());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('useGroup fires on idKey', async () => {
+    vi.mocked(groupsApi.getGroupByIdKey).mockResolvedValueOnce({ idKey: 'g1' } as never);
+    const { result } = renderHookWithQuery(() => useGroup('g1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(groupsApi.getGroupByIdKey).toHaveBeenCalledWith('g1');
+  });
+
+  it('useChildGroups idle without parent', () => {
+    const { result } = renderHookWithQuery(() => useChildGroups());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('useChildGroups fires on parent', async () => {
+    vi.mocked(groupsApi.getChildGroups).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useChildGroups('g1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(groupsApi.getChildGroups).toHaveBeenCalledWith('g1');
+  });
+});
+
+describe('group CRUD mutations', () => {
+  it('create invalidates groups list', async () => {
+    vi.mocked(groupsApi.createGroup).mockResolvedValueOnce({ idKey: 'g1' } as never);
+    const { result, client } = renderHookWithQuery(() => useCreateGroup());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'X' } as never);
+    });
+    expect(groupsApi.createGroup).toHaveBeenCalledWith({ name: 'X' });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['groups'] });
+  });
+
+  it('update invalidates specific + list', async () => {
+    vi.mocked(groupsApi.updateGroup).mockResolvedValueOnce({ idKey: 'g1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateGroup());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 'g1', request: { name: 'Y' } as never });
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['groups', 'g1'] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['groups'] });
+  });
+
+  it('delete invalidates list', async () => {
+    vi.mocked(groupsApi.deleteGroup).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useDeleteGroup());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('g1');
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['groups'] });
+  });
+});
+
+describe('group schedules', () => {
+  it('useGroupSchedules idle without groupIdKey', () => {
+    const { result } = renderHookWithQuery(() => useGroupSchedules());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('useGroupSchedules fires on groupIdKey', async () => {
+    vi.mocked(groupsApi.getGroupSchedules).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useGroupSchedules('g1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(groupsApi.getGroupSchedules).toHaveBeenCalledWith('g1');
+  });
+
+  it('add / remove schedule invalidate the schedule key', async () => {
+    vi.mocked(groupsApi.addGroupSchedule).mockResolvedValueOnce({ idKey: 's1' } as never);
+    vi.mocked(groupsApi.removeGroupSchedule).mockResolvedValueOnce(undefined as never);
+    const add = renderHookWithQuery(() => useAddGroupSchedule());
+    const rm = renderHookWithQuery(() => useRemoveGroupSchedule());
+    const invAdd = vi.spyOn(add.client, 'invalidateQueries');
+    const invRm = vi.spyOn(rm.client, 'invalidateQueries');
+
+    await act(async () => {
+      await add.result.current.mutateAsync({
+        groupIdKey: 'g1',
+        request: { scheduleIdKey: 's1' } as never,
+      });
+    });
+    expect(invAdd).toHaveBeenCalledWith({ queryKey: ['groups', 'g1', 'schedules'] });
+
+    await act(async () => {
+      await rm.result.current.mutateAsync({ groupIdKey: 'g1', scheduleIdKey: 's1' });
+    });
+    expect(invRm).toHaveBeenCalledWith({ queryKey: ['groups', 'g1', 'schedules'] });
+  });
+});
+
+describe('group attendance queries', () => {
+  it('useGroupAttendanceHistory idle without groupIdKey', () => {
+    const { result } = renderHookWithQuery(() => useGroupAttendanceHistory());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('useGroupAttendanceDetail idle until BOTH keys present', async () => {
+    const onlyGroup = renderHookWithQuery(() => useGroupAttendanceDetail('g1'));
+    expect(onlyGroup.result.current.fetchStatus).toBe('idle');
+
+    vi.mocked(groupsApi.getGroupAttendanceDetail).mockResolvedValueOnce([] as never);
+    const both = renderHookWithQuery(() => useGroupAttendanceDetail('g1', 'o1'));
+    await waitFor(() => expect(both.result.current.isSuccess).toBe(true));
+    expect(groupsApi.getGroupAttendanceDetail).toHaveBeenCalledWith('g1', 'o1');
+  });
+});

--- a/src/web/src/hooks/__tests__/useImport.test.tsx
+++ b/src/web/src/hooks/__tests__/useImport.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * useImport — wizard-state state machine (pure, no TanStack Query).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useImport } from '../useImport';
+
+describe('useImport', () => {
+  it('starts on the upload step with empty state', () => {
+    const { result } = renderHook(() => useImport());
+    expect(result.current.currentStep).toBe('upload');
+    expect(result.current.file).toBeNull();
+    expect(result.current.csvHeaders).toEqual([]);
+    expect(result.current.previewRows).toEqual([]);
+    expect(result.current.fieldMappings).toEqual([]);
+  });
+
+  it('handleFileSelected advances to the mapping step with the file + preview', () => {
+    const { result } = renderHook(() => useImport());
+    const file = new File(['a,b'], 'x.csv', { type: 'text/csv' });
+    act(() => {
+      result.current.handleFileSelected(file, ['a', 'b'], [['1', '2']]);
+    });
+    expect(result.current.currentStep).toBe('mapping');
+    expect(result.current.file).toBe(file);
+    expect(result.current.csvHeaders).toEqual(['a', 'b']);
+    expect(result.current.previewRows).toEqual([['1', '2']]);
+  });
+
+  it('handleMappingsChange replaces mappings without changing step', () => {
+    const { result } = renderHook(() => useImport());
+    const mapping = [{ csvColumn: 'a', field: 'firstName' }] as never;
+    act(() => {
+      result.current.handleMappingsChange(mapping);
+    });
+    expect(result.current.fieldMappings).toEqual(mapping);
+    expect(result.current.currentStep).toBe('upload');
+  });
+
+  it('goToStep navigates explicitly', () => {
+    const { result } = renderHook(() => useImport());
+    act(() => {
+      result.current.goToStep('validation');
+    });
+    expect(result.current.currentStep).toBe('validation');
+    act(() => {
+      result.current.goToStep('progress');
+    });
+    expect(result.current.currentStep).toBe('progress');
+  });
+
+  it('reset returns to the initial blank state', () => {
+    const { result } = renderHook(() => useImport());
+    const file = new File(['x'], 'x.csv');
+    act(() => {
+      result.current.handleFileSelected(file, ['a'], [['1']]);
+      result.current.handleMappingsChange([{ csvColumn: 'a' }] as never);
+      result.current.goToStep('progress');
+    });
+    act(() => {
+      result.current.reset();
+    });
+    expect(result.current.currentStep).toBe('upload');
+    expect(result.current.file).toBeNull();
+    expect(result.current.csvHeaders).toEqual([]);
+    expect(result.current.previewRows).toEqual([]);
+    expect(result.current.fieldMappings).toEqual([]);
+  });
+});

--- a/src/web/src/hooks/__tests__/useImportJobs.test.tsx
+++ b/src/web/src/hooks/__tests__/useImportJobs.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * useImportJobs — query + client-side type filter.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/import', () => ({
+  getImportJobs: vi.fn(),
+}));
+
+import * as api from '@/services/api/import';
+import { useImportJobs } from '../useImportJobs';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useImportJobs', () => {
+  it('fetches all jobs and exposes them as allJobs', async () => {
+    vi.mocked(api.getImportJobs).mockResolvedValueOnce([
+      { idKey: 'j1', importType: 'People' },
+      { idKey: 'j2', importType: 'Families' },
+    ] as never);
+    const { result } = renderHookWithQuery(() => useImportJobs());
+    await waitFor(() => expect(result.current.allJobs).toHaveLength(2));
+    // default filter is "all"
+    expect(result.current.typeFilter).toBe('all');
+    expect(result.current.jobs).toHaveLength(2);
+  });
+
+  it('filters by typeFilter when set', async () => {
+    vi.mocked(api.getImportJobs).mockResolvedValueOnce([
+      { idKey: 'j1', importType: 'People' },
+      { idKey: 'j2', importType: 'Families' },
+    ] as never);
+    const { result } = renderHookWithQuery(() => useImportJobs());
+    await waitFor(() => expect(result.current.allJobs).toHaveLength(2));
+    act(() => {
+      result.current.setTypeFilter('People');
+    });
+    expect(result.current.jobs).toEqual([{ idKey: 'j1', importType: 'People' }]);
+    // allJobs is unchanged
+    expect(result.current.allJobs).toHaveLength(2);
+  });
+
+  it('returns [] while loading', () => {
+    vi.mocked(api.getImportJobs).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useImportJobs());
+    expect(result.current.jobs).toEqual([]);
+  });
+});

--- a/src/web/src/hooks/__tests__/useLocations.test.tsx
+++ b/src/web/src/hooks/__tests__/useLocations.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * useLocations / useLocationTree / useLocation / CRUD mutations.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/locations', () => ({
+  getLocations: vi.fn(),
+  getLocationTree: vi.fn(),
+  getLocation: vi.fn(),
+  createLocation: vi.fn(),
+  updateLocation: vi.fn(),
+  deleteLocation: vi.fn(),
+}));
+
+import * as locationsApi from '@/services/api/locations';
+import {
+  useCreateLocation,
+  useDeleteLocation,
+  useLocation,
+  useLocations,
+  useLocationTree,
+  useUpdateLocation,
+} from '../useLocations';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useLocations', () => {
+  it('passes options to api', async () => {
+    vi.mocked(locationsApi.getLocations).mockResolvedValueOnce([] as never);
+    const opts = { campusIdKey: 'c1', includeInactive: true };
+    const { result } = renderHookWithQuery(() => useLocations(opts));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(locationsApi.getLocations).toHaveBeenCalledWith(opts);
+  });
+
+  it('defaults to no options', async () => {
+    vi.mocked(locationsApi.getLocations).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useLocations());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(locationsApi.getLocations).toHaveBeenCalledWith(undefined);
+  });
+});
+
+describe('useLocationTree', () => {
+  it('fires with optional options', async () => {
+    vi.mocked(locationsApi.getLocationTree).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useLocationTree({ campusIdKey: 'c1' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(locationsApi.getLocationTree).toHaveBeenCalledWith({ campusIdKey: 'c1' });
+  });
+});
+
+describe('useLocation', () => {
+  it('idle without idKey', () => {
+    const { result } = renderHookWithQuery(() => useLocation());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with idKey', async () => {
+    vi.mocked(locationsApi.getLocation).mockResolvedValueOnce({ idKey: 'l1' } as never);
+    const { result } = renderHookWithQuery(() => useLocation('l1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(locationsApi.getLocation).toHaveBeenCalledWith('l1');
+  });
+});
+
+describe('CRUD mutations', () => {
+  it('create invalidates locations', async () => {
+    vi.mocked(locationsApi.createLocation).mockResolvedValueOnce({ idKey: 'l1' } as never);
+    const { result, client } = renderHookWithQuery(() => useCreateLocation());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'Room A' } as never);
+    });
+    expect(locationsApi.createLocation).toHaveBeenCalledWith({ name: 'Room A' });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['locations'] });
+  });
+
+  it('update invalidates', async () => {
+    vi.mocked(locationsApi.updateLocation).mockResolvedValueOnce({ idKey: 'l1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateLocation());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 'l1', request: { name: 'Y' } as never });
+    });
+    expect(locationsApi.updateLocation).toHaveBeenCalledWith('l1', { name: 'Y' });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['locations'] });
+  });
+
+  it('delete invalidates', async () => {
+    vi.mocked(locationsApi.deleteLocation).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useDeleteLocation());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('l1');
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['locations'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useMembershipRequests.test.tsx
+++ b/src/web/src/hooks/__tests__/useMembershipRequests.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * useMembershipRequests — group membership approval flow.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/membershipRequests', () => ({
+  getPendingRequests: vi.fn(),
+  submitMembershipRequest: vi.fn(),
+  processRequest: vi.fn(),
+}));
+
+import * as api from '@/services/api/membershipRequests';
+import {
+  usePendingRequests,
+  useProcessRequest,
+  useSubmitMembershipRequest,
+} from '../useMembershipRequests';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('usePendingRequests', () => {
+  it('idle without groupIdKey', () => {
+    const { result } = renderHookWithQuery(() => usePendingRequests());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with groupIdKey', async () => {
+    vi.mocked(api.getPendingRequests).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => usePendingRequests('g1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getPendingRequests).toHaveBeenCalledWith('g1');
+  });
+});
+
+describe('useSubmitMembershipRequest', () => {
+  it('calls api with groupIdKey and invalidates group-scoped keys', async () => {
+    vi.mocked(api.submitMembershipRequest).mockResolvedValueOnce({ idKey: 'r1' } as never);
+    const { result, client } = renderHookWithQuery(() => useSubmitMembershipRequest('g1'));
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ note: 'x' } as never);
+    });
+    expect(api.submitMembershipRequest).toHaveBeenCalledWith('g1', { note: 'x' });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['groups', 'g1'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['groups', 'g1', 'membership-requests'] });
+  });
+});
+
+describe('useProcessRequest', () => {
+  it('calls api and invalidates requests + members', async () => {
+    vi.mocked(api.processRequest).mockResolvedValueOnce({ idKey: 'r1' } as never);
+    const { result, client } = renderHookWithQuery(() => useProcessRequest('g1'));
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({
+        requestIdKey: 'r1',
+        request: { approve: true } as never,
+      });
+    });
+    expect(api.processRequest).toHaveBeenCalledWith('g1', 'r1', { approve: true });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['groups', 'g1', 'membership-requests'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['groups', 'g1', 'members'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useMutationWithToast.test.tsx
+++ b/src/web/src/hooks/__tests__/useMutationWithToast.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * useMutationWithToast — wraps TanStack `useMutation` to surface toast notifications.
+ *
+ * Behaviors worth locking in:
+ *   - successMessage may be a string OR a function of data.
+ *   - errorMessage may be a string OR a function of the error.
+ *   - No successMessage => no success toast; no errorMessage => default
+ *     user-friendly error toast (never raw error.message).
+ *   - custom onSuccess / onError callbacks are forwarded.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { act } from '@testing-library/react';
+
+const successToast = vi.fn();
+const errorToast = vi.fn();
+
+vi.mock('@/contexts/ToastContext', () => ({
+  useToast: () => ({
+    success: successToast,
+    error: errorToast,
+    warning: vi.fn(),
+    info: vi.fn(),
+    addToast: vi.fn(),
+    removeToast: vi.fn(),
+  }),
+}));
+
+import { useMutationWithToast } from '../useMutationWithToast';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => {
+  successToast.mockReset();
+  errorToast.mockReset();
+  // Silence console.error noise from error-path tests.
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+describe('useMutationWithToast — success path', () => {
+  it('static successMessage surfaces a success toast', async () => {
+    const mutationFn = vi.fn().mockResolvedValue('done');
+    const { result } = renderHookWithQuery(() =>
+      useMutationWithToast({ mutationFn, successMessage: 'It worked' })
+    );
+    await act(async () => {
+      await result.current.mutateAsync(undefined as never);
+    });
+    expect(successToast).toHaveBeenCalledWith('Success', 'It worked');
+  });
+
+  it('function successMessage receives the data and renders result', async () => {
+    const mutationFn = vi.fn().mockResolvedValue({ name: 'Jane' });
+    const { result } = renderHookWithQuery(() =>
+      useMutationWithToast({
+        mutationFn,
+        successMessage: (d) => `Hi ${(d as { name: string }).name}`,
+      })
+    );
+    await act(async () => {
+      await result.current.mutateAsync(undefined as never);
+    });
+    expect(successToast).toHaveBeenCalledWith('Success', 'Hi Jane');
+  });
+
+  it('no successMessage => no success toast', async () => {
+    const mutationFn = vi.fn().mockResolvedValue('done');
+    const onSuccess = vi.fn();
+    const { result } = renderHookWithQuery(() =>
+      useMutationWithToast({ mutationFn, onSuccess })
+    );
+    await act(async () => {
+      await result.current.mutateAsync(undefined as never);
+    });
+    expect(successToast).not.toHaveBeenCalled();
+    // Custom callback still fires.
+    expect(onSuccess).toHaveBeenCalled();
+  });
+});
+
+describe('useMutationWithToast — error path', () => {
+  it('static errorMessage surfaces an error toast', async () => {
+    const mutationFn = vi.fn().mockRejectedValue(new Error('raw'));
+    const { result } = renderHookWithQuery(() =>
+      useMutationWithToast({
+        mutationFn,
+        errorMessage: 'User-friendly message',
+      })
+    );
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(undefined as never);
+      } catch {
+        /* expected */
+      }
+    });
+    expect(errorToast).toHaveBeenCalledWith('Error', 'User-friendly message');
+  });
+
+  it('function errorMessage receives the error', async () => {
+    const err = new Error('boom');
+    const mutationFn = vi.fn().mockRejectedValue(err);
+    const { result } = renderHookWithQuery(() =>
+      useMutationWithToast({
+        mutationFn,
+        errorMessage: (e) => `Saw ${(e as Error).message}`,
+      })
+    );
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(undefined as never);
+      } catch {
+        /* expected */
+      }
+    });
+    expect(errorToast).toHaveBeenCalledWith('Error', 'Saw boom');
+  });
+
+  it('no errorMessage => generic "please try again" toast (never raw error)', async () => {
+    const mutationFn = vi.fn().mockRejectedValue(new Error('secret db error'));
+    const onError = vi.fn();
+    const { result } = renderHookWithQuery(() =>
+      useMutationWithToast({ mutationFn, onError })
+    );
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(undefined as never);
+      } catch {
+        /* expected */
+      }
+    });
+    expect(errorToast).toHaveBeenCalledWith('Error', 'An error occurred. Please try again.');
+    expect(onError).toHaveBeenCalled();
+    // Guardrail: never leak the raw error message to the toast.
+    const [, message] = errorToast.mock.calls[0];
+    expect(String(message)).not.toContain('secret');
+  });
+});

--- a/src/web/src/hooks/__tests__/useMyGroups.test.tsx
+++ b/src/web/src/hooks/__tests__/useMyGroups.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * useMyGroups — hooks for group leaders managing their groups.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/myGroups', () => ({
+  getMyGroups: vi.fn(),
+  getMyGroupMembers: vi.fn(),
+  updateGroupMember: vi.fn(),
+  removeGroupMember: vi.fn(),
+  recordAttendance: vi.fn(),
+}));
+
+import * as api from '@/services/api/myGroups';
+import {
+  useMyGroupMembers,
+  useMyGroups,
+  useRecordAttendance,
+  useRemoveGroupMember,
+  useUpdateGroupMember,
+} from '../useMyGroups';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useMyGroups', () => {
+  it('fetches my groups', async () => {
+    vi.mocked(api.getMyGroups).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useMyGroups());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getMyGroups).toHaveBeenCalled();
+  });
+});
+
+describe('useMyGroupMembers', () => {
+  it('idle without groupIdKey', () => {
+    const { result } = renderHookWithQuery(() => useMyGroupMembers());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with groupIdKey', async () => {
+    vi.mocked(api.getMyGroupMembers).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useMyGroupMembers('g1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getMyGroupMembers).toHaveBeenCalledWith('g1');
+  });
+});
+
+describe('useUpdateGroupMember / useRemoveGroupMember', () => {
+  it('update calls api and invalidates members/groups', async () => {
+    vi.mocked(api.updateGroupMember).mockResolvedValueOnce({} as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateGroupMember('g1'));
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({
+        memberIdKey: 'm1',
+        data: { status: 'Active' } as never,
+      });
+    });
+    expect(api.updateGroupMember).toHaveBeenCalledWith('g1', 'm1', { status: 'Active' });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['my-groups', 'g1', 'members'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['my-groups'] });
+  });
+
+  it('remove calls api and invalidates', async () => {
+    vi.mocked(api.removeGroupMember).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useRemoveGroupMember('g1'));
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('m1');
+    });
+    expect(api.removeGroupMember).toHaveBeenCalledWith('g1', 'm1');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['my-groups', 'g1', 'members'] });
+  });
+});
+
+describe('useRecordAttendance', () => {
+  it('calls api and invalidates my-groups + group attendance', async () => {
+    vi.mocked(api.recordAttendance).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useRecordAttendance('g1'));
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ attendance: [] } as never);
+    });
+    expect(api.recordAttendance).toHaveBeenCalledWith('g1', { attendance: [] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['my-groups'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['groups', 'g1', 'attendance'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useNotifications.test.tsx
+++ b/src/web/src/hooks/__tests__/useNotifications.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * useNotifications and related hooks.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/notifications', () => ({
+  getNotifications: vi.fn(),
+  getNotification: vi.fn(),
+  getUnreadCount: vi.fn(),
+  getPreferences: vi.fn(),
+  markAsRead: vi.fn(),
+  markAllAsRead: vi.fn(),
+  deleteNotification: vi.fn(),
+  updatePreference: vi.fn(),
+}));
+
+import * as api from '@/services/api/notifications';
+import {
+  useDeleteNotification,
+  useMarkAllAsRead,
+  useMarkAsRead,
+  useNotification,
+  useNotificationPreferences,
+  useNotifications,
+  useUnreadCount,
+  useUpdatePreference,
+} from '../useNotifications';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useNotifications', () => {
+  it('forwards unreadOnly + limit to api', async () => {
+    vi.mocked(api.getNotifications).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useNotifications(true, 5));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getNotifications).toHaveBeenCalledWith(true, 5);
+  });
+});
+
+describe('useNotification', () => {
+  it('idle without idKey', () => {
+    const { result } = renderHookWithQuery(() => useNotification());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with idKey', async () => {
+    vi.mocked(api.getNotification).mockResolvedValueOnce({ idKey: 'n1' } as never);
+    const { result } = renderHookWithQuery(() => useNotification('n1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getNotification).toHaveBeenCalledWith('n1');
+  });
+});
+
+describe('useUnreadCount / useNotificationPreferences', () => {
+  it('unread count hits api', async () => {
+    vi.mocked(api.getUnreadCount).mockResolvedValueOnce(3 as never);
+    const { result } = renderHookWithQuery(() => useUnreadCount());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBe(3);
+  });
+
+  it('preferences hits api', async () => {
+    vi.mocked(api.getPreferences).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useNotificationPreferences());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getPreferences).toHaveBeenCalled();
+  });
+});
+
+describe('mutations invalidate the right keys', () => {
+  it('markAsRead invalidates notifications + unread-count + detail', async () => {
+    vi.mocked(api.markAsRead).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useMarkAsRead());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('n1');
+    });
+    expect(api.markAsRead).toHaveBeenCalledWith('n1');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['notifications'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['notifications', 'unread-count'] });
+  });
+
+  it('markAllAsRead invalidates', async () => {
+    vi.mocked(api.markAllAsRead).mockResolvedValueOnce(2 as never);
+    const { result, client } = renderHookWithQuery(() => useMarkAllAsRead());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['notifications'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['notifications', 'unread-count'] });
+  });
+
+  it('deleteNotification invalidates', async () => {
+    vi.mocked(api.deleteNotification).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useDeleteNotification());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('n1');
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['notifications'] });
+  });
+
+  it('updatePreference invalidates preferences', async () => {
+    vi.mocked(api.updatePreference).mockResolvedValueOnce({ id: 1 } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdatePreference());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ type: 'email', enabled: true } as never);
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['notifications', 'preferences'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/usePeople.test.tsx
+++ b/src/web/src/hooks/__tests__/usePeople.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * usePeople + friends: TanStack Query wrappers for services/api/people.
+ *
+ * Checked behaviors:
+ *   - usePerson / usePersonFamily / usePersonGroups / usePersonAttendance
+ *     / usePersonGivingSummary / usePersonNotes are disabled when no idKey.
+ *   - usePersonAttendance default days = 90; respects overrides.
+ *   - Mutations (create/update/delete/uploadPhoto + note CRUD) invalidate
+ *     the right keys.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/people', () => ({
+  searchPeople: vi.fn(),
+  getPersonByIdKey: vi.fn(),
+  createPerson: vi.fn(),
+  updatePerson: vi.fn(),
+  deletePerson: vi.fn(),
+  uploadPersonPhoto: vi.fn(),
+  getPersonFamily: vi.fn(),
+  getPersonGroups: vi.fn(),
+  getPersonAttendance: vi.fn(),
+  getPersonGivingSummary: vi.fn(),
+  getPersonNotes: vi.fn(),
+  createPersonNote: vi.fn(),
+  updatePersonNote: vi.fn(),
+  deletePersonNote: vi.fn(),
+}));
+
+import * as peopleApi from '@/services/api/people';
+import {
+  useCreatePerson,
+  useCreatePersonNote,
+  useDeletePerson,
+  useDeletePersonNote,
+  usePeople,
+  usePerson,
+  usePersonAttendance,
+  usePersonFamily,
+  usePersonGivingSummary,
+  usePersonGroups,
+  usePersonNotes,
+  useUpdatePerson,
+  useUpdatePersonNote,
+  useUploadPersonPhoto,
+} from '../usePeople';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('usePeople', () => {
+  it('forwards params', async () => {
+    vi.mocked(peopleApi.searchPeople).mockResolvedValueOnce({ data: [] } as never);
+    const { result } = renderHookWithQuery(() => usePeople({ q: 'jo' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(peopleApi.searchPeople).toHaveBeenCalledWith({ q: 'jo' });
+  });
+});
+
+describe('usePerson', () => {
+  it('is idle without idKey', () => {
+    const { result } = renderHookWithQuery(() => usePerson());
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(peopleApi.getPersonByIdKey).not.toHaveBeenCalled();
+  });
+
+  it('fetches when idKey present', async () => {
+    vi.mocked(peopleApi.getPersonByIdKey).mockResolvedValueOnce({ idKey: 'p1' } as never);
+    const { result } = renderHookWithQuery(() => usePerson('p1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(peopleApi.getPersonByIdKey).toHaveBeenCalledWith('p1');
+  });
+});
+
+describe('usePersonFamily / usePersonGroups', () => {
+  it('both are idle without idKey', () => {
+    const fam = renderHookWithQuery(() => usePersonFamily()).result;
+    const grp = renderHookWithQuery(() => usePersonGroups()).result;
+    expect(fam.current.fetchStatus).toBe('idle');
+    expect(grp.current.fetchStatus).toBe('idle');
+  });
+
+  it('both fire when idKey provided', async () => {
+    vi.mocked(peopleApi.getPersonFamily).mockResolvedValueOnce({ familyMembers: [] } as never);
+    vi.mocked(peopleApi.getPersonGroups).mockResolvedValueOnce([] as never);
+    const fam = renderHookWithQuery(() => usePersonFamily('p1'));
+    const grp = renderHookWithQuery(() => usePersonGroups('p1'));
+    await waitFor(() => expect(fam.result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(grp.result.current.isSuccess).toBe(true));
+    expect(peopleApi.getPersonFamily).toHaveBeenCalledWith('p1');
+    expect(peopleApi.getPersonGroups).toHaveBeenCalledWith('p1');
+  });
+});
+
+describe('usePersonAttendance', () => {
+  it('defaults days to 90', async () => {
+    vi.mocked(peopleApi.getPersonAttendance).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => usePersonAttendance('p1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(peopleApi.getPersonAttendance).toHaveBeenCalledWith('p1', 90);
+  });
+
+  it('respects custom days', async () => {
+    vi.mocked(peopleApi.getPersonAttendance).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => usePersonAttendance('p1', 30));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(peopleApi.getPersonAttendance).toHaveBeenCalledWith('p1', 30);
+  });
+
+  it('is idle without personIdKey', () => {
+    const { result } = renderHookWithQuery(() => usePersonAttendance(undefined));
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+describe('usePersonGivingSummary / usePersonNotes', () => {
+  it('giving summary fires on idKey', async () => {
+    vi.mocked(peopleApi.getPersonGivingSummary).mockResolvedValueOnce({ ytdTotal: 0 } as never);
+    const { result } = renderHookWithQuery(() => usePersonGivingSummary('p1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(peopleApi.getPersonGivingSummary).toHaveBeenCalledWith('p1');
+  });
+
+  it('person notes idle without idKey', () => {
+    const { result } = renderHookWithQuery(() => usePersonNotes());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('person notes fetches on idKey', async () => {
+    vi.mocked(peopleApi.getPersonNotes).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => usePersonNotes('p1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(peopleApi.getPersonNotes).toHaveBeenCalledWith('p1');
+  });
+});
+
+describe('mutations: useCreatePerson / useUpdatePerson / useDeletePerson / useUploadPersonPhoto', () => {
+  it('create invalidates people list', async () => {
+    vi.mocked(peopleApi.createPerson).mockResolvedValueOnce({ idKey: 'p1' } as never);
+    const { result, client } = renderHookWithQuery(() => useCreatePerson());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ firstName: 'A' } as never);
+    });
+    expect(peopleApi.createPerson).toHaveBeenCalledWith({ firstName: 'A' });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['people'] });
+  });
+
+  it('update invalidates specific + list', async () => {
+    vi.mocked(peopleApi.updatePerson).mockResolvedValueOnce({ idKey: 'p1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdatePerson());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 'p1', request: { firstName: 'X' } as never });
+    });
+    expect(peopleApi.updatePerson).toHaveBeenCalledWith('p1', { firstName: 'X' });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['people', 'p1'] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['people'] });
+  });
+
+  it('delete invalidates people list', async () => {
+    vi.mocked(peopleApi.deletePerson).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useDeletePerson());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('p1');
+    });
+    expect(peopleApi.deletePerson).toHaveBeenCalledWith('p1');
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['people'] });
+  });
+
+  it('upload photo invalidates', async () => {
+    vi.mocked(peopleApi.uploadPersonPhoto).mockResolvedValueOnce({ idKey: 'p1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUploadPersonPhoto());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    const file = new File(['x'], 'p.png', { type: 'image/png' });
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 'p1', file });
+    });
+    expect(peopleApi.uploadPersonPhoto).toHaveBeenCalledWith('p1', file);
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['people', 'p1'] });
+  });
+});
+
+describe('person note mutations', () => {
+  it('create / update / delete each invalidate the note list', async () => {
+    vi.mocked(peopleApi.createPersonNote).mockResolvedValueOnce({ idKey: 'n1' } as never);
+    vi.mocked(peopleApi.updatePersonNote).mockResolvedValueOnce({ idKey: 'n1' } as never);
+    vi.mocked(peopleApi.deletePersonNote).mockResolvedValueOnce(undefined as never);
+
+    const create = renderHookWithQuery(() => useCreatePersonNote());
+    const update = renderHookWithQuery(() => useUpdatePersonNote());
+    const del = renderHookWithQuery(() => useDeletePersonNote());
+
+    const invC = vi.spyOn(create.client, 'invalidateQueries');
+    const invU = vi.spyOn(update.client, 'invalidateQueries');
+    const invD = vi.spyOn(del.client, 'invalidateQueries');
+
+    await act(async () => {
+      await create.result.current.mutateAsync({
+        personIdKey: 'p1',
+        request: { body: 'hi' } as never,
+      });
+    });
+    expect(peopleApi.createPersonNote).toHaveBeenCalledWith('p1', { body: 'hi' });
+    expect(invC).toHaveBeenCalledWith({ queryKey: ['people', 'p1', 'notes'] });
+
+    await act(async () => {
+      await update.result.current.mutateAsync({
+        personIdKey: 'p1',
+        noteIdKey: 'n1',
+        request: { body: 'new' } as never,
+      });
+    });
+    expect(peopleApi.updatePersonNote).toHaveBeenCalledWith('p1', 'n1', { body: 'new' });
+    expect(invU).toHaveBeenCalledWith({ queryKey: ['people', 'p1', 'notes'] });
+
+    await act(async () => {
+      await del.result.current.mutateAsync({ personIdKey: 'p1', noteIdKey: 'n1' });
+    });
+    expect(peopleApi.deletePersonNote).toHaveBeenCalledWith('p1', 'n1');
+    expect(invD).toHaveBeenCalledWith({ queryKey: ['people', 'p1', 'notes'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/usePersonMerge.test.tsx
+++ b/src/web/src/hooks/__tests__/usePersonMerge.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * usePersonMerge hooks — dedupe workflow.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/personMerge', () => ({
+  getDuplicates: vi.fn(),
+  getDuplicatesForPerson: vi.fn(),
+  comparePeople: vi.fn(),
+  mergePeople: vi.fn(),
+  getMergeHistory: vi.fn(),
+  ignoreDuplicate: vi.fn(),
+  unignoreDuplicate: vi.fn(),
+}));
+
+import * as api from '@/services/api/personMerge';
+import {
+  useDuplicates,
+  useDuplicatesForPerson,
+  useIgnoreDuplicate,
+  useMergeHistory,
+  useMergePeople,
+  usePersonComparison,
+  useUnignoreDuplicate,
+} from '../usePersonMerge';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useDuplicates', () => {
+  it('defaults page=1, pageSize=25', async () => {
+    vi.mocked(api.getDuplicates).mockResolvedValueOnce({ data: [] } as never);
+    const { result } = renderHookWithQuery(() => useDuplicates());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getDuplicates).toHaveBeenCalledWith(1, 25);
+  });
+});
+
+describe('useDuplicatesForPerson', () => {
+  it('idle without idKey', () => {
+    const { result } = renderHookWithQuery(() => useDuplicatesForPerson());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with idKey', async () => {
+    vi.mocked(api.getDuplicatesForPerson).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useDuplicatesForPerson('p1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getDuplicatesForPerson).toHaveBeenCalledWith('p1');
+  });
+});
+
+describe('usePersonComparison', () => {
+  it('idle without BOTH ids', () => {
+    const a = renderHookWithQuery(() => usePersonComparison('p1')).result;
+    const b = renderHookWithQuery(() => usePersonComparison(undefined, 'p2')).result;
+    expect(a.current.fetchStatus).toBe('idle');
+    expect(b.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with both', async () => {
+    vi.mocked(api.comparePeople).mockResolvedValueOnce({} as never);
+    const { result } = renderHookWithQuery(() => usePersonComparison('p1', 'p2'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.comparePeople).toHaveBeenCalledWith('p1', 'p2');
+  });
+});
+
+describe('useMergePeople', () => {
+  it('invalidates duplicates + people + mergeHistory', async () => {
+    vi.mocked(api.mergePeople).mockResolvedValueOnce({} as never);
+    const { result, client } = renderHookWithQuery(() => useMergePeople());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ targetIdKey: 'p1', sourceIdKey: 'p2' } as never);
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['duplicates'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['people'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['mergeHistory'] });
+  });
+});
+
+describe('useMergeHistory', () => {
+  it('defaults to page 1 size 25', async () => {
+    vi.mocked(api.getMergeHistory).mockResolvedValueOnce({ data: [] } as never);
+    const { result } = renderHookWithQuery(() => useMergeHistory());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getMergeHistory).toHaveBeenCalledWith(1, 25);
+  });
+});
+
+describe('useIgnoreDuplicate / useUnignoreDuplicate', () => {
+  it('both invalidate duplicates', async () => {
+    vi.mocked(api.ignoreDuplicate).mockResolvedValueOnce(undefined as never);
+    vi.mocked(api.unignoreDuplicate).mockResolvedValueOnce(undefined as never);
+
+    const ig = renderHookWithQuery(() => useIgnoreDuplicate());
+    const un = renderHookWithQuery(() => useUnignoreDuplicate());
+    const invIg = vi.spyOn(ig.client, 'invalidateQueries');
+    const invUn = vi.spyOn(un.client, 'invalidateQueries');
+
+    await act(async () => {
+      await ig.result.current.mutateAsync({ person1IdKey: 'p1', person2IdKey: 'p2' } as never);
+    });
+    expect(invIg).toHaveBeenCalledWith({ queryKey: ['duplicates'] });
+
+    await act(async () => {
+      await un.result.current.mutateAsync({ person1IdKey: 'p1', person2IdKey: 'p2' });
+    });
+    expect(api.unignoreDuplicate).toHaveBeenCalledWith('p1', 'p2');
+    expect(invUn).toHaveBeenCalledWith({ queryKey: ['duplicates'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useProfile.test.tsx
+++ b/src/web/src/hooks/__tests__/useProfile.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * useProfile (my-profile) hooks.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/profile', () => ({
+  getMyProfile: vi.fn(),
+  updateMyProfile: vi.fn(),
+  getMyFamily: vi.fn(),
+  updateFamilyMember: vi.fn(),
+  getMyInvolvement: vi.fn(),
+}));
+
+import * as api from '@/services/api/profile';
+import {
+  useMyFamily,
+  useMyInvolvement,
+  useMyProfile,
+  useUpdateFamilyMember,
+  useUpdateMyProfile,
+} from '../useProfile';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useMyProfile / update', () => {
+  it('useMyProfile fetches', async () => {
+    vi.mocked(api.getMyProfile).mockResolvedValueOnce({ idKey: 'u1' } as never);
+    const { result } = renderHookWithQuery(() => useMyProfile());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getMyProfile).toHaveBeenCalled();
+  });
+
+  it('useUpdateMyProfile invalidates profile', async () => {
+    vi.mocked(api.updateMyProfile).mockResolvedValueOnce({ idKey: 'u1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateMyProfile());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ firstName: 'A' } as never);
+    });
+    expect(api.updateMyProfile).toHaveBeenCalledWith({ firstName: 'A' });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['profile', 'me'] });
+  });
+});
+
+describe('family', () => {
+  it('useMyFamily fetches', async () => {
+    vi.mocked(api.getMyFamily).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useMyFamily());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getMyFamily).toHaveBeenCalled();
+  });
+
+  it('useUpdateFamilyMember invalidates family list', async () => {
+    vi.mocked(api.updateFamilyMember).mockResolvedValueOnce({ idKey: 'p1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateFamilyMember());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({
+        personIdKey: 'p1',
+        data: { firstName: 'X' } as never,
+      });
+    });
+    expect(api.updateFamilyMember).toHaveBeenCalledWith('p1', { firstName: 'X' });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['profile', 'me', 'family'] });
+  });
+});
+
+describe('involvement', () => {
+  it('useMyInvolvement fetches', async () => {
+    vi.mocked(api.getMyInvolvement).mockResolvedValueOnce({ groups: [] } as never);
+    const { result } = renderHookWithQuery(() => useMyInvolvement());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getMyInvolvement).toHaveBeenCalled();
+  });
+});

--- a/src/web/src/hooks/__tests__/usePublicGroups.test.tsx
+++ b/src/web/src/hooks/__tests__/usePublicGroups.test.tsx
@@ -1,0 +1,37 @@
+/**
+ * usePublicGroups — single-line wrapper.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+
+vi.mock('@/services/api/publicGroups', () => ({
+  searchPublicGroups: vi.fn(),
+}));
+
+import * as api from '@/services/api/publicGroups';
+import { usePublicGroups } from '../usePublicGroups';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('usePublicGroups', () => {
+  it('default: no params', async () => {
+    vi.mocked(api.searchPublicGroups).mockResolvedValueOnce({ data: [] } as never);
+    const { result } = renderHookWithQuery(() => usePublicGroups());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.searchPublicGroups).toHaveBeenCalledWith({});
+  });
+
+  it('forwards params', async () => {
+    vi.mocked(api.searchPublicGroups).mockResolvedValueOnce({ data: [] } as never);
+    const { result } = renderHookWithQuery(() =>
+      usePublicGroups({ searchTerm: 'bible', pageNumber: 1 })
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.searchPublicGroups).toHaveBeenCalledWith({
+      searchTerm: 'bible',
+      pageNumber: 1,
+    });
+  });
+});

--- a/src/web/src/hooks/__tests__/useRoomRoster.test.tsx
+++ b/src/web/src/hooks/__tests__/useRoomRoster.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * useRoomRoster / useMultipleRoomRosters / useCheckOutFromRoster.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/checkin', () => ({
+  getRoomRoster: vi.fn(),
+  getMultipleRoomRosters: vi.fn(),
+  checkoutFromRoster: vi.fn(),
+}));
+
+import * as checkinApi from '@/services/api/checkin';
+import {
+  useCheckOutFromRoster,
+  useMultipleRoomRosters,
+  useRoomRoster,
+} from '../useRoomRoster';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useRoomRoster', () => {
+  it('idle without locationIdKey', () => {
+    const { result } = renderHookWithQuery(() => useRoomRoster());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with locationIdKey', async () => {
+    vi.mocked(checkinApi.getRoomRoster).mockResolvedValueOnce({
+      locationIdKey: 'l1',
+    } as never);
+    const { result } = renderHookWithQuery(() => useRoomRoster('l1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(checkinApi.getRoomRoster).toHaveBeenCalledWith('l1');
+  });
+});
+
+describe('useMultipleRoomRosters', () => {
+  it('idle when empty list', () => {
+    const { result } = renderHookWithQuery(() => useMultipleRoomRosters([]));
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('idle when undefined', () => {
+    const { result } = renderHookWithQuery(() => useMultipleRoomRosters());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires when list has items', async () => {
+    vi.mocked(checkinApi.getMultipleRoomRosters).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useMultipleRoomRosters(['l1', 'l2']));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(checkinApi.getMultipleRoomRosters).toHaveBeenCalledWith(['l1', 'l2']);
+  });
+});
+
+describe('useCheckOutFromRoster', () => {
+  it('invalidates all roster queries', async () => {
+    vi.mocked(checkinApi.checkoutFromRoster).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useCheckOutFromRoster());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('a1');
+    });
+    expect(checkinApi.checkoutFromRoster).toHaveBeenCalledWith('a1');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['checkin', 'roster'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useSchedules.test.tsx
+++ b/src/web/src/hooks/__tests__/useSchedules.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * useSchedules + detail/occurrences/CRUD hooks.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/schedules', () => ({
+  searchSchedules: vi.fn(),
+  getScheduleByIdKey: vi.fn(),
+  getScheduleOccurrences: vi.fn(),
+  createSchedule: vi.fn(),
+  updateSchedule: vi.fn(),
+  deleteSchedule: vi.fn(),
+}));
+
+import * as schedulesApi from '@/services/api/schedules';
+import {
+  useCreateSchedule,
+  useDeleteSchedule,
+  useSchedule,
+  useScheduleOccurrences,
+  useSchedules,
+  useUpdateSchedule,
+} from '../useSchedules';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('useSchedules', () => {
+  it('forwards params', async () => {
+    vi.mocked(schedulesApi.searchSchedules).mockResolvedValueOnce({ data: [] } as never);
+    const { result } = renderHookWithQuery(() => useSchedules({ query: 's' }));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(schedulesApi.searchSchedules).toHaveBeenCalledWith({ query: 's' });
+  });
+});
+
+describe('useSchedule', () => {
+  it('idle without idKey', () => {
+    const { result } = renderHookWithQuery(() => useSchedule());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('fires with idKey', async () => {
+    vi.mocked(schedulesApi.getScheduleByIdKey).mockResolvedValueOnce({ idKey: 's1' } as never);
+    const { result } = renderHookWithQuery(() => useSchedule('s1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(schedulesApi.getScheduleByIdKey).toHaveBeenCalledWith('s1');
+  });
+});
+
+describe('useScheduleOccurrences', () => {
+  it('idle without idKey', () => {
+    const { result } = renderHookWithQuery(() => useScheduleOccurrences());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('passes idKey/startDate/count to api; count defaults to 10', async () => {
+    vi.mocked(schedulesApi.getScheduleOccurrences).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useScheduleOccurrences('s1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(schedulesApi.getScheduleOccurrences).toHaveBeenCalledWith('s1', undefined, 10);
+  });
+
+  it('respects custom startDate and count', async () => {
+    vi.mocked(schedulesApi.getScheduleOccurrences).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() =>
+      useScheduleOccurrences('s1', '2024-01-01', 20)
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(schedulesApi.getScheduleOccurrences).toHaveBeenCalledWith('s1', '2024-01-01', 20);
+  });
+});
+
+describe('schedule mutations', () => {
+  it('create invalidates schedules', async () => {
+    vi.mocked(schedulesApi.createSchedule).mockResolvedValueOnce({ idKey: 's1' } as never);
+    const { result, client } = renderHookWithQuery(() => useCreateSchedule());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'N' } as never);
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['schedules'] });
+  });
+
+  it('update invalidates specific + list', async () => {
+    vi.mocked(schedulesApi.updateSchedule).mockResolvedValueOnce({ idKey: 's1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateSchedule());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 's1', request: { name: 'N' } as never });
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['schedules', 's1'] });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['schedules'] });
+  });
+
+  it('delete invalidates list', async () => {
+    vi.mocked(schedulesApi.deleteSchedule).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useDeleteSchedule());
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('s1');
+    });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: ['schedules'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useSecurityRoles.test.tsx
+++ b/src/web/src/hooks/__tests__/useSecurityRoles.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * Security roles admin hooks.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/securityRoles', () => ({
+  getSecurityRoles: vi.fn(),
+  getSecurityRole: vi.fn(),
+  getSecurityClaims: vi.fn(),
+  createSecurityRole: vi.fn(),
+  updateSecurityRole: vi.fn(),
+  deleteSecurityRole: vi.fn(),
+  assignRoleClaim: vi.fn(),
+  removeRoleClaim: vi.fn(),
+  addRoleMember: vi.fn(),
+  removeRoleMember: vi.fn(),
+}));
+
+import * as api from '@/services/api/securityRoles';
+import {
+  useAddRoleMember,
+  useAssignRoleClaim,
+  useCreateSecurityRole,
+  useDeleteSecurityRole,
+  useRemoveRoleClaim,
+  useRemoveRoleMember,
+  useSecurityClaims,
+  useSecurityRole,
+  useSecurityRoles,
+  useUpdateSecurityRole,
+} from '../useSecurityRoles';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('query hooks', () => {
+  it('useSecurityRoles fetches', async () => {
+    vi.mocked(api.getSecurityRoles).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useSecurityRoles());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getSecurityRoles).toHaveBeenCalled();
+  });
+
+  it('useSecurityRole idle without idKey', () => {
+    const { result } = renderHookWithQuery(() => useSecurityRole());
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('useSecurityRole fires with idKey', async () => {
+    vi.mocked(api.getSecurityRole).mockResolvedValueOnce({ idKey: 'r1' } as never);
+    const { result } = renderHookWithQuery(() => useSecurityRole('r1'));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getSecurityRole).toHaveBeenCalledWith('r1');
+  });
+
+  it('useSecurityClaims fetches', async () => {
+    vi.mocked(api.getSecurityClaims).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useSecurityClaims());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+describe('mutations', () => {
+  it('create invalidates roles', async () => {
+    vi.mocked(api.createSecurityRole).mockResolvedValueOnce({ idKey: 'r1' } as never);
+    const { result, client } = renderHookWithQuery(() => useCreateSecurityRole());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ name: 'Admin' } as never);
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['security-roles'] });
+  });
+
+  it('update invalidates both list and specific', async () => {
+    vi.mocked(api.updateSecurityRole).mockResolvedValueOnce({ idKey: 'r1' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdateSecurityRole());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ idKey: 'r1', request: { name: 'N' } as never });
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['security-roles'] });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['security-roles', 'r1'] });
+  });
+
+  it('delete invalidates', async () => {
+    vi.mocked(api.deleteSecurityRole).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useDeleteSecurityRole());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('r1');
+    });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['security-roles'] });
+  });
+
+  it('claim assign/remove invalidate list + specific', async () => {
+    vi.mocked(api.assignRoleClaim).mockResolvedValueOnce(undefined as never);
+    vi.mocked(api.removeRoleClaim).mockResolvedValueOnce(undefined as never);
+    const assign = renderHookWithQuery(() => useAssignRoleClaim());
+    const remove = renderHookWithQuery(() => useRemoveRoleClaim());
+    const invA = vi.spyOn(assign.client, 'invalidateQueries');
+    const invR = vi.spyOn(remove.client, 'invalidateQueries');
+
+    await act(async () => {
+      await assign.result.current.mutateAsync({
+        idKey: 'r1',
+        request: { claimIdKey: 'c1' } as never,
+      });
+    });
+    expect(api.assignRoleClaim).toHaveBeenCalledWith('r1', { claimIdKey: 'c1' });
+    expect(invA).toHaveBeenCalledWith({ queryKey: ['security-roles', 'r1'] });
+
+    await act(async () => {
+      await remove.result.current.mutateAsync({ idKey: 'r1', claimIdKey: 'c1' });
+    });
+    expect(api.removeRoleClaim).toHaveBeenCalledWith('r1', 'c1');
+    expect(invR).toHaveBeenCalledWith({ queryKey: ['security-roles', 'r1'] });
+  });
+
+  it('member add/remove invalidate list + specific', async () => {
+    vi.mocked(api.addRoleMember).mockResolvedValueOnce(undefined as never);
+    vi.mocked(api.removeRoleMember).mockResolvedValueOnce(undefined as never);
+    const add = renderHookWithQuery(() => useAddRoleMember());
+    const rm = renderHookWithQuery(() => useRemoveRoleMember());
+    const invA = vi.spyOn(add.client, 'invalidateQueries');
+    const invR = vi.spyOn(rm.client, 'invalidateQueries');
+
+    await act(async () => {
+      await add.result.current.mutateAsync({
+        idKey: 'r1',
+        request: { personIdKey: 'p1' } as never,
+      });
+    });
+    expect(api.addRoleMember).toHaveBeenCalledWith('r1', { personIdKey: 'p1' });
+    expect(invA).toHaveBeenCalledWith({ queryKey: ['security-roles', 'r1'] });
+
+    await act(async () => {
+      await rm.result.current.mutateAsync({ idKey: 'r1', personIdKey: 'p1' });
+    });
+    expect(api.removeRoleMember).toHaveBeenCalledWith('r1', 'p1');
+    expect(invR).toHaveBeenCalledWith({ queryKey: ['security-roles', 'r1'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useSettings.test.tsx
+++ b/src/web/src/hooks/__tests__/useSettings.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * useSettings hook module: preferences, sessions, password, 2FA.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor, act } from '@testing-library/react';
+
+vi.mock('@/services/api/settings', () => ({
+  getPreferences: vi.fn(),
+  updatePreferences: vi.fn(),
+  getSessions: vi.fn(),
+  revokeSession: vi.fn(),
+  changePassword: vi.fn(),
+  getTwoFactorStatus: vi.fn(),
+  setupTwoFactor: vi.fn(),
+  verifyTwoFactor: vi.fn(),
+  disableTwoFactor: vi.fn(),
+}));
+
+import * as api from '@/services/api/settings';
+import {
+  useChangePassword,
+  useDisableTwoFactor,
+  usePreferences,
+  useRevokeSession,
+  useSessions,
+  useSetupTwoFactor,
+  useTwoFactorStatus,
+  useUpdatePreferences,
+  useVerifyTwoFactor,
+} from '../useSettings';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('preferences', () => {
+  it('usePreferences fetches', async () => {
+    vi.mocked(api.getPreferences).mockResolvedValueOnce({ theme: 'dark' } as never);
+    const { result } = renderHookWithQuery(() => usePreferences());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getPreferences).toHaveBeenCalled();
+  });
+
+  it('useUpdatePreferences invalidates preferences', async () => {
+    vi.mocked(api.updatePreferences).mockResolvedValueOnce({ theme: 'light' } as never);
+    const { result, client } = renderHookWithQuery(() => useUpdatePreferences());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync({ theme: 'light' } as never);
+    });
+    expect(api.updatePreferences).toHaveBeenCalledWith({ theme: 'light' });
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['settings', 'preferences'] });
+  });
+});
+
+describe('sessions', () => {
+  it('useSessions fetches', async () => {
+    vi.mocked(api.getSessions).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useSessions());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getSessions).toHaveBeenCalled();
+  });
+
+  it('useRevokeSession invalidates sessions', async () => {
+    vi.mocked(api.revokeSession).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useRevokeSession());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('s1');
+    });
+    expect(api.revokeSession).toHaveBeenCalledWith('s1');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['settings', 'sessions'] });
+  });
+});
+
+describe('security', () => {
+  it('useChangePassword calls API', async () => {
+    vi.mocked(api.changePassword).mockResolvedValueOnce(undefined as never);
+    const { result } = renderHookWithQuery(() => useChangePassword());
+    await act(async () => {
+      await result.current.mutateAsync({ currentPassword: 'a', newPassword: 'b' } as never);
+    });
+    expect(api.changePassword).toHaveBeenCalledWith({
+      currentPassword: 'a',
+      newPassword: 'b',
+    });
+  });
+
+  it('useTwoFactorStatus fetches', async () => {
+    vi.mocked(api.getTwoFactorStatus).mockResolvedValueOnce({ isEnabled: false } as never);
+    const { result } = renderHookWithQuery(() => useTwoFactorStatus());
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getTwoFactorStatus).toHaveBeenCalled();
+  });
+
+  it('useSetupTwoFactor triggers generation', async () => {
+    vi.mocked(api.setupTwoFactor).mockResolvedValueOnce({ qrCode: 'x' } as never);
+    const { result } = renderHookWithQuery(() => useSetupTwoFactor());
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+    expect(api.setupTwoFactor).toHaveBeenCalled();
+  });
+
+  it('useVerifyTwoFactor invalidates status', async () => {
+    vi.mocked(api.verifyTwoFactor).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useVerifyTwoFactor());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('123456');
+    });
+    expect(api.verifyTwoFactor).toHaveBeenCalledWith('123456');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['settings', 'two-factor', 'status'] });
+  });
+
+  it('useDisableTwoFactor invalidates status', async () => {
+    vi.mocked(api.disableTwoFactor).mockResolvedValueOnce(undefined as never);
+    const { result, client } = renderHookWithQuery(() => useDisableTwoFactor());
+    const inv = vi.spyOn(client, 'invalidateQueries');
+    await act(async () => {
+      await result.current.mutateAsync('123456');
+    });
+    expect(api.disableTwoFactor).toHaveBeenCalledWith('123456');
+    expect(inv).toHaveBeenCalledWith({ queryKey: ['settings', 'two-factor', 'status'] });
+  });
+});

--- a/src/web/src/hooks/__tests__/useSupervisorAttendance.test.tsx
+++ b/src/web/src/hooks/__tests__/useSupervisorAttendance.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * useSupervisorAttendance + extractLocationIdKeys.
+ *
+ * The hook aggregates multiple room rosters into a flat, time-sorted
+ * AttendanceResultDto list. The mapping function is private, so we exercise
+ * it via the public query result.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { waitFor } from '@testing-library/react';
+
+vi.mock('@/services/api/checkin', () => ({
+  getMultipleRoomRosters: vi.fn(),
+}));
+
+import * as checkinApi from '@/services/api/checkin';
+import {
+  extractLocationIdKeys,
+  useSupervisorAttendance,
+} from '../useSupervisorAttendance';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('extractLocationIdKeys', () => {
+  it('returns [] when areas is undefined', () => {
+    expect(extractLocationIdKeys(undefined)).toEqual([]);
+  });
+
+  it('deduplicates location idKeys across areas', () => {
+    const areas = [
+      {
+        locations: [{ idKey: 'l1' }, { idKey: 'l2' }],
+      },
+      {
+        locations: [{ idKey: 'l2' }, { idKey: 'l3' }],
+      },
+    ] as never;
+    const out = extractLocationIdKeys(areas);
+    expect(out.sort()).toEqual(['l1', 'l2', 'l3']);
+  });
+});
+
+describe('useSupervisorAttendance', () => {
+  it('idle when enabled=false', () => {
+    const { result } = renderHookWithQuery(() => useSupervisorAttendance([], false));
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(checkinApi.getMultipleRoomRosters).not.toHaveBeenCalled();
+  });
+
+  it('treats undefined locations as empty list', async () => {
+    vi.mocked(checkinApi.getMultipleRoomRosters).mockResolvedValueOnce([] as never);
+    const { result } = renderHookWithQuery(() => useSupervisorAttendance(undefined));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(checkinApi.getMultipleRoomRosters).toHaveBeenCalledWith([]);
+  });
+
+  it('flattens rosters + maps roster children into AttendanceResult, sorted newest first', async () => {
+    vi.mocked(checkinApi.getMultipleRoomRosters).mockResolvedValueOnce([
+      {
+        locationName: 'Room A',
+        children: [
+          {
+            attendanceIdKey: 'a1',
+            personIdKey: 'p1',
+            fullName: 'Alice',
+            securityCode: 'AAA',
+            checkInTime: '2024-01-01T09:00:00Z',
+            isFirstTime: false,
+          },
+          {
+            attendanceIdKey: 'a2',
+            personIdKey: 'p2',
+            fullName: 'Bob',
+            securityCode: null,
+            checkInTime: '2024-01-01T10:00:00Z',
+            isFirstTime: true,
+          },
+        ],
+      },
+      // Empty roster is skipped.
+      { locationName: 'Room B', children: [] },
+    ] as never);
+
+    const { result } = renderHookWithQuery(() =>
+      useSupervisorAttendance(['l1', 'l2'])
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const data = result.current.data!;
+    expect(data).toHaveLength(2);
+    // Sorted newest → oldest.
+    expect(data[0].personName).toBe('Bob');
+    expect(data[1].personName).toBe('Alice');
+    // Null securityCode becomes ''.
+    expect(data[1].securityCode).toBe('AAA');
+    expect(data[0].securityCode).toBe('');
+    // Location name carries through; group/schedule are empty strings.
+    expect(data[0].locationName).toBe('Room A');
+    expect(data[0].groupName).toBe('');
+    expect(data[0].scheduleName).toBe('');
+  });
+
+  it('rethrows API errors with a wrapping message', async () => {
+    vi.mocked(checkinApi.getMultipleRoomRosters).mockRejectedValueOnce(
+      new Error('boom')
+    );
+    const { result } = renderHookWithQuery(() => useSupervisorAttendance(['l1']));
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect((result.current.error as Error).message).toMatch(
+      /Failed to fetch supervisor attendance: boom/
+    );
+  });
+});

--- a/src/web/src/hooks/__tests__/useSupervisorMode.test.tsx
+++ b/src/web/src/hooks/__tests__/useSupervisorMode.test.tsx
@@ -1,0 +1,120 @@
+/**
+ * useSupervisorMode — local session state with activity timeout + backend-expiry
+ * polling. All timers are faked so we can drive the two intervals deterministically.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { useSupervisorMode } from '../useSupervisorMode';
+
+function makeSession(overrides: Partial<{ expiresAt: string; token: string }> = {}) {
+  return {
+    token: 'tok',
+    supervisor: {
+      idKey: 's1',
+      firstName: 'Ad',
+      lastName: 'Min',
+      fullName: 'Admin',
+    } as never,
+    expiresAt: overrides.expiresAt ?? new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('useSupervisorMode', () => {
+  it('starts inactive', () => {
+    const { result } = renderHook(() => useSupervisorMode());
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.supervisor).toBeNull();
+    expect(result.current.sessionToken).toBeNull();
+    expect(result.current.timeRemaining).toBeNull();
+  });
+
+  it('startSession activates + computes timeRemaining after one tick', () => {
+    const { result } = renderHook(() => useSupervisorMode());
+    act(() => {
+      result.current.startSession(makeSession());
+    });
+    expect(result.current.isActive).toBe(true);
+    expect(result.current.sessionToken).toBe('tok');
+
+    // Advance 1s to trigger activity-timeout interval and backend-check interval.
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(result.current.timeRemaining).toBeGreaterThan(0);
+    // 2-minute inactivity window; at 1s elapsed we should see ~119 seconds.
+    expect(result.current.timeRemaining).toBeLessThanOrEqual(120);
+  });
+
+  it('endSession clears state', () => {
+    const { result } = renderHook(() => useSupervisorMode());
+    act(() => {
+      result.current.startSession(makeSession());
+    });
+    act(() => {
+      result.current.endSession();
+    });
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.supervisor).toBeNull();
+    expect(result.current.timeRemaining).toBeNull();
+  });
+
+  it('auto-expires after 2 minutes of inactivity', () => {
+    const { result } = renderHook(() => useSupervisorMode());
+    act(() => {
+      result.current.startSession(makeSession());
+    });
+    act(() => {
+      vi.advanceTimersByTime(2 * 60 * 1000 + 1000);
+    });
+    expect(result.current.isActive).toBe(false);
+  });
+
+  it('resetTimeout pushes the expiry window forward', () => {
+    const { result } = renderHook(() => useSupervisorMode());
+    act(() => {
+      result.current.startSession(makeSession());
+    });
+
+    // After 90 seconds of inactivity, still active.
+    act(() => {
+      vi.advanceTimersByTime(90 * 1000);
+    });
+    expect(result.current.isActive).toBe(true);
+
+    // Reset right before timeout — should continue past 2 minutes from original start.
+    act(() => {
+      result.current.resetTimeout();
+    });
+
+    // 60s more — still active (would have expired without reset).
+    act(() => {
+      vi.advanceTimersByTime(60 * 1000);
+    });
+    expect(result.current.isActive).toBe(true);
+  });
+
+  it('ends session when the backend expiresAt is in the past', () => {
+    const { result } = renderHook(() => useSupervisorMode());
+    // expiresAt already in the past — backend check runs immediately.
+    act(() => {
+      result.current.startSession(
+        makeSession({ expiresAt: new Date(Date.now() - 1000).toISOString() })
+      );
+    });
+    // The "check immediately" path fires in the effect; allow React to flush.
+    act(() => {
+      vi.advanceTimersByTime(0);
+    });
+    expect(result.current.isActive).toBe(false);
+  });
+});

--- a/src/web/src/services/api/__tests__/services.admin.test.ts
+++ b/src/web/src/services/api/__tests__/services.admin.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Admin-tier API service coverage (wave 3):
+ *   - securityRoles: role CRUD, claims CRUD, role-member CRUD, claims listing
+ *   - people.ts: remaining givingSummary + notes mutations
+ *   - checkin.ts: opportunities, registerFamily, checkoutFromRoster
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../client', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+  patch: vi.fn(),
+  apiClient: vi.fn(),
+  setTokens: vi.fn(),
+  clearTokens: vi.fn(),
+  getAccessToken: vi.fn(),
+  getRefreshToken: vi.fn(),
+  ApiClientError: class MockApiClientError extends Error {
+    statusCode: number;
+    constructor(statusCode: number, error: { message?: string }) {
+      super(error?.message || 'err');
+      this.statusCode = statusCode;
+    }
+  },
+}));
+
+vi.mock('@/services/offline/OfflineFamilyCache', () => ({
+  offlineFamilyCache: {
+    cacheResults: vi.fn().mockResolvedValue(undefined),
+    getCachedResults: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+import * as client from '../client';
+
+const mockGet = vi.mocked(client.get);
+const mockPost = vi.mocked(client.post);
+const mockPut = vi.mocked(client.put);
+const mockDel = vi.mocked(client.del);
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPost.mockReset();
+  mockPut.mockReset();
+  mockDel.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+describe('securityRolesApi', () => {
+  it('list / get / claims list', async () => {
+    const api = await import('../securityRoles');
+    mockGet.mockResolvedValueOnce({ data: [{ idKey: 'r1' }] });
+    expect(await api.getSecurityRoles()).toEqual([{ idKey: 'r1' }]);
+    expect(mockGet).toHaveBeenCalledWith('/admin/security-roles');
+
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'r1' } });
+    await api.getSecurityRole('r1');
+    expect(mockGet).toHaveBeenLastCalledWith('/admin/security-roles/r1');
+
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getSecurityClaims();
+    expect(mockGet).toHaveBeenLastCalledWith('/admin/security-claims');
+  });
+
+  it('create / update / delete role', async () => {
+    const api = await import('../securityRoles');
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'r1' } });
+    await api.createSecurityRole({ name: 'Admin' });
+    expect(mockPost).toHaveBeenCalledWith('/admin/security-roles', { name: 'Admin' });
+
+    mockPut.mockResolvedValueOnce({ data: { idKey: 'r1' } });
+    await api.updateSecurityRole('r1', { name: 'Admin2', isActive: true });
+    expect(mockPut).toHaveBeenCalledWith('/admin/security-roles/r1', {
+      name: 'Admin2',
+      isActive: true,
+    });
+
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.deleteSecurityRole('r1');
+    expect(mockDel).toHaveBeenCalledWith('/admin/security-roles/r1');
+  });
+
+  it('assign/remove role claim', async () => {
+    const api = await import('../securityRoles');
+    mockPost.mockResolvedValueOnce(undefined);
+    await api.assignRoleClaim('r1', { claimIdKey: 'c1', allowOrDeny: 'A' });
+    expect(mockPost).toHaveBeenCalledWith('/admin/security-roles/r1/claims', {
+      claimIdKey: 'c1',
+      allowOrDeny: 'A',
+    });
+
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.removeRoleClaim('r1', 'c1');
+    expect(mockDel).toHaveBeenCalledWith('/admin/security-roles/r1/claims/c1');
+  });
+
+  it('add/remove role member', async () => {
+    const api = await import('../securityRoles');
+    mockPost.mockResolvedValueOnce(undefined);
+    await api.addRoleMember('r1', { personIdKey: 'p1' });
+    expect(mockPost).toHaveBeenCalledWith('/admin/security-roles/r1/members', {
+      personIdKey: 'p1',
+    });
+
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.removeRoleMember('r1', 'p1');
+    expect(mockDel).toHaveBeenCalledWith('/admin/security-roles/r1/members/p1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('peopleApi deeper coverage', () => {
+  it('createPerson posts to /people', async () => {
+    const api = await import('../people');
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'p1' } });
+    await api.createPerson({ firstName: 'Jo' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/people', { firstName: 'Jo' });
+  });
+
+  it('updatePerson puts to /people/:idKey', async () => {
+    const api = await import('../people');
+    mockPut.mockResolvedValueOnce({ data: { idKey: 'p1' } });
+    await api.updatePerson('p1', { firstName: 'X' } as never);
+    expect(mockPut).toHaveBeenCalledWith('/people/p1', { firstName: 'X' });
+  });
+
+  it('getPersonGroups returns the paged result as-is (no envelope unwrap)', async () => {
+    const api = await import('../people');
+    const paged = { data: [{ idKey: 'g1' }], meta: { page: 1 } };
+    mockGet.mockResolvedValueOnce(paged);
+    const out = await api.getPersonGroups('p1');
+    expect(mockGet).toHaveBeenCalledWith('/people/p1/groups');
+    expect(out).toBe(paged);
+  });
+
+  it('getPersonGivingSummary unwraps envelope', async () => {
+    const api = await import('../people');
+    mockGet.mockResolvedValueOnce({ data: { ytdTotal: 100 } });
+    const out = await api.getPersonGivingSummary('p1');
+    expect(mockGet).toHaveBeenCalledWith('/people/p1/giving-summary');
+    expect(out).toEqual({ ytdTotal: 100 });
+  });
+
+  it('note CRUD: create / update / delete', async () => {
+    const api = await import('../people');
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'n1' } });
+    await api.createPersonNote('p1', { body: 'hi' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/people/p1/notes', { body: 'hi' });
+
+    mockPut.mockResolvedValueOnce({ data: { idKey: 'n1' } });
+    await api.updatePersonNote('p1', 'n1', { body: 'bye' } as never);
+    expect(mockPut).toHaveBeenCalledWith('/people/p1/notes/n1', { body: 'bye' });
+
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.deletePersonNote('p1', 'n1');
+    expect(mockDel).toHaveBeenCalledWith('/people/p1/notes/n1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('checkinApi deeper coverage', () => {
+  it('getCheckinOpportunities maps backend response to frontend DTOs', async () => {
+    const api = await import('../checkin');
+    mockGet.mockResolvedValueOnce({
+      data: {
+        family: {
+          familyIdKey: 'F1',
+          familyName: 'Smith',
+          members: [
+            {
+              personIdKey: 'P1',
+              firstName: 'A',
+              lastName: 'B',
+              fullName: 'A B',
+              age: 5,
+            },
+          ],
+        },
+        opportunities: [
+          {
+            person: {
+              personIdKey: 'P1',
+              firstName: 'A',
+              lastName: 'B',
+              fullName: 'A B',
+            },
+            currentAttendance: null,
+            availableOptions: [],
+          },
+        ],
+      },
+    });
+    const out = await api.getCheckinOpportunities('F1', { scheduleId: 's1' });
+    const url = mockGet.mock.calls[0][0] as string;
+    expect(url).toBe('/checkin/opportunities/F1?scheduleId=s1');
+    expect(out.family.idKey).toBe('F1');
+    expect(out.family.name).toBe('Smith');
+    expect(out.opportunities[0].person.idKey).toBe('P1');
+  });
+
+  it('getCheckinOpportunities without params omits query', async () => {
+    const api = await import('../checkin');
+    mockGet.mockResolvedValueOnce({
+      data: {
+        family: { familyIdKey: 'F1', familyName: 'S', members: [] },
+        opportunities: [],
+      },
+    });
+    await api.getCheckinOpportunities('F1');
+    expect(mockGet).toHaveBeenCalledWith('/checkin/opportunities/F1');
+  });
+
+  it('registerFamily posts and maps response', async () => {
+    const api = await import('../checkin');
+    mockPost.mockResolvedValueOnce({
+      data: {
+        familyIdKey: 'F1',
+        familyName: 'Smith',
+        members: [
+          {
+            personIdKey: 'P1',
+            firstName: 'A',
+            lastName: 'B',
+            fullName: 'A B',
+          },
+        ],
+      },
+    });
+    const out = await api.registerFamily({ familyName: 'Smith' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/checkin/register-family', {
+      familyName: 'Smith',
+    });
+    expect(out.idKey).toBe('F1');
+    expect(out.members[0].idKey).toBe('P1');
+  });
+
+  it('checkoutFromRoster posts with undefined body', async () => {
+    const api = await import('../checkin');
+    mockPost.mockResolvedValueOnce(undefined);
+    await api.checkoutFromRoster('a1');
+    expect(mockPost).toHaveBeenCalledWith('/checkin/checkout/a1', undefined);
+  });
+
+  it('searchFamiliesForCheckin falls back to cached results when offline', async () => {
+    const { offlineFamilyCache } = await import('@/services/offline/OfflineFamilyCache');
+    const mockClient = await import('../client');
+    const api = await import('../checkin');
+    // Force offline mode for this test.
+    const origOnline = Object.getOwnPropertyDescriptor(navigator, 'onLine');
+    Object.defineProperty(navigator, 'onLine', {
+      configurable: true,
+      get: () => false,
+    });
+    vi.mocked(mockClient.get).mockRejectedValueOnce(new Error('Network Error'));
+    vi.mocked(offlineFamilyCache.getCachedResults).mockResolvedValueOnce([
+      { idKey: 'F1', name: 'Cached', members: [] },
+    ] as never);
+    try {
+      const out = await api.searchFamiliesForCheckin({
+        searchValue: '555',
+      } as never);
+      expect(out).toEqual([{ idKey: 'F1', name: 'Cached', members: [] }]);
+    } finally {
+      if (origOnline) Object.defineProperty(navigator, 'onLine', origOnline);
+    }
+  });
+});

--- a/src/web/src/services/api/__tests__/services.extra.test.ts
+++ b/src/web/src/services/api/__tests__/services.extra.test.ts
@@ -1,0 +1,1019 @@
+/**
+ * Additional API service coverage (wave 3, #498).
+ *
+ * Targets modules that the existing services.test.ts / services.more.test.ts
+ * only smoke-imported: followups, pager, personMerge, pickup, authorizedPickup,
+ * publicGroups, communications, communicationTemplates, membershipRequests,
+ * myGroups, files, auditLogApi, settings, devices (deeper), import (deeper),
+ * giving (deeper), checkinOperations, groups (member endpoints).
+ *
+ * Same pattern as the existing files: mock ./client once, import each service
+ * lazily, assert URL / HTTP method / body / envelope unwrapping.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../client', () => ({
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
+  del: vi.fn(),
+  patch: vi.fn(),
+  apiClient: vi.fn(),
+  setTokens: vi.fn(),
+  clearTokens: vi.fn(),
+  getAccessToken: vi.fn(),
+  getRefreshToken: vi.fn(),
+  ApiClientError: class MockApiClientError extends Error {
+    statusCode: number;
+    constructor(statusCode: number, error: { message?: string }) {
+      super(error?.message || 'err');
+      this.statusCode = statusCode;
+    }
+  },
+}));
+
+vi.mock('@/services/offline/OfflineFamilyCache', () => ({
+  offlineFamilyCache: {
+    cacheResults: vi.fn().mockResolvedValue(undefined),
+    getCachedResults: vi.fn().mockResolvedValue(null),
+  },
+}));
+
+import * as client from '../client';
+
+const mockGet = vi.mocked(client.get);
+const mockPost = vi.mocked(client.post);
+const mockPut = vi.mocked(client.put);
+const mockDel = vi.mocked(client.del);
+const mockApiClient = vi.mocked(client.apiClient);
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockPost.mockReset();
+  mockPut.mockReset();
+  mockDel.mockReset();
+  mockApiClient.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+describe('followupsApi', () => {
+  it('getPendingFollowUps without assignee => /followups/pending', async () => {
+    const api = await import('../followups');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getPendingFollowUps();
+    expect(mockGet).toHaveBeenCalledWith('/followups/pending');
+  });
+
+  it('getPendingFollowUps with assignee appends query', async () => {
+    const api = await import('../followups');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getPendingFollowUps('u1');
+    const url = mockGet.mock.calls[0][0] as string;
+    expect(url).toBe('/followups/pending?assignedToIdKey=u1');
+  });
+
+  it('getFollowUp unwraps envelope', async () => {
+    const api = await import('../followups');
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'f1' } });
+    expect(await api.getFollowUp('f1')).toEqual({ idKey: 'f1' });
+    expect(mockGet).toHaveBeenCalledWith('/followups/f1');
+  });
+
+  it('updateFollowUpStatus puts to /followups/:idKey/status', async () => {
+    const api = await import('../followups');
+    mockPut.mockResolvedValueOnce({ data: { idKey: 'f1' } });
+    await api.updateFollowUpStatus('f1', { status: 'Done' } as never);
+    expect(mockPut).toHaveBeenCalledWith('/followups/f1/status', { status: 'Done' });
+  });
+
+  it('assignFollowUp puts with no envelope', async () => {
+    const api = await import('../followups');
+    mockPut.mockResolvedValueOnce(undefined);
+    await api.assignFollowUp('f1', { personIdKey: 'p1' } as never);
+    expect(mockPut).toHaveBeenCalledWith('/followups/f1/assign', { personIdKey: 'p1' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('pagerApi', () => {
+  it('sendPage posts to /pager/send', async () => {
+    const api = await import('../pager');
+    mockPost.mockResolvedValueOnce({ data: { messageIdKey: 'm1' } });
+    await api.sendPage({ pagerNumber: 7, message: 'Come' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/pager/send', { pagerNumber: 7, message: 'Come' });
+  });
+
+  it('searchPagers without args omits query', async () => {
+    const api = await import('../pager');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.searchPagers();
+    expect(mockGet).toHaveBeenCalledWith('/pager/search');
+  });
+
+  it('searchPagers with searchTerm + date builds query', async () => {
+    const api = await import('../pager');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.searchPagers('Smith', '2024-01-01');
+    const url = mockGet.mock.calls[0][0] as string;
+    expect(url).toContain('/pager/search?');
+    expect(url).toContain('searchTerm=Smith');
+    expect(url).toContain('date=2024-01-01');
+  });
+
+  it('getPagerHistory uses pager number in path and optional date query', async () => {
+    const api = await import('../pager');
+    mockGet.mockResolvedValueOnce({ data: { pages: [] } });
+    await api.getPagerHistory(7);
+    expect(mockGet).toHaveBeenCalledWith('/pager/7/history');
+
+    mockGet.mockResolvedValueOnce({ data: { pages: [] } });
+    await api.getPagerHistory(7, '2024-01-01');
+    const url = mockGet.mock.calls.at(-1)?.[0] as string;
+    expect(url).toContain('/pager/7/history?date=2024-01-01');
+  });
+
+  it('getNextPagerNumber with/without campus', async () => {
+    const api = await import('../pager');
+    mockGet.mockResolvedValueOnce({ data: 42 });
+    expect(await api.getNextPagerNumber()).toBe(42);
+    expect(mockGet).toHaveBeenCalledWith('/pager/next-number');
+
+    mockGet.mockResolvedValueOnce({ data: 43 });
+    await api.getNextPagerNumber('c1');
+    expect(mockGet).toHaveBeenLastCalledWith('/pager/next-number?campusId=c1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('personMergeApi', () => {
+  it('getDuplicates default pagination', async () => {
+    const api = await import('../personMerge');
+    mockGet.mockResolvedValueOnce({ data: [], meta: {} });
+    await api.getDuplicates();
+    const url = mockGet.mock.calls[0][0] as string;
+    expect(url).toContain('/people/duplicates?');
+    expect(url).toContain('page=1');
+    expect(url).toContain('pageSize=25');
+  });
+
+  it('getDuplicatesForPerson unwraps envelope', async () => {
+    const api = await import('../personMerge');
+    mockGet.mockResolvedValueOnce({ data: [{ idKey: 'p2' }] });
+    const out = await api.getDuplicatesForPerson('p1');
+    expect(mockGet).toHaveBeenCalledWith('/people/p1/duplicates');
+    expect(out).toEqual([{ idKey: 'p2' }]);
+  });
+
+  it('comparePeople builds query with both idKeys', async () => {
+    const api = await import('../personMerge');
+    mockGet.mockResolvedValueOnce({ data: { person1: {}, person2: {} } });
+    await api.comparePeople('p1', 'p2');
+    expect(mockGet).toHaveBeenCalledWith(
+      '/people/compare?person1IdKey=p1&person2IdKey=p2'
+    );
+  });
+
+  it('mergePeople posts to /people/merge', async () => {
+    const api = await import('../personMerge');
+    mockPost.mockResolvedValueOnce({ data: { mergedIdKey: 'p1' } });
+    const req = { targetIdKey: 'p1', sourceIdKey: 'p2' } as never;
+    await api.mergePeople(req);
+    expect(mockPost).toHaveBeenCalledWith('/people/merge', req);
+  });
+
+  it('getMergeHistory default pagination', async () => {
+    const api = await import('../personMerge');
+    mockGet.mockResolvedValueOnce({ data: [], meta: {} });
+    await api.getMergeHistory();
+    const url = mockGet.mock.calls[0][0] as string;
+    expect(url).toContain('/people/merge-history?');
+    expect(url).toContain('page=1');
+  });
+
+  it('ignoreDuplicate posts to /people/duplicates/ignore', async () => {
+    const api = await import('../personMerge');
+    mockPost.mockResolvedValueOnce(undefined);
+    await api.ignoreDuplicate({ person1IdKey: 'p1', person2IdKey: 'p2' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/people/duplicates/ignore', {
+      person1IdKey: 'p1',
+      person2IdKey: 'p2',
+    });
+  });
+
+  it('unignoreDuplicate deletes with both idKeys in path', async () => {
+    const api = await import('../personMerge');
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.unignoreDuplicate('p1', 'p2');
+    expect(mockDel).toHaveBeenCalledWith('/people/duplicates/ignore/p1/p2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('pickupApi', () => {
+  it('verifyPickup posts to /checkin/verify-pickup', async () => {
+    const api = await import('../pickup');
+    mockPost.mockResolvedValueOnce({ data: { isAuthorized: true } });
+    const req = { childIdKey: 'c1', pickupPersonName: 'Bob' } as never;
+    await api.verifyPickup(req);
+    expect(mockPost).toHaveBeenCalledWith('/checkin/verify-pickup', req);
+  });
+
+  it('recordPickup returns body directly (no unwrap)', async () => {
+    const api = await import('../pickup');
+    mockPost.mockResolvedValueOnce({ idKey: 'log1' });
+    const out = await api.recordPickup({ childIdKey: 'c1' } as never);
+    expect(out).toEqual({ idKey: 'log1' });
+    expect(mockPost).toHaveBeenCalledWith('/checkin/record-pickup', { childIdKey: 'c1' });
+  });
+
+  it('getPickupHistory without dates / with dates', async () => {
+    const api = await import('../pickup');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getPickupHistory('c1');
+    expect(mockGet).toHaveBeenCalledWith('/checkin/people/c1/pickup-history');
+
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getPickupHistory('c1', '2024-01-01', '2024-02-01');
+    const url = mockGet.mock.calls.at(-1)?.[0] as string;
+    expect(url).toContain('fromDate=2024-01-01');
+    expect(url).toContain('toDate=2024-02-01');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('authorizedPickupApi', () => {
+  it('getAuthorizedPickups unwraps envelope', async () => {
+    const api = await import('../authorizedPickup');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getAuthorizedPickups('c1');
+    expect(mockGet).toHaveBeenCalledWith('/people/c1/authorized-pickups');
+  });
+
+  it('createAuthorizedPickup posts to child-scoped URL', async () => {
+    const api = await import('../authorizedPickup');
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'ap1' } });
+    await api.createAuthorizedPickup('c1', { personIdKey: 'p1' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/people/c1/authorized-pickups', {
+      personIdKey: 'p1',
+    });
+  });
+
+  it('updateAuthorizedPickup puts by pickup idKey (child agnostic)', async () => {
+    const api = await import('../authorizedPickup');
+    mockPut.mockResolvedValueOnce({ data: { idKey: 'ap1' } });
+    await api.updateAuthorizedPickup('ap1', { relationship: 'Parent' } as never);
+    expect(mockPut).toHaveBeenCalledWith('/authorized-pickups/ap1', {
+      relationship: 'Parent',
+    });
+  });
+
+  it('deleteAuthorizedPickup deletes by pickup idKey', async () => {
+    const api = await import('../authorizedPickup');
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.deleteAuthorizedPickup('ap1');
+    expect(mockDel).toHaveBeenCalledWith('/authorized-pickups/ap1');
+  });
+
+  it('autoPopulateFamilyMembers posts with empty body and unwraps data', async () => {
+    const api = await import('../authorizedPickup');
+    mockPost.mockResolvedValueOnce({
+      data: { message: 'ok', count: 2, pickups: [] },
+    });
+    const out = await api.autoPopulateFamilyMembers('c1');
+    expect(mockPost).toHaveBeenCalledWith(
+      '/people/c1/authorized-pickups/auto-populate',
+      {}
+    );
+    expect(out.count).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('publicGroupsApi', () => {
+  it('searchPublicGroups with no params hits /groups/public (skipAuth)', async () => {
+    const api = await import('../publicGroups');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.searchPublicGroups();
+    expect(mockGet).toHaveBeenCalledWith('/groups/public', { skipAuth: true });
+  });
+
+  it('searchPublicGroups encodes the full param set', async () => {
+    const api = await import('../publicGroups');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.searchPublicGroups({
+      searchTerm: 'bible',
+      groupTypeIdKey: 'gt1',
+      campusIdKey: 'c1',
+      dayOfWeek: 0,
+      timeOfDay: 2,
+      hasOpenings: true,
+      pageNumber: 2,
+      pageSize: 20,
+    });
+    const url = mockGet.mock.calls[0][0] as string;
+    for (const token of [
+      '/groups/public?',
+      'searchTerm=bible',
+      'groupTypeIdKey=gt1',
+      'campusIdKey=c1',
+      'dayOfWeek=0',
+      'timeOfDay=2',
+      'hasOpenings=true',
+      'pageNumber=2',
+      'pageSize=20',
+    ]) {
+      expect(url).toContain(token);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('communicationsApi', () => {
+  it('createCommunication, sendCommunication, scheduleCommunication, cancelSchedule', async () => {
+    const api = await import('../communications');
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'c1' } });
+    await api.createCommunication({ subject: 'S' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/communications', { subject: 'S' });
+
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'c1' } });
+    await api.sendCommunication('c1');
+    expect(mockPost).toHaveBeenLastCalledWith('/communications/c1/send');
+
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'c1' } });
+    await api.scheduleCommunication('c1', '2024-01-01T12:00:00Z');
+    expect(mockPost).toHaveBeenLastCalledWith('/communications/c1/schedule', {
+      scheduledDateTime: '2024-01-01T12:00:00Z',
+    });
+
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'c1' } });
+    await api.cancelSchedule('c1');
+    expect(mockPost).toHaveBeenLastCalledWith('/communications/c1/cancel-schedule');
+  });
+
+  it('getCommunication / getCommunications (with / without params)', async () => {
+    const api = await import('../communications');
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'c1' } });
+    await api.getCommunication('c1');
+    expect(mockGet).toHaveBeenCalledWith('/communications/c1');
+
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getCommunications();
+    expect(mockGet).toHaveBeenLastCalledWith('/communications');
+
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getCommunications({ page: 2, pageSize: 50, status: 'Draft' });
+    const url = mockGet.mock.calls.at(-1)?.[0] as string;
+    expect(url).toContain('page=2');
+    expect(url).toContain('pageSize=50');
+    expect(url).toContain('status=Draft');
+  });
+
+  it('getMergeFields unwraps', async () => {
+    const api = await import('../communications');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getMergeFields();
+    expect(mockGet).toHaveBeenCalledWith('/communications/merge-fields');
+  });
+
+  it('previewCommunication posts', async () => {
+    const api = await import('../communications');
+    mockPost.mockResolvedValueOnce({ data: { body: 'x' } });
+    await api.previewCommunication({ templateIdKey: 't1' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/communications/preview', {
+      templateIdKey: 't1',
+    });
+  });
+
+  it('getCommunicationPreferences / update / bulkUpdate', async () => {
+    const api = await import('../communications');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getCommunicationPreferences('p1');
+    expect(mockGet).toHaveBeenCalledWith('/people/p1/communication-preferences');
+
+    mockPut.mockResolvedValueOnce({ data: { type: 'Email' } });
+    await api.updateCommunicationPreference('p1', 'Email', { optIn: false } as never);
+    expect(mockPut).toHaveBeenLastCalledWith(
+      '/people/p1/communication-preferences/Email',
+      { optIn: false }
+    );
+
+    mockPut.mockResolvedValueOnce({ data: [] });
+    await api.bulkUpdateCommunicationPreferences('p1', {
+      preferences: [],
+    } as never);
+    expect(mockPut).toHaveBeenLastCalledWith('/people/p1/communication-preferences', {
+      preferences: [],
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('communicationTemplatesApi', () => {
+  it('list / get / create / update / delete', async () => {
+    const api = await import('../communicationTemplates');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getCommunicationTemplates();
+    expect(mockGet).toHaveBeenCalledWith('/communication-templates');
+
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getCommunicationTemplates({ page: 1, pageSize: 20, type: 'Email', isActive: true });
+    const url = mockGet.mock.calls.at(-1)?.[0] as string;
+    expect(url).toContain('page=1');
+    expect(url).toContain('pageSize=20');
+    expect(url).toContain('type=Email');
+    expect(url).toContain('isActive=true');
+
+    mockGet.mockResolvedValueOnce({ data: { idKey: 't1' } });
+    await api.getCommunicationTemplate('t1');
+    expect(mockGet).toHaveBeenLastCalledWith('/communication-templates/t1');
+
+    mockPost.mockResolvedValueOnce({ data: { idKey: 't1' } });
+    await api.createCommunicationTemplate({ name: 'N' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/communication-templates', { name: 'N' });
+
+    mockPut.mockResolvedValueOnce({ data: { idKey: 't1' } });
+    await api.updateCommunicationTemplate('t1', { name: 'X' } as never);
+    expect(mockPut).toHaveBeenCalledWith('/communication-templates/t1', { name: 'X' });
+
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.deleteCommunicationTemplate('t1');
+    expect(mockDel).toHaveBeenCalledWith('/communication-templates/t1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('membershipRequestsApi', () => {
+  it('submit / list / process', async () => {
+    const api = await import('../membershipRequests');
+    mockPost.mockResolvedValueOnce({ idKey: 'r1' });
+    await api.submitMembershipRequest('g1', { note: 'x' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/groups/g1/membership-requests', { note: 'x' });
+
+    mockGet.mockResolvedValueOnce([{ idKey: 'r1' }]);
+    const pending = await api.getPendingRequests('g1');
+    expect(mockGet).toHaveBeenCalledWith('/groups/g1/membership-requests');
+    expect(pending).toEqual([{ idKey: 'r1' }]);
+
+    mockPut.mockResolvedValueOnce({ idKey: 'r1' });
+    await api.processRequest('g1', 'r1', { approve: true } as never);
+    expect(mockPut).toHaveBeenCalledWith('/groups/g1/membership-requests/r1', { approve: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('myGroupsApi', () => {
+  it('getMyGroups / getMyGroupMembers / update / remove / recordAttendance', async () => {
+    const api = await import('../myGroups');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getMyGroups();
+    expect(mockGet).toHaveBeenCalledWith('/my-groups');
+
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getMyGroupMembers('g1');
+    expect(mockGet).toHaveBeenLastCalledWith('/my-groups/g1/members');
+
+    mockPut.mockResolvedValueOnce({ data: { idKey: 'm1' } });
+    await api.updateGroupMember('g1', 'm1', { note: 'x' } as never);
+    expect(mockPut).toHaveBeenCalledWith('/my-groups/g1/members/m1', { note: 'x' });
+
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.removeGroupMember('g1', 'm1');
+    expect(mockDel).toHaveBeenCalledWith('/my-groups/g1/members/m1');
+
+    mockPost.mockResolvedValueOnce(undefined);
+    await api.recordAttendance('g1', { attendance: [] } as never);
+    expect(mockPost).toHaveBeenCalledWith('/my-groups/g1/attendance', { attendance: [] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('settingsApi', () => {
+  it('preferences get/update, sessions get/revoke', async () => {
+    const api = await import('../settings');
+    mockGet.mockResolvedValueOnce({ data: { theme: 'dark' } });
+    await api.getPreferences();
+    expect(mockGet).toHaveBeenCalledWith('/my-settings/preferences');
+
+    mockPut.mockResolvedValueOnce({ data: { theme: 'light' } });
+    await api.updatePreferences({ theme: 'light' } as never);
+    expect(mockPut).toHaveBeenCalledWith('/my-settings/preferences', { theme: 'light' });
+
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getSessions();
+    expect(mockGet).toHaveBeenLastCalledWith('/my-settings/sessions');
+
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.revokeSession('s1');
+    expect(mockDel).toHaveBeenCalledWith('/my-settings/sessions/s1');
+  });
+
+  it('security: changePassword / 2FA status / setup / verify / disable', async () => {
+    const api = await import('../settings');
+    mockPost.mockResolvedValueOnce(undefined);
+    await api.changePassword({ currentPassword: 'a', newPassword: 'b' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/my-settings/change-password', {
+      currentPassword: 'a',
+      newPassword: 'b',
+    });
+
+    mockGet.mockResolvedValueOnce({ data: { isEnabled: false } });
+    await api.getTwoFactorStatus();
+    expect(mockGet).toHaveBeenLastCalledWith('/my-settings/two-factor');
+
+    mockPost.mockResolvedValueOnce({ data: { qrCode: 'q' } });
+    await api.setupTwoFactor();
+    expect(mockPost).toHaveBeenLastCalledWith('/my-settings/two-factor/setup');
+
+    mockPost.mockResolvedValueOnce(undefined);
+    await api.verifyTwoFactor('123456');
+    expect(mockPost).toHaveBeenLastCalledWith('/my-settings/two-factor/verify', {
+      code: '123456',
+    });
+
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.disableTwoFactor('123456');
+    // disable sends body via stringified JSON
+    const [url, options] = mockDel.mock.calls.at(-1) as [string, { body: string }];
+    expect(url).toBe('/my-settings/two-factor');
+    expect(options.body).toBe(JSON.stringify({ code: '123456' }));
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('auditLogApi', () => {
+  it('searchAuditLogs empty params => /audit-logs', async () => {
+    const api = await import('../auditLogApi');
+    mockGet.mockResolvedValueOnce({ data: [], meta: {} });
+    await api.searchAuditLogs();
+    expect(mockGet).toHaveBeenCalledWith('/audit-logs');
+  });
+
+  it('searchAuditLogs forwards the full filter', async () => {
+    const api = await import('../auditLogApi');
+    const { AuditAction } = await import('../types');
+    mockGet.mockResolvedValueOnce({ data: [], meta: {} });
+    await api.searchAuditLogs({
+      startDate: '2024-01-01',
+      endDate: '2024-02-01',
+      entityType: 'Person',
+      actionType: AuditAction.Update,
+      personIdKey: 'p1',
+      entityIdKey: 'e1',
+      page: 2,
+      pageSize: 25,
+    });
+    const url = mockGet.mock.calls[0][0] as string;
+    for (const token of [
+      '/audit-logs?',
+      'startDate=2024-01-01',
+      'endDate=2024-02-01',
+      'entityType=Person',
+      'actionType=Update',
+      'personIdKey=p1',
+      'entityIdKey=e1',
+      'page=2',
+      'pageSize=25',
+    ]) {
+      expect(url).toContain(token);
+    }
+  });
+
+  it('getEntityAuditHistory has no envelope', async () => {
+    const api = await import('../auditLogApi');
+    mockGet.mockResolvedValueOnce([{ idKey: 'a1' }]);
+    const out = await api.getEntityAuditHistory('Person', 'p1');
+    expect(mockGet).toHaveBeenCalledWith('/audit-logs/entity/Person/p1');
+    expect(out).toEqual([{ idKey: 'a1' }]);
+  });
+
+  it('exportAuditLogs uses fetch directly and returns a blob', async () => {
+    const api = await import('../auditLogApi');
+    // Stub global fetch
+    const blob = new Blob(['csv'], { type: 'text/csv' });
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      blob: () => Promise.resolve(blob),
+    } as unknown as Response);
+    vi.mocked(client.getAccessToken).mockReturnValue('tok');
+
+    try {
+      const out = await api.exportAuditLogs({
+        startDate: '2024-01-01',
+        format: 'csv',
+      } as never);
+      expect(out).toBe(blob);
+      const [url, opts] = fetchSpy.mock.calls[0];
+      expect(String(url)).toContain('/audit-logs/export?');
+      expect(String(url)).toContain('startDate=2024-01-01');
+      expect(String(url)).toContain('format=csv');
+      const headers = (opts as RequestInit).headers as Record<string, string>;
+      expect(headers['Authorization']).toBe('Bearer tok');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('exportAuditLogs throws on non-ok response', async () => {
+    const api = await import('../auditLogApi');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Nope',
+    } as unknown as Response);
+    try {
+      await expect(api.exportAuditLogs({ format: 'csv' } as never)).rejects.toThrow(
+        /Failed to export audit logs/
+      );
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('filesApi', () => {
+  it('uploadFile sends FormData through apiClient', async () => {
+    const api = await import('../files');
+    mockApiClient.mockResolvedValueOnce({ data: { idKey: 'f1' } } as never);
+    const file = new File(['x'], 'x.txt', { type: 'text/plain' });
+    await api.uploadFile(file, { description: 'd', binaryFileTypeIdKey: 'bft1' });
+    const [endpoint, options] = mockApiClient.mock.calls[0];
+    expect(endpoint).toBe('/files');
+    const opts = options as RequestInit;
+    expect(opts.method).toBe('POST');
+    expect(opts.body).toBeInstanceOf(FormData);
+  });
+
+  it('getFileMetadata unwraps envelope', async () => {
+    const api = await import('../files');
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'f1' } });
+    expect(await api.getFileMetadata('f1')).toEqual({ idKey: 'f1' });
+    expect(mockGet).toHaveBeenCalledWith('/files/f1/metadata');
+  });
+
+  it('downloadFile uses fetch directly', async () => {
+    const api = await import('../files');
+    const blob = new Blob(['x']);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      blob: () => Promise.resolve(blob),
+    } as unknown as Response);
+    vi.mocked(client.getAccessToken).mockReturnValue('tok');
+
+    try {
+      const out = await api.downloadFile('f1');
+      expect(out).toBe(blob);
+      const [url, opts] = fetchSpy.mock.calls[0];
+      expect(String(url)).toContain('/files/f1');
+      const headers = (opts as RequestInit).headers as Record<string, string>;
+      expect(headers['Authorization']).toBe('Bearer tok');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('downloadFile throws on non-ok', async () => {
+    const api = await import('../files');
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Nope',
+    } as unknown as Response);
+    try {
+      await expect(api.downloadFile('f1')).rejects.toThrow(/Failed to download file/);
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it('deleteFile deletes by idKey', async () => {
+    const api = await import('../files');
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.deleteFile('f1');
+    expect(mockDel).toHaveBeenCalledWith('/files/f1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('devicesApi deeper coverage', () => {
+  it('getDevices forwards filters + unwraps envelope', async () => {
+    const api = await import('../devices');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getDevices({
+      q: 'iPad',
+      campusId: 'c1',
+      includeInactive: true,
+      page: 2,
+      pageSize: 25,
+    });
+    const url = mockGet.mock.calls[0][0] as string;
+    expect(url).toContain('/devices?');
+    expect(url).toContain('q=iPad');
+    expect(url).toContain('campusIdKey=c1');
+    expect(url).toContain('includeInactive=true');
+    expect(url).toContain('page=2');
+    expect(url).toContain('pageSize=25');
+  });
+
+  it('getDeviceByIdKey / create / update / delete', async () => {
+    const api = await import('../devices');
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'd1' } });
+    await api.getDeviceByIdKey('d1');
+    expect(mockGet).toHaveBeenCalledWith('/devices/d1');
+
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'd1' } });
+    await api.createDevice({ name: 'iPad 1' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/devices', { name: 'iPad 1' });
+
+    mockPut.mockResolvedValueOnce({ data: { idKey: 'd1' } });
+    await api.updateDevice('d1', { name: 'iPad 2' } as never);
+    expect(mockPut).toHaveBeenCalledWith('/devices/d1', { name: 'iPad 2' });
+
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.deleteDevice('d1');
+    expect(mockDel).toHaveBeenCalledWith('/devices/d1');
+  });
+
+  it('generateKioskToken posts empty body', async () => {
+    const api = await import('../devices');
+    mockPost.mockResolvedValueOnce({ data: { token: 't', deviceIdKey: 'd1', deviceName: 'A' } });
+    const out = await api.generateKioskToken('d1');
+    expect(mockPost).toHaveBeenCalledWith('/devices/d1/token', {});
+    expect(out.token).toBe('t');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('importApi deeper coverage', () => {
+  it('uploadCsvPreview calls apiClient with FormData', async () => {
+    const api = await import('../import');
+    mockApiClient.mockResolvedValueOnce({ data: { headers: [] } } as never);
+    const file = new File(['a,b'], 'x.csv', { type: 'text/csv' });
+    await api.uploadCsvPreview(file);
+    const [endpoint, options] = mockApiClient.mock.calls[0];
+    expect(endpoint).toBe('/import/upload');
+    expect((options as RequestInit).method).toBe('POST');
+    expect((options as RequestInit).body).toBeInstanceOf(FormData);
+  });
+
+  it('getImportTemplates with/without type filter', async () => {
+    const api = await import('../import');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getImportTemplates();
+    expect(mockGet).toHaveBeenCalledWith('/import/templates');
+
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getImportTemplates('People');
+    expect(mockGet).toHaveBeenLastCalledWith('/import/templates?type=People');
+  });
+
+  it('getImportTemplate / createImportTemplate / deleteImportTemplate', async () => {
+    const api = await import('../import');
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'it1' } });
+    await api.getImportTemplate('it1');
+    expect(mockGet).toHaveBeenLastCalledWith('/import/templates/it1');
+
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'it1' } });
+    await api.createImportTemplate({ name: 'N' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/import/templates', { name: 'N' });
+
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.deleteImportTemplate('it1');
+    expect(mockDel).toHaveBeenCalledWith('/import/templates/it1');
+  });
+
+  it('validateImport sends FormData with mappings JSON', async () => {
+    const api = await import('../import');
+    mockApiClient.mockResolvedValueOnce({ data: { jobIdKey: 'j1' } } as never);
+    const file = new File(['a,b'], 'x.csv', { type: 'text/csv' });
+    await api.validateImport(file, 'People', { a: 'firstName' });
+    const [endpoint, options] = mockApiClient.mock.calls[0];
+    expect(endpoint).toBe('/import/validate');
+    expect((options as RequestInit).body).toBeInstanceOf(FormData);
+  });
+
+  it('executeImport includes templateIdKey when provided', async () => {
+    const api = await import('../import');
+    mockApiClient.mockResolvedValueOnce({ data: { idKey: 'j1' } } as never);
+    const file = new File(['a,b'], 'x.csv', { type: 'text/csv' });
+    await api.executeImport(file, 'People', {}, 'tpl1');
+    const [, options] = mockApiClient.mock.calls[0];
+    const body = (options as RequestInit).body as FormData;
+    expect(body.get('templateIdKey')).toBe('tpl1');
+    expect(body.get('importType')).toBe('People');
+  });
+
+  it('getImportJobs / getImportJobStatus', async () => {
+    const api = await import('../import');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getImportJobs();
+    expect(mockGet).toHaveBeenLastCalledWith('/import/jobs');
+
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await api.getImportJobs('People');
+    expect(mockGet).toHaveBeenLastCalledWith('/import/jobs?type=People');
+
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'j1' } });
+    await api.getImportJobStatus('j1');
+    expect(mockGet).toHaveBeenLastCalledWith('/import/jobs/j1');
+  });
+
+  it('downloadImportErrors uses fetch directly', async () => {
+    const api = await import('../import');
+    const blob = new Blob(['csv']);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      blob: () => Promise.resolve(blob),
+    } as unknown as Response);
+    vi.mocked(client.getAccessToken).mockReturnValue('tok');
+    try {
+      const out = await api.downloadImportErrors('j1');
+      expect(out).toBe(blob);
+      const [url] = fetchSpy.mock.calls[0];
+      expect(String(url)).toContain('/import/jobs/j1/errors');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('givingApi deeper coverage', () => {
+  it('getFund, getBatch, getBatchSummary unwrap envelopes', async () => {
+    const giving = await import('../giving');
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'f1' } });
+    expect(await giving.getFund('f1')).toEqual({ idKey: 'f1' });
+
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'b1' } });
+    expect(await giving.getBatch('b1')).toEqual({ idKey: 'b1' });
+
+    mockGet.mockResolvedValueOnce({ data: { totalAmount: 10 } });
+    expect(await giving.getBatchSummary('b1')).toEqual({ totalAmount: 10 });
+  });
+
+  it('deactivateFund deletes at /giving/admin/funds/:idKey', async () => {
+    const giving = await import('../giving');
+    mockDel.mockResolvedValueOnce(undefined);
+    await giving.deactivateFund('f1');
+    expect(mockDel).toHaveBeenCalledWith('/giving/admin/funds/f1');
+  });
+
+  it('getBatches forwards all filters and pagination', async () => {
+    const giving = await import('../giving');
+    mockGet.mockResolvedValueOnce({ data: [], meta: { page: 1 } });
+    await giving.getBatches({
+      status: 'Open',
+      campusIdKey: 'c1',
+      startDate: '2024-01-01',
+      endDate: '2024-02-01',
+      page: 2,
+      pageSize: 25,
+    });
+    const url = mockGet.mock.calls[0][0] as string;
+    expect(url).toContain('/giving/batches?');
+    expect(url).toContain('status=Open');
+    expect(url).toContain('campusIdKey=c1');
+    expect(url).toContain('startDate=2024-01-01');
+    expect(url).toContain('page=2');
+  });
+
+  it('openBatch / closeBatch post empty object body', async () => {
+    const giving = await import('../giving');
+    mockPost.mockResolvedValueOnce({ message: 'ok' });
+    await giving.openBatch('b1');
+    expect(mockPost).toHaveBeenCalledWith('/giving/batches/b1/open', {});
+
+    mockPost.mockResolvedValueOnce({ message: 'ok' });
+    await giving.closeBatch('b1');
+    expect(mockPost).toHaveBeenLastCalledWith('/giving/batches/b1/close', {});
+  });
+
+  it('createBatch and addContribution return body directly (no unwrap)', async () => {
+    const giving = await import('../giving');
+    mockPost.mockResolvedValueOnce({ idKey: 'b1' });
+    const out = await giving.createBatch({ name: 'Jan' } as never);
+    expect(out).toEqual({ idKey: 'b1' });
+
+    mockPost.mockResolvedValueOnce({ idKey: 'c1' });
+    const c = await giving.addContribution('b1', { amount: 10 } as never);
+    expect(c).toEqual({ idKey: 'c1' });
+    expect(mockPost).toHaveBeenLastCalledWith('/giving/batches/b1/contributions', {
+      amount: 10,
+    });
+  });
+
+  it('contribution get/update/delete hit /giving/contributions/:idKey', async () => {
+    const giving = await import('../giving');
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'c1' } });
+    await giving.getContribution('c1');
+    expect(mockGet).toHaveBeenLastCalledWith('/giving/contributions/c1');
+
+    mockPut.mockResolvedValueOnce({ data: { idKey: 'c1' } });
+    await giving.updateContribution('c1', { amount: 15 } as never);
+    expect(mockPut).toHaveBeenCalledWith('/giving/contributions/c1', { amount: 15 });
+
+    mockDel.mockResolvedValueOnce(undefined);
+    await giving.deleteContribution('c1');
+    expect(mockDel).toHaveBeenCalledWith('/giving/contributions/c1');
+  });
+
+  it('statements: getStatements default pagination; getStatement unwraps', async () => {
+    const giving = await import('../giving');
+    mockGet.mockResolvedValueOnce({ data: [], meta: {} });
+    await giving.getStatements();
+    const url = mockGet.mock.calls[0][0] as string;
+    expect(url).toContain('/giving/statements?');
+    expect(url).toContain('page=1');
+    expect(url).toContain('pageSize=25');
+
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'st1' } });
+    expect(await giving.getStatement('st1')).toEqual({ idKey: 'st1' });
+  });
+
+  it('previewStatement posts to preview', async () => {
+    const giving = await import('../giving');
+    mockPost.mockResolvedValueOnce({ data: { peopleCount: 5 } });
+    await giving.previewStatement({ startDate: 'a', endDate: 'b' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/giving/statements/preview', {
+      startDate: 'a',
+      endDate: 'b',
+    });
+  });
+
+  it('generateStatement returns body directly', async () => {
+    const giving = await import('../giving');
+    mockPost.mockResolvedValueOnce({ idKey: 'st1' });
+    const out = await giving.generateStatement({ startDate: 'a', endDate: 'b' } as never);
+    expect(out).toEqual({ idKey: 'st1' });
+  });
+
+  it('getEligiblePeople includes minimumAmount only when defined', async () => {
+    const giving = await import('../giving');
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await giving.getEligiblePeople('2024-01-01', '2024-02-01');
+    const url1 = mockGet.mock.calls.at(-1)?.[0] as string;
+    expect(url1).toContain('startDate=2024-01-01');
+    expect(url1).toContain('endDate=2024-02-01');
+    expect(url1).not.toContain('minimumAmount');
+
+    mockGet.mockResolvedValueOnce({ data: [] });
+    await giving.getEligiblePeople('2024-01-01', '2024-02-01', 25);
+    const url2 = mockGet.mock.calls.at(-1)?.[0] as string;
+    expect(url2).toContain('minimumAmount=25');
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('checkinOperationsApi (#482)', () => {
+  it('getCheckinOperationsDashboard unwraps envelope', async () => {
+    const api = await import('../checkinOperations');
+    mockGet.mockResolvedValueOnce({
+      data: { rooms: [], attendees: [], summary: {}, generatedAt: 'now' },
+    });
+    await api.getCheckinOperationsDashboard();
+    expect(mockGet).toHaveBeenCalledWith('/checkin-operations/dashboard');
+  });
+
+  it('toggleCheckinOperationsRoom encodes locationIdKey', async () => {
+    const api = await import('../checkinOperations');
+    mockPost.mockResolvedValueOnce({
+      data: { locationIdKey: 'abc/def', isOpen: true },
+    });
+    await api.toggleCheckinOperationsRoom('abc/def');
+    // encodeURIComponent turns `/` into `%2F`
+    expect(mockPost).toHaveBeenCalledWith(
+      '/checkin-operations/rooms/abc%2Fdef/toggle',
+      undefined
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+describe('groupsApi member endpoints', () => {
+  it('getGroupMembers builds status/role/pagination query', async () => {
+    const api = await import('../groups');
+    mockGet.mockResolvedValueOnce({ data: [], meta: {} });
+    await api.getGroupMembers('g1', {
+      status: 'Active',
+      roleId: 'r1',
+      page: 2,
+      pageSize: 25,
+    });
+    const url = mockGet.mock.calls[0][0] as string;
+    expect(url).toContain('/groups/g1/members?');
+    expect(url).toContain('status=Active');
+    expect(url).toContain('roleId=r1');
+    expect(url).toContain('page=2');
+    expect(url).toContain('pageSize=25');
+  });
+
+  it('addGroupMember posts + removeGroupMember deletes', async () => {
+    const api = await import('../groups');
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'm1' } });
+    await api.addGroupMember('g1', { personIdKey: 'p1' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/groups/g1/members', { personIdKey: 'p1' });
+
+    mockDel.mockResolvedValueOnce(undefined);
+    await api.removeGroupMember('g1', 'm1');
+    expect(mockDel).toHaveBeenCalledWith('/groups/g1/members/m1');
+  });
+});

--- a/src/web/src/test-utils/queryTestHarness.tsx
+++ b/src/web/src/test-utils/queryTestHarness.tsx
@@ -1,0 +1,54 @@
+/**
+ * Shared TanStack Query test harness.
+ *
+ * Hook tests that wrap `useQuery` / `useMutation` need a `QueryClientProvider`
+ * to function. Creating the client inline in each test duplicates the same
+ * defaults (disable retries, drop cache between tests) and invites drift.
+ *
+ * `createTestQueryClient` returns a fresh client configured for deterministic
+ * tests:
+ *   - `retry: false` so an API rejection surfaces immediately as `isError`.
+ *   - `staleTime: 0` / `gcTime: 0` so every test starts with a cold cache.
+ *
+ * `renderHookWithQuery` wraps `renderHook` with a provider that uses this
+ * client. Use it for every hook test that relies on a QueryClient.
+ */
+
+import type { ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, type RenderHookOptions } from '@testing-library/react';
+
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        staleTime: 0,
+        gcTime: 0,
+        // Vitest's happy-dom environment is always "visible"; disable
+        // refetch-on-mount timing effects for deterministic runs.
+        refetchOnWindowFocus: false,
+      },
+      mutations: {
+        retry: false,
+      },
+    },
+  });
+}
+
+type HarnessOptions<TProps> = RenderHookOptions<TProps> & {
+  /** Supply a pre-built client — useful when a test needs to seed cache. */
+  client?: QueryClient;
+};
+
+export function renderHookWithQuery<TResult, TProps>(
+  hook: (props: TProps) => TResult,
+  options?: HarnessOptions<TProps>
+) {
+  const client = options?.client ?? createTestQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  const result = renderHook(hook, { wrapper, ...options });
+  return { client, ...result };
+}

--- a/src/web/vitest.config.ts
+++ b/src/web/vitest.config.ts
@@ -31,17 +31,23 @@ export default defineConfig({
         'src/vite-env.d.ts',
       ],
       thresholds: {
-        // Honest-denominator floor. Wave 2 (#498) added tests for contexts,
-        // UI primitives, data-display components, and check-in flows against
-        // the full honest denominator. No new exclusions were added — every
-        // point of movement comes from real tests. Achieved floor:
-        //   lines 18.21, statements 18.23, functions 14.27, branches 15.33
-        // Thresholds set just below the achieved number (small buffer so
-        // minor churn does not break CI). Raise further in wave 3.
-        lines: 17,
-        statements: 17,
-        functions: 13,
-        branches: 14,
+        // Honest-denominator floor. Wave 3 (#498) added a shared
+        // renderHookWithQuery harness and tests for ~24 TanStack Query hook
+        // modules (campuses/families/people/groups/schedules/locations/
+        // giving/settings/profile/notifications/security-roles/auditLogs/
+        // devices/comms/comm-templates/checkin/personMerge/publicGroups/
+        // supervisorMode/supervisorAttendance/globalSearch/import/import-jobs/
+        // myGroups/checkinOperations/mutationWithToast + the 4 features/*
+        // api+hooks pairs (admin/defined-types, followups, pager,
+        // authorized-pickup) + deeper services/api coverage.
+        //   lines 32.15, statements 32.07, functions 36.82, branches 19.35
+        // Thresholds set ~1-2 pts below the achieved number (small buffer so
+        // minor churn does not break CI). No coverage.exclude changes — every
+        // point of movement comes from real tests.
+        lines: 30,
+        statements: 30,
+        functions: 34,
+        branches: 18,
         // Critical path: offline services must stay well tested.
         // These are higher than the global floor because offline queue bugs
         // cause silent check-in data loss.


### PR DESCRIPTION
## Summary

Wave 3 of #498 raises unit test coverage from the wave-2 floor (18.21% lines) to **32.15% lines** against the honest, full-source denominator. No `coverage.exclude` / `coverage.include` / `coverage.all` changes — every gain comes from real tests against real code.

### Coverage deltas (global)

| Metric | Before (wave 2) | After (wave 3) | Δ |
|---|---|---|---|
| Statements | 18.23% | **32.07%** | +13.84 |
| Branches   | 15.33% | **19.35%** | +4.02 |
| Functions  | 14.27% | **36.82%** | +22.55 |
| Lines      | 18.21% | **32.15%** | +13.94 |

### Per-bucket deltas

- **Hooks tier:** 8.64% → **~67% lines** (26/27 substantive hook files at 100%; remainder is `useNotificationHub`/`useOfflineCheckin`/`usePrintBridgeConnection`/`useQrScanner`, which are integration-heavy and belong in E2E)
- **services/api tier:** 52% → **85% lines**
- **services/offline tier:** unchanged at 84% (already critical-path)
- **test-utils:** new folder, 100% covered (by the hook tests that consume the harness)

Test count went from **687 → 1062** (+375 new tests).

### New threshold values

```ts
thresholds: {
  lines: 30, statements: 30, functions: 34, branches: 18,
  'src/services/offline/**/*.ts': { lines: 80, statements: 80, functions: 85, branches: 50 },
}
```

Set ~1–2 pts below the achieved floor to give minor-churn headroom without ratcheting accidentally above reality.

## Bucket A — Hooks tier (shared query harness + 25 hook tests)

### Shared test harness

- **`src/web/src/test-utils/queryTestHarness.tsx`** — `createTestQueryClient()` (retry: false, staleTime/gcTime: 0, refetchOnWindowFocus: false) + `renderHookWithQuery(hook, options)` that wraps `renderHook` in a fresh QueryClientProvider. Used by every hook test to keep them deterministic.

### Hook test files (each catches a real behavior regression)

- `useCampuses.test.tsx` — list/detail (idle→fetch), CRUD mutations invalidate `['campuses']`
- `useFamilies.test.tsx` — search params forwarded, add/remove member invalidate families + people
- `usePeople.test.tsx` — 16 tests; default 90-day attendance window, note CRUD invalidations
- `useGroups.test.tsx` — schedule attach/detach, attendance queries disabled until both keys provided
- `useSchedules.test.tsx` — occurrences default count=10, respects overrides
- `useLocations.test.tsx` — tree + flat list variants, CRUD invalidations
- `useDefinedTypes.test.tsx` — guard against empty-string idKey (`!!` falsy check)
- `useGroupTypes.test.tsx` — `includeArchived` default false
- `useNotifications.test.tsx` — mark-as-read invalidates unread-count + list + detail
- `useSettings.test.tsx` — 2FA setup/verify/disable all invalidate the status key
- `useProfile.test.tsx` — my-profile/my-family/my-involvement
- `useGiving.test.tsx` — 17 tests; batch open/close, contribution mutations invalidate per-batch summary + contributions, statement PDF download side-effect (anchor click, URL.createObjectURL → revokeObjectURL)
- `useSecurityRoles.test.tsx` — role + claim + member CRUD, double-invalidation of list + per-role detail
- `useMembershipRequests.test.tsx` — submit/process invalidate group-scoped keys
- `useMyGroups.test.tsx` — record attendance invalidates both `my-groups` and the admin `groups/:id/attendance` key (so the detail page refreshes without waiting for staleTime)
- `useAnalytics.test.tsx` — attendance analytics/trends/by-group + first-time-visitors
- `useDashboard.test.tsx` — success + error surfacing
- `useCommunications.test.tsx` — send / schedule / cancel-schedule / preview
- `useCheckinOperations.test.tsx` — live dashboard query (enabled/disabled gating) + toggle mutation invalidation; asserts on exported polling-interval constant (5000ms) to catch accidental changes
- `useAuth.test.tsx` — `useUser` / `useIsAuthenticated` correctly slice the AuthContext (no leak of full user from `useIsAuthenticated`)
- `useDevices.test.tsx` — kiosk token generation invalidates device-specific key
- `useAuditLogs.test.tsx` — export mutation creates download anchor with format-specific extension (csv/json/xlsx)
- `useRoomRoster.test.tsx` — multiple-room-rosters idle when list is empty or undefined
- `useCheckin.test.tsx` — kiosk search requires ≥2 chars, retry:false
- `usePersonMerge.test.tsx` — merge invalidates duplicates + people + mergeHistory
- `useCommunicationPreferences.test.tsx` — per-person preference invalidation
- `useCommunicationTemplates.test.tsx` — invalidation on BOTH onSuccess AND onError paths
- `usePublicGroups.test.tsx` — single-line wrapper default/param cases
- `useMutationWithToast.test.tsx` — function-vs-string success/error messages, default "please try again" toast never leaks raw error text
- `useImport.test.tsx` — wizard state-machine (upload → mapping → reset path)
- `useImportJobs.test.tsx` — client-side type filter
- `useSupervisorMode.test.tsx` — 2-minute inactivity timeout, `resetTimeout` pushes expiry forward, backend-expiry polling
- `useSupervisorAttendance.test.tsx` — flattens multi-roster response, sorts newest→oldest, wraps API errors with a prefix message
- `useGlobalSearch.test.tsx` — debounced query with 2-char minimum, recent-searches dedup + localStorage persistence, page resets on query/category change

## Bucket B — services/api push to 85%

### New `services.extra.test.ts` (71 tests)

Covers: `followups`, `pager`, `personMerge`, `pickup`, `authorizedPickup`, `publicGroups`, `communications` (full surface incl. preferences), `communicationTemplates`, `membershipRequests`, `myGroups`, `files` (FormData upload, fetch-based blob download + 4xx throw), `auditLogApi` (full filter forwarding + export blob), deeper `devices` / `import` (FormData preview+validate+execute) / `giving` (statements + contributions) / `checkinOperations` (IdKey URL-encoding for `/` in path), and `groups` member endpoints.

### New `services.admin.test.ts` (14 tests)

Covers: `securityRoles` (entire surface: roles + claims + members), deeper `people` (note CRUD, giving-summary, createPerson/updatePerson), deeper `checkin` (opportunities DTO mapping, `registerFamily`, `checkoutFromRoster`, offline-cache fallback when `navigator.onLine === false`).

## Bucket C — features/ tier (all four sub-features)

`src/features/{admin/defined-types,followups,pager,authorized-pickup}` each had their own `api.ts` + `hooks.ts` untested (collectively ~800 lines). Added tests for each; all 49 feature-tier tests pass.

## Forbidden list — none touched

- No production source code modified.
- No E2E specs modified.
- No `coverage.exclude` / `coverage.include` / `coverage.all` changes.
- No existing test file deleted or modified.
- No smoke-padding; every test asserts on a real URL / body / invalidation / DOM side-effect.
- No test mocks more than a handful of modules.

## Honest ceiling assessment

**50% is NOT reachable in one more wave** without moving into pages/large-component territory that is already covered by E2E specs. Concrete evidence:

- `pages/**` is ~3400 uncovered lines (25+ page components, each 100–900 lines). These orchestrate 5+ hooks, routing, forms, and modals — testing them as units requires mocking so many dependencies that the test becomes brittle and low-signal. Wave 2's instructions were explicit about this ("pages/large stateful components = E2E territory"), and wave 3 kept to that discipline.
- `components/admin` + `components/giving` + `components/import` are similarly heavy form/modal components.
- `services/printing/PrintBridgeClient.ts`, `hooks/useNotificationHub.ts`, `hooks/useOfflineCheckin.ts`, `hooks/useQrScanner.ts`, `hooks/usePrintBridgeConnection.ts`, `services/errorTracking.ts` all depend on WebSocket / SignalR / IndexedDB / MediaDevices / third-party error trackers — they need integration tests, not unit tests.

**Realistic unit-test ceiling: 35–40% lines.** To push meaningfully past 40% requires either:
1. Adding component integration tests for `pages/admin/families`, `pages/admin/groups`, `pages/admin/people` (each would be a substantial, multi-test file rendering the page against a mocked API + router).
2. Or explicitly migrating the page-level coverage story to E2E in CI (which is where those flows already get exercised via Playwright).

The hook + services-api + features layers are now thoroughly covered. Future coverage gains come from components/pages or E2E — not from squeezing more out of hooks/services.

## Test plan

- [x] `docker run node:20-alpine` → `npx vitest run --coverage` passes all thresholds
- [x] `npx tsc --noEmit` → 0 errors
- [x] `dotnet build` → green
- [x] `git diff --name-only` → only `test-utils/**`, `**/__tests__/**`, `*.test.{ts,tsx}`, and `vitest.config.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)