### PR TITLE
test(frontend): wave 4 — reach unit-test ceiling (#498)

### DIFF
--- a/src/web/src/api/__tests__/client.test.ts
+++ b/src/web/src/api/__tests__/client.test.ts
@@ -1,0 +1,199 @@
+/**
+ * api/client.ts tests
+ *
+ * Covers the low-level fetch wrapper:
+ *   - Attaches Authorization bearer when getAccessToken returns a token.
+ *   - Skips Authorization header when no token.
+ *   - Sets Content-Type: application/json by default on bodies.
+ *   - Preserves existing Content-Type if caller already set one.
+ *   - Throws ApiException on 401 and fires onUnauthorized callback.
+ *   - Throws ApiException on non-401 errors (e.g. 500).
+ *   - Happy path returns the fetched Response untouched.
+ *   - getApiClient / configureApiClient singleton semantics.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ApiClient,
+  ApiException,
+  configureApiClient,
+  getApiBaseUrl,
+  getApiClient,
+} from '../client';
+
+const makeResponse = (
+  status: number,
+  body: string = '',
+  headers: Record<string, string> = {}
+): Response => {
+  const headerMap = new Headers(headers);
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 401 ? 'Unauthorized' : `status ${status}`,
+    text: async () => body,
+    json: async () => (body ? JSON.parse(body) : null),
+    headers: headerMap,
+  } as unknown as Response;
+};
+
+describe('ApiClient', () => {
+  const fetchSpy = vi.fn();
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('attaches Authorization header when token returned', async () => {
+    fetchSpy.mockResolvedValueOnce(makeResponse(200, '{}'));
+    const client = new ApiClient({
+      baseUrl: 'https://api.test',
+      getAccessToken: async () => 'tkn',
+    });
+    await client.fetch('/ping');
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init.headers as Headers).get('Authorization')).toBe('Bearer tkn');
+  });
+
+  it('omits Authorization when token is null', async () => {
+    fetchSpy.mockResolvedValueOnce(makeResponse(200, '{}'));
+    const client = new ApiClient({
+      baseUrl: 'https://api.test',
+      getAccessToken: async () => null,
+    });
+    await client.fetch('/ping');
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init.headers as Headers).has('Authorization')).toBe(false);
+  });
+
+  it('works when no getAccessToken is configured', async () => {
+    fetchSpy.mockResolvedValueOnce(makeResponse(200, '{}'));
+    const client = new ApiClient({ baseUrl: 'https://api.test' });
+    const res = await client.fetch('/ping');
+    expect(res.status).toBe(200);
+  });
+
+  it('sets Content-Type to application/json when a body is provided', async () => {
+    fetchSpy.mockResolvedValueOnce(makeResponse(200, '{}'));
+    const client = new ApiClient({ baseUrl: 'https://api.test' });
+    await client.fetch('/create', { method: 'POST', body: '{"x":1}' });
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init.headers as Headers).get('Content-Type')).toBe('application/json');
+  });
+
+  it('preserves caller-supplied Content-Type', async () => {
+    fetchSpy.mockResolvedValueOnce(makeResponse(200, ''));
+    const client = new ApiClient({ baseUrl: 'https://api.test' });
+    const headers = new Headers({ 'Content-Type': 'multipart/form-data' });
+    await client.fetch('/upload', { method: 'POST', body: 'raw', headers });
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init.headers as Headers).get('Content-Type')).toBe('multipart/form-data');
+  });
+
+  it('does not set Content-Type when no body is supplied', async () => {
+    fetchSpy.mockResolvedValueOnce(makeResponse(200, ''));
+    const client = new ApiClient({ baseUrl: 'https://api.test' });
+    await client.fetch('/ping');
+    const [, init] = fetchSpy.mock.calls[0];
+    expect((init.headers as Headers).get('Content-Type')).toBeNull();
+  });
+
+  it('fires onUnauthorized and throws ApiException on 401', async () => {
+    fetchSpy.mockResolvedValueOnce(makeResponse(401, 'no token'));
+    const onUnauthorized = vi.fn();
+    const client = new ApiClient({
+      baseUrl: 'https://api.test',
+      onUnauthorized,
+    });
+    await expect(client.fetch('/secure')).rejects.toBeInstanceOf(ApiException);
+    expect(onUnauthorized).toHaveBeenCalled();
+  });
+
+  it('does not require onUnauthorized to be set on 401', async () => {
+    fetchSpy.mockResolvedValueOnce(makeResponse(401, ''));
+    const client = new ApiClient({ baseUrl: 'https://api.test' });
+    await expect(client.fetch('/secure')).rejects.toBeInstanceOf(ApiException);
+  });
+
+  it('throws ApiException on non-401 error with status/text', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      makeResponse(500, 'boom', { 'x-trace': 'abc' })
+    );
+    const client = new ApiClient({ baseUrl: 'https://api.test' });
+    try {
+      await client.fetch('/boom');
+      expect.unreachable();
+    } catch (e) {
+      expect(e).toBeInstanceOf(ApiException);
+      const err = e as ApiException;
+      expect(err.status).toBe(500);
+      expect(err.response).toBe('boom');
+      expect(err.headers['x-trace']).toBe('abc');
+    }
+  });
+
+  it('returns the Response on success', async () => {
+    const r = makeResponse(200, 'ok');
+    fetchSpy.mockResolvedValueOnce(r);
+    const client = new ApiClient({ baseUrl: 'https://api.test' });
+    const result = await client.fetch('/ping');
+    expect(result).toBe(r);
+  });
+
+  it('ApiException carries status, statusText, response, headers, result', () => {
+    const e = new ApiException(422, 'invalid', 'bad', { h: '1' }, { msg: 'x' });
+    expect(e.name).toBe('ApiException');
+    expect(e.status).toBe(422);
+    expect(e.message).toMatch(/422.*invalid/);
+    expect(e.headers.h).toBe('1');
+    expect(e.result).toEqual({ msg: 'x' });
+  });
+});
+
+describe('getApiBaseUrl', () => {
+  it('returns a non-empty URL (env default or provided)', () => {
+    const url = getApiBaseUrl();
+    expect(url.length).toBeGreaterThan(0);
+    expect(url).toMatch(/^http/);
+  });
+});
+
+describe('configureApiClient / getApiClient', () => {
+  const fetchSpy = vi.fn();
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('returns the configured client when configureApiClient is called', async () => {
+    configureApiClient({
+      baseUrl: 'https://configured.test',
+      getAccessToken: async () => 'ctok',
+    });
+    fetchSpy.mockResolvedValueOnce(makeResponse(200, ''));
+    const client = getApiClient();
+    await client.fetch('/x');
+    expect(fetchSpy.mock.calls[0][0]).toBe('https://configured.test/x');
+  });
+
+  it('falls back to env-based client when never configured', async () => {
+    // Force a reset via fresh module import
+    vi.resetModules();
+    const mod = await import('../client');
+    fetchSpy.mockResolvedValueOnce(makeResponse(200, ''));
+    const client = mod.getApiClient();
+    await client.fetch('/fallback');
+    // URL should resolve from env default to http://localhost:5000 or env var.
+    const url = fetchSpy.mock.calls[0][0];
+    expect(url).toMatch(/^http.*\/fallback$/);
+  });
+});

--- a/src/web/src/components/__tests__/RouteErrorBoundary.test.tsx
+++ b/src/web/src/components/__tests__/RouteErrorBoundary.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * RouteErrorBoundary tests
+ *
+ * Exercises every status-code branch plus the non-HTTP JS error path:
+ *   - 404 renders "Page Not Found" + Dashboard / Home links.
+ *   - 403 renders "Access Denied" + single Dashboard link.
+ *   - 500 renders "Server Error" + Reload button.
+ *   - Other HTTP statuses fall through to the generic HTTP error block.
+ *   - Non-HTTP errors (thrown Error) render the JS-error branch.
+ */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+import { RouteErrorBoundary } from '../RouteErrorBoundary';
+
+// Build a router whose loader throws the supplied value, forcing the
+// RouteErrorBoundary to render with that error.
+function renderWithError(error: unknown) {
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/',
+        loader: () => {
+          throw error;
+        },
+        element: <div>should not render</div>,
+        errorElement: <RouteErrorBoundary />,
+      },
+    ],
+    { initialEntries: ['/'] }
+  );
+  return render(<RouterProvider router={router} />);
+}
+
+describe('RouteErrorBoundary', () => {
+  it('renders 404 branch for 404 route errors', async () => {
+    renderWithError(new Response(null, { status: 404 }));
+    expect(await screen.findByText('404')).toBeInTheDocument();
+    expect(screen.getByText(/page not found/i)).toBeInTheDocument();
+    // Both CTA links present.
+    expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /go home/i })).toBeInTheDocument();
+  });
+
+  it('renders 403 branch for 403 route errors', async () => {
+    renderWithError(new Response(null, { status: 403 }));
+    expect(await screen.findByText('403')).toBeInTheDocument();
+    expect(screen.getByText(/access denied/i)).toBeInTheDocument();
+  });
+
+  it('renders 500 branch with reload button', async () => {
+    renderWithError(new Response(null, { status: 500 }));
+    expect(await screen.findByText('500')).toBeInTheDocument();
+    expect(screen.getByText(/server error/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /reload/i })).toBeInTheDocument();
+  });
+
+  it('renders generic HTTP branch for other statuses', async () => {
+    renderWithError(new Response(null, { status: 418, statusText: "I'm a teapot" }));
+    expect(await screen.findByText('418')).toBeInTheDocument();
+    expect(screen.getByText(/teapot/i)).toBeInTheDocument();
+  });
+
+  it('renders JS-error branch when thrown value is a plain Error', async () => {
+    renderWithError(new Error('boom'));
+    expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument();
+    // Two CTAs (reload button + dashboard link).
+    expect(screen.getByRole('button', { name: /reload/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /dashboard/i })).toBeInTheDocument();
+  });
+
+  it('wraps non-Error throws in a new Error object for JS branch', async () => {
+    renderWithError('string error');
+    expect(await screen.findByText(/something went wrong/i)).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/common/__tests__/PhotoUpload.test.tsx
+++ b/src/web/src/components/common/__tests__/PhotoUpload.test.tsx
@@ -1,0 +1,159 @@
+/**
+ * PhotoUpload tests
+ *
+ * Exercises validation, drag-drop, file-input, and preview branches:
+ *   - Default render shows dropzone + "Browse Files".
+ *   - Drag enter / leave toggles the blue border state.
+ *   - validateFile: rejects unknown types, rejects files > maxSize.
+ *   - handleFile on valid file: creates object URL, shows preview, fires onFileSelect.
+ *   - Clear preview resets state and revokes the URL.
+ *   - File input onChange path picks the first file.
+ *   - Error banner shows last validation error.
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PhotoUpload } from '../PhotoUpload';
+
+const makeFile = (
+  name: string,
+  size: number,
+  type: string = 'image/png'
+): File => {
+  const file = new File(['x'.repeat(size)], name, { type });
+  // In happy-dom File `size` is inferred from content length; force if needed.
+  Object.defineProperty(file, 'size', { value: size });
+  return file;
+};
+
+describe('PhotoUpload', () => {
+  beforeEach(() => {
+    // Provide object URL stubs; happy-dom has them but restore cleanly between tests.
+    const urls: string[] = [];
+    vi.spyOn(URL, 'createObjectURL').mockImplementation((_obj) => {
+      const url = `blob:mock-${urls.length}`;
+      urls.push(url);
+      return url;
+    });
+    vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders dropzone with Browse Files CTA by default', () => {
+    render(<PhotoUpload onFileSelect={vi.fn()} />);
+    expect(screen.getByText(/drag and drop/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /browse files/i })).toBeInTheDocument();
+  });
+
+  it('drag enter/leave toggle the dragging class on the dropzone', () => {
+    const { container } = render(<PhotoUpload onFileSelect={vi.fn()} />);
+    const zone = container.querySelector('[class*="border-dashed"]') as HTMLElement;
+    expect(zone).toBeTruthy();
+    act(() => {
+      zone.dispatchEvent(new DragEvent('dragenter', { bubbles: true }));
+    });
+    expect(zone.className).toMatch(/border-blue-500/);
+    act(() => {
+      zone.dispatchEvent(new DragEvent('dragleave', { bubbles: true }));
+    });
+    expect(zone.className).not.toMatch(/border-blue-500/);
+  });
+
+  it('rejects invalid file types with an error banner', async () => {
+    const onFileSelect = vi.fn();
+    render(<PhotoUpload onFileSelect={onFileSelect} />);
+    const input = screen.getByLabelText(/file input/i) as HTMLInputElement;
+    const bad = makeFile('evil.txt', 100, 'text/plain');
+    // fireEvent.change bypasses the browser's accept-attribute gate that
+    // userEvent.upload enforces; the component still receives the onChange
+    // event and runs its own validateFile().
+    act(() => {
+      fireEvent.change(input, { target: { files: [bad] } });
+    });
+    expect(screen.getByText(/please select a valid image file/i)).toBeInTheDocument();
+    expect(onFileSelect).not.toHaveBeenCalled();
+  });
+
+  it('rejects files larger than maxSizeMB', async () => {
+    const onFileSelect = vi.fn();
+    render(<PhotoUpload onFileSelect={onFileSelect} maxSizeMB={1} />);
+    const input = screen.getByLabelText(/file input/i) as HTMLInputElement;
+    // 2 MB file while maxSize=1 MB.
+    const big = makeFile('big.png', 2 * 1024 * 1024, 'image/png');
+    await act(async () => {
+      await userEvent.upload(input, big);
+    });
+    expect(screen.getByText(/must be less than 1mb/i)).toBeInTheDocument();
+    expect(onFileSelect).not.toHaveBeenCalled();
+  });
+
+  it('happy path: valid file creates preview and calls onFileSelect', async () => {
+    const onFileSelect = vi.fn();
+    render(<PhotoUpload onFileSelect={onFileSelect} />);
+    const input = screen.getByLabelText(/file input/i) as HTMLInputElement;
+    const good = makeFile('pic.png', 500, 'image/png');
+    await act(async () => {
+      await userEvent.upload(input, good);
+    });
+    expect(onFileSelect).toHaveBeenCalledWith(good);
+    // Preview image renders
+    const preview = screen.getByRole('img', { name: /preview/i });
+    expect(preview).toHaveAttribute('src', expect.stringContaining('blob:mock'));
+  });
+
+  it('Clear preview button revokes URL and returns to dropzone', async () => {
+    const user = userEvent.setup();
+    render(<PhotoUpload onFileSelect={vi.fn()} />);
+    const input = screen.getByLabelText(/file input/i) as HTMLInputElement;
+    await act(async () => {
+      await userEvent.upload(input, makeFile('p.png', 100, 'image/png'));
+    });
+    expect(screen.getByRole('img', { name: /preview/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /clear preview/i }));
+    expect(screen.queryByRole('img', { name: /preview/i })).toBeNull();
+    expect(URL.revokeObjectURL).toHaveBeenCalled();
+  });
+
+  it('Browse Files click triggers the hidden file input', async () => {
+    const user = userEvent.setup();
+    render(<PhotoUpload onFileSelect={vi.fn()} />);
+    const input = screen.getByLabelText(/file input/i) as HTMLInputElement;
+    const spy = vi.spyOn(input, 'click');
+    await user.click(screen.getByRole('button', { name: /browse files/i }));
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('drop event with a file triggers validation + onFileSelect', () => {
+    const onFileSelect = vi.fn();
+    const { container } = render(<PhotoUpload onFileSelect={onFileSelect} />);
+    const zone = container.querySelector('[class*="border-dashed"]') as HTMLElement;
+    const file = makeFile('dragged.png', 100, 'image/png');
+    const dropEvent = new DragEvent('drop', { bubbles: true });
+    // Attach files to the event
+    Object.defineProperty(dropEvent, 'dataTransfer', {
+      value: { files: [file] },
+    });
+    act(() => {
+      zone.dispatchEvent(dropEvent);
+    });
+    expect(onFileSelect).toHaveBeenCalledWith(file);
+  });
+
+  it('drop with no files is a no-op', () => {
+    const onFileSelect = vi.fn();
+    const { container } = render(<PhotoUpload onFileSelect={onFileSelect} />);
+    const zone = container.querySelector('[class*="border-dashed"]') as HTMLElement;
+    const dropEvent = new DragEvent('drop', { bubbles: true });
+    Object.defineProperty(dropEvent, 'dataTransfer', {
+      value: { files: [] },
+    });
+    act(() => {
+      zone.dispatchEvent(dropEvent);
+    });
+    expect(onFileSelect).not.toHaveBeenCalled();
+  });
+});

--- a/src/web/src/components/groups/__tests__/GroupCard.test.tsx
+++ b/src/web/src/components/groups/__tests__/GroupCard.test.tsx
@@ -1,0 +1,174 @@
+/**
+ * GroupCard (public groups) tests
+ *
+ * Catches regressions in:
+ *   - Renders name + publicDescription when given.
+ *   - Campus / groupType / openings badges show conditionally.
+ *   - "Full" badge replaces "Open" when hasOpenings=false.
+ *   - Meeting schedule line renders only when summary is present.
+ *   - Member count shows "N members" with optional "/ capacity".
+ *   - Renders as <button> when onClick supplied; onClick fires with the group.
+ *   - Renders as <div> when no onClick.
+ *   - Request to Join button only when showRequestButton && hasOpenings;
+ *     clicking stops propagation and opens the modal.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../RequestToJoinModal', () => ({
+  RequestToJoinModal: ({
+    isOpen,
+    groupName,
+    onClose,
+  }: {
+    isOpen: boolean;
+    groupName: string;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="rtj-modal">
+        <span>modal:{groupName}</span>
+        <button onClick={onClose}>modal-close</button>
+      </div>
+    ) : null,
+}));
+
+import { GroupCard } from '../GroupCard';
+
+const baseGroup = {
+  idKey: 'g1',
+  name: 'Alpha',
+  publicDescription: 'Fun group',
+  campusName: 'Main',
+  groupTypeName: 'Small Group',
+  meetingScheduleSummary: 'Sundays 10am',
+  memberCount: 5,
+  capacity: 10,
+  hasOpenings: true,
+};
+
+describe('GroupCard (public)', () => {
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders name and description', () => {
+    render(<GroupCard group={baseGroup as never} />);
+    expect(screen.getByRole('heading', { name: 'Alpha' })).toBeInTheDocument();
+    expect(screen.getByText('Fun group')).toBeInTheDocument();
+  });
+
+  it('hides description when missing', () => {
+    render(
+      <GroupCard group={{ ...baseGroup, publicDescription: '' } as never} />
+    );
+    expect(screen.queryByText('Fun group')).toBeNull();
+  });
+
+  it('renders campus + group type badges', () => {
+    render(<GroupCard group={baseGroup as never} />);
+    expect(screen.getByText('Main')).toBeInTheDocument();
+    expect(screen.getByText('Small Group')).toBeInTheDocument();
+  });
+
+  it('renders Open badge when hasOpenings=true', () => {
+    render(<GroupCard group={baseGroup as never} />);
+    expect(screen.getByText('Open')).toBeInTheDocument();
+    expect(screen.queryByText('Full')).toBeNull();
+  });
+
+  it('renders Full badge when hasOpenings=false', () => {
+    render(
+      <GroupCard group={{ ...baseGroup, hasOpenings: false } as never} />
+    );
+    expect(screen.getByText('Full')).toBeInTheDocument();
+    expect(screen.queryByText('Open')).toBeNull();
+  });
+
+  it('shows meeting schedule summary when present', () => {
+    render(<GroupCard group={baseGroup as never} />);
+    expect(screen.getByText('Sundays 10am')).toBeInTheDocument();
+  });
+
+  it('omits meeting schedule when summary empty', () => {
+    render(
+      <GroupCard
+        group={{ ...baseGroup, meetingScheduleSummary: '' } as never}
+      />
+    );
+    expect(screen.queryByText('Sundays 10am')).toBeNull();
+  });
+
+  it('renders member count with capacity', () => {
+    render(<GroupCard group={baseGroup as never} />);
+    expect(screen.getByText(/5 \/ 10 members/i)).toBeInTheDocument();
+  });
+
+  it('renders member count without capacity when capacity is nullish', () => {
+    const { container } = render(
+      <GroupCard group={{ ...baseGroup, capacity: null } as never} />
+    );
+    // Should show "5" then " members" (no slash).
+    expect(container.textContent).toMatch(/5\s*members/);
+    expect(container.textContent).not.toMatch(/5 \/ /);
+  });
+
+  it('renders as <button> when onClick is provided and fires with the group', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(<GroupCard group={baseGroup as never} onClick={onClick} />);
+    const button = screen.getByRole('button', { name: /alpha/i });
+    await user.click(button);
+    expect(onClick).toHaveBeenCalledWith(baseGroup);
+  });
+
+  it('renders as <div> when onClick is not provided (no cursor-pointer ring class)', () => {
+    const { container } = render(<GroupCard group={baseGroup as never} />);
+    // The element doesn't have role="button"
+    const element = container.querySelector('h3')!.closest('div, button');
+    expect(element?.tagName).toBe('DIV');
+  });
+
+  it('opens Request-to-Join modal when button clicked; propagation is stopped', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(<GroupCard group={baseGroup as never} onClick={onClick} />);
+    // Button has exact text; distinguish from the card's accessible name which
+    // includes the whole card text.
+    const buttons = screen.getAllByRole('button');
+    const joinBtn = buttons.find((b) => b.textContent === 'Request to Join');
+    expect(joinBtn).toBeTruthy();
+    await user.click(joinBtn!);
+    expect(screen.getByTestId('rtj-modal')).toBeInTheDocument();
+    expect(screen.getByText('modal:Alpha')).toBeInTheDocument();
+    // onClick on the card must NOT have fired because the button stopped propagation.
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('hides Request-to-Join button when showRequestButton=false', () => {
+    render(
+      <GroupCard group={baseGroup as never} showRequestButton={false} />
+    );
+    expect(screen.queryByRole('button', { name: /request to join/i })).toBeNull();
+  });
+
+  it('hides Request-to-Join button when no openings even if showRequestButton=true', () => {
+    render(
+      <GroupCard
+        group={{ ...baseGroup, hasOpenings: false } as never}
+        showRequestButton
+      />
+    );
+    expect(screen.queryByRole('button', { name: /request to join/i })).toBeNull();
+  });
+
+  it('closes the modal on close click', async () => {
+    const user = userEvent.setup();
+    render(<GroupCard group={baseGroup as never} />);
+    // Without onClick, the outer element is a div; the only button in the
+    // tree is "Request to Join".
+    await user.click(screen.getByRole('button', { name: 'Request to Join' }));
+    expect(screen.getByTestId('rtj-modal')).toBeInTheDocument();
+    await user.click(screen.getByText('modal-close'));
+    expect(screen.queryByTestId('rtj-modal')).toBeNull();
+  });
+});

--- a/src/web/src/components/groups/__tests__/PendingRequestsList.test.tsx
+++ b/src/web/src/components/groups/__tests__/PendingRequestsList.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * PendingRequestsList tests
+ *
+ * Branches:
+ *   - Loading -> spinner.
+ *   - Empty requests -> "No pending requests".
+ *   - Renders one button per request with requester name + date.
+ *   - Shows request note preview when requestNote present.
+ *   - Clicking a request opens the review modal with that request.
+ *   - Approve / Deny handlers call processRequest mutation with correct shape.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUsePendingRequests = vi.fn();
+const mockMutateAsync = vi.fn();
+
+vi.mock('@/hooks/useMembershipRequests', () => ({
+  usePendingRequests: (groupIdKey: string) => mockUsePendingRequests(groupIdKey),
+  useProcessRequest: () => ({ mutateAsync: mockMutateAsync }),
+}));
+
+// Capture the props passed into the modal.
+vi.mock('../RequestReviewModal', () => ({
+  RequestReviewModal: ({
+    isOpen,
+    request,
+    onApprove,
+    onDeny,
+    onClose,
+  }: {
+    isOpen: boolean;
+    request: { idKey: string } | null;
+    onApprove: (id: string, note?: string) => void;
+    onDeny: (id: string, note?: string) => void;
+    onClose: () => void;
+  }) =>
+    isOpen ? (
+      <div data-testid="review-modal">
+        <span>modal:{request?.idKey}</span>
+        <button onClick={() => onApprove(request!.idKey, 'ok')}>approve</button>
+        <button onClick={() => onDeny(request!.idKey, 'no')}>deny</button>
+        <button onClick={onClose}>close</button>
+      </div>
+    ) : null,
+}));
+
+import { PendingRequestsList } from '../PendingRequestsList';
+
+describe('PendingRequestsList', () => {
+  beforeEach(() => {
+    mockUsePendingRequests.mockReset();
+    mockMutateAsync.mockReset();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders loading spinner', () => {
+    mockUsePendingRequests.mockReturnValue({ data: undefined, isLoading: true });
+    const { container } = render(<PendingRequestsList groupIdKey="g1" />);
+    // Spinner has animate-spin class.
+    expect(container.querySelector('.animate-spin')).toBeTruthy();
+  });
+
+  it('renders "No pending requests" when empty', () => {
+    mockUsePendingRequests.mockReturnValue({ data: [], isLoading: false });
+    render(<PendingRequestsList groupIdKey="g1" />);
+    expect(screen.getByText(/no pending requests/i)).toBeInTheDocument();
+  });
+
+  it('renders one button per request with requester name + request note', () => {
+    mockUsePendingRequests.mockReturnValue({
+      data: [
+        {
+          idKey: 'r1',
+          requester: { fullName: 'Alice Req' },
+          createdDateTime: '2026-04-01T10:00:00Z',
+          requestNote: 'please',
+        },
+        {
+          idKey: 'r2',
+          requester: { fullName: 'Bob Req' },
+          createdDateTime: '2026-04-01T11:00:00Z',
+          requestNote: '',
+        },
+      ],
+      isLoading: false,
+    });
+    render(<PendingRequestsList groupIdKey="g1" />);
+    expect(screen.getByText('Alice Req')).toBeInTheDocument();
+    expect(screen.getByText('Bob Req')).toBeInTheDocument();
+    expect(screen.getByText('please')).toBeInTheDocument();
+  });
+
+  it('clicking a request opens the modal with that request', async () => {
+    mockUsePendingRequests.mockReturnValue({
+      data: [
+        {
+          idKey: 'r1',
+          requester: { fullName: 'Alice Req' },
+          createdDateTime: '2026-04-01T10:00:00Z',
+          requestNote: '',
+        },
+      ],
+      isLoading: false,
+    });
+    const user = userEvent.setup();
+    render(<PendingRequestsList groupIdKey="g1" />);
+    await user.click(screen.getByText('Alice Req'));
+    expect(screen.getByTestId('review-modal')).toBeInTheDocument();
+    expect(screen.getByText('modal:r1')).toBeInTheDocument();
+  });
+
+  it('Approve in modal mutates with status=Approved and passes note', async () => {
+    mockUsePendingRequests.mockReturnValue({
+      data: [
+        {
+          idKey: 'r1',
+          requester: { fullName: 'Alice' },
+          createdDateTime: '2026-04-01T10:00:00Z',
+          requestNote: '',
+        },
+      ],
+      isLoading: false,
+    });
+    mockMutateAsync.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    render(<PendingRequestsList groupIdKey="g1" />);
+    await user.click(screen.getByText('Alice'));
+    await user.click(screen.getByText('approve'));
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      requestIdKey: 'r1',
+      request: { status: 'Approved', note: 'ok' },
+    });
+  });
+
+  it('Deny in modal mutates with status=Denied', async () => {
+    mockUsePendingRequests.mockReturnValue({
+      data: [
+        {
+          idKey: 'r1',
+          requester: { fullName: 'Alice' },
+          createdDateTime: '2026-04-01T10:00:00Z',
+          requestNote: '',
+        },
+      ],
+      isLoading: false,
+    });
+    mockMutateAsync.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    render(<PendingRequestsList groupIdKey="g1" />);
+    await user.click(screen.getByText('Alice'));
+    await user.click(screen.getByText('deny'));
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      requestIdKey: 'r1',
+      request: { status: 'Denied', note: 'no' },
+    });
+  });
+
+  it('close in modal clears selection (modal unmounts)', async () => {
+    mockUsePendingRequests.mockReturnValue({
+      data: [
+        {
+          idKey: 'r1',
+          requester: { fullName: 'Alice' },
+          createdDateTime: '2026-04-01T10:00:00Z',
+          requestNote: '',
+        },
+      ],
+      isLoading: false,
+    });
+    const user = userEvent.setup();
+    render(<PendingRequestsList groupIdKey="g1" />);
+    await user.click(screen.getByText('Alice'));
+    expect(screen.getByTestId('review-modal')).toBeInTheDocument();
+    await user.click(screen.getByText('close'));
+    expect(screen.queryByTestId('review-modal')).toBeNull();
+  });
+
+  it('uses empty list fallback when data is undefined', () => {
+    mockUsePendingRequests.mockReturnValue({ data: undefined, isLoading: false });
+    render(<PendingRequestsList groupIdKey="g1" />);
+    expect(screen.getByText(/no pending requests/i)).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/groups/__tests__/RequestToJoinModal.test.tsx
+++ b/src/web/src/components/groups/__tests__/RequestToJoinModal.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * RequestToJoinModal tests
+ *
+ * Branches:
+ *   - Closed (isOpen=false) renders nothing.
+ *   - Open renders header, groupName, textarea, counter.
+ *   - Submit calls submitMutation.mutateAsync with trimmed note; empty -> undefined.
+ *   - Error message displayed on mutation rejection.
+ *   - Success view shown when mutation resolves.
+ *   - Close button fires onClose (disabled while pending).
+ *   - Escape key triggers close.
+ *   - Backdrop click triggers close.
+ */
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mutation: {
+  mutateAsync: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+};
+
+vi.mock('@/hooks/useMembershipRequests', () => ({
+  useSubmitMembershipRequest: () => mutation,
+}));
+
+import { RequestToJoinModal } from '../RequestToJoinModal';
+
+describe('RequestToJoinModal', () => {
+  beforeEach(() => {
+    mutation = {
+      mutateAsync: vi.fn().mockResolvedValue(undefined),
+      isPending: false,
+    };
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders nothing when isOpen=false', () => {
+    const { container } = render(
+      <RequestToJoinModal
+        isOpen={false}
+        onClose={vi.fn()}
+        groupIdKey="g1"
+        groupName="Alpha"
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders header + groupName + textarea when open', () => {
+    render(
+      <RequestToJoinModal
+        isOpen
+        onClose={vi.fn()}
+        groupIdKey="g1"
+        groupName="Alpha"
+      />
+    );
+    expect(screen.getByRole('heading', { name: /request to join group/i })).toBeInTheDocument();
+    expect(screen.getByText('Alpha')).toBeInTheDocument();
+    expect(screen.getByLabelText(/message/i)).toBeInTheDocument();
+  });
+
+  it('submit with trimmed note calls mutateAsync with note', async () => {
+    const user = userEvent.setup();
+    render(
+      <RequestToJoinModal
+        isOpen
+        onClose={vi.fn()}
+        groupIdKey="g1"
+        groupName="Alpha"
+      />
+    );
+    await user.type(screen.getByLabelText(/message/i), '  please  ');
+    await user.click(screen.getByRole('button', { name: /submit request/i }));
+    expect(mutation.mutateAsync).toHaveBeenCalledWith({ note: 'please' });
+  });
+
+  it('submit with empty note sends undefined', async () => {
+    const user = userEvent.setup();
+    render(
+      <RequestToJoinModal
+        isOpen
+        onClose={vi.fn()}
+        groupIdKey="g1"
+        groupName="Alpha"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /submit request/i }));
+    expect(mutation.mutateAsync).toHaveBeenCalledWith({ note: undefined });
+  });
+
+  it('displays Error.message when mutation rejects with Error', async () => {
+    mutation.mutateAsync = vi.fn().mockRejectedValue(new Error('already a member'));
+    const user = userEvent.setup();
+    render(
+      <RequestToJoinModal
+        isOpen
+        onClose={vi.fn()}
+        groupIdKey="g1"
+        groupName="Alpha"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /submit request/i }));
+    expect(await screen.findByText(/already a member/)).toBeInTheDocument();
+  });
+
+  it('displays default error when rejection is not Error', async () => {
+    mutation.mutateAsync = vi.fn().mockRejectedValue('raw');
+    const user = userEvent.setup();
+    render(
+      <RequestToJoinModal
+        isOpen
+        onClose={vi.fn()}
+        groupIdKey="g1"
+        groupName="Alpha"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /submit request/i }));
+    expect(await screen.findByText(/failed to submit request/i)).toBeInTheDocument();
+  });
+
+  it('shows success view after successful submit', async () => {
+    const user = userEvent.setup();
+    render(
+      <RequestToJoinModal
+        isOpen
+        onClose={vi.fn()}
+        groupIdKey="g1"
+        groupName="Alpha"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /submit request/i }));
+    expect(await screen.findByText(/request submitted/i)).toBeInTheDocument();
+  });
+
+  it('Close button fires onClose', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <RequestToJoinModal
+        isOpen
+        onClose={onClose}
+        groupIdKey="g1"
+        groupName="Alpha"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Cancel button fires onClose', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <RequestToJoinModal
+        isOpen
+        onClose={onClose}
+        groupIdKey="g1"
+        groupName="Alpha"
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Escape key triggers close', () => {
+    const onClose = vi.fn();
+    render(
+      <RequestToJoinModal
+        isOpen
+        onClose={onClose}
+        groupIdKey="g1"
+        groupName="Alpha"
+      />
+    );
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Close button is disabled while mutation is pending', () => {
+    mutation.isPending = true;
+    render(
+      <RequestToJoinModal
+        isOpen
+        onClose={vi.fn()}
+        groupIdKey="g1"
+        groupName="Alpha"
+      />
+    );
+    expect(screen.getByRole('button', { name: /close/i })).toBeDisabled();
+  });
+
+  it('counter tracks note length', async () => {
+    const user = userEvent.setup();
+    render(
+      <RequestToJoinModal
+        isOpen
+        onClose={vi.fn()}
+        groupIdKey="g1"
+        groupName="Alpha"
+      />
+    );
+    await user.type(screen.getByLabelText(/message/i), 'hello');
+    expect(screen.getByText(/5\/2000/)).toBeInTheDocument();
+  });
+});

--- a/src/web/src/components/notifications/__tests__/NotificationList.test.tsx
+++ b/src/web/src/components/notifications/__tests__/NotificationList.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * NotificationList tests
+ *
+ * Branches:
+ *   - Loading -> "Loading notifications..." text.
+ *   - Error -> "Failed to load notifications" panel.
+ *   - Empty state with unreadOnly toggle changes title/description.
+ *   - Populated state renders one NotificationItem per item.
+ *   - Click with onNotificationClick prefers the prop callback.
+ *   - Click without prop navigates to actionUrl (if present).
+ *   - Mark-as-read and delete handlers call mutations with idKey.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockUseNotifications = vi.fn();
+const mockMarkMutate = vi.fn();
+const mockDeleteMutate = vi.fn();
+const mockNavigate = vi.fn();
+
+vi.mock('@/hooks/useNotifications', () => ({
+  useNotifications: (unreadOnly?: boolean, limit?: number) =>
+    mockUseNotifications(unreadOnly, limit),
+  useMarkAsRead: () => ({ mutate: mockMarkMutate }),
+  useDeleteNotification: () => ({ mutate: mockDeleteMutate }),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom'
+  );
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+// Replace NotificationItem with a test-friendly stub so we can drive it.
+vi.mock('../NotificationItem', () => ({
+  NotificationItem: ({
+    notification,
+    onMarkAsRead,
+    onDelete,
+    onClick,
+  }: {
+    notification: { idKey: string; title: string };
+    onMarkAsRead: (id: string) => void;
+    onDelete: (id: string) => void;
+    onClick: (n: unknown) => void;
+  }) => (
+    <div data-testid={`notif-${notification.idKey}`}>
+      <span>{notification.title}</span>
+      <button onClick={() => onClick(notification)}>click</button>
+      <button onClick={() => onMarkAsRead(notification.idKey)}>read</button>
+      <button onClick={() => onDelete(notification.idKey)}>delete</button>
+    </div>
+  ),
+}));
+
+import { NotificationList } from '../NotificationList';
+
+const wrap = (ui: React.ReactElement) => (
+  <MemoryRouter>{ui}</MemoryRouter>
+);
+
+describe('NotificationList', () => {
+  beforeEach(() => {
+    mockUseNotifications.mockReset();
+    mockMarkMutate.mockReset();
+    mockDeleteMutate.mockReset();
+    mockNavigate.mockReset();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders loading state', () => {
+    mockUseNotifications.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+    render(wrap(<NotificationList />));
+    expect(screen.getByText(/loading notifications/i)).toBeInTheDocument();
+  });
+
+  it('renders error state', () => {
+    mockUseNotifications.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('x'),
+    });
+    render(wrap(<NotificationList />));
+    expect(screen.getByText(/failed to load notifications/i)).toBeInTheDocument();
+  });
+
+  it('renders "No notifications" empty state when unreadOnly=false', () => {
+    mockUseNotifications.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+    render(wrap(<NotificationList />));
+    expect(screen.getByText(/^no notifications$/i)).toBeInTheDocument();
+    expect(screen.getByText(/don't have any notifications yet/i)).toBeInTheDocument();
+  });
+
+  it('renders "No unread notifications" empty state when unreadOnly=true', () => {
+    mockUseNotifications.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+    render(wrap(<NotificationList unreadOnly />));
+    expect(screen.getByText(/no unread notifications/i)).toBeInTheDocument();
+  });
+
+  it('renders NotificationItem per notification', () => {
+    mockUseNotifications.mockReturnValue({
+      data: [
+        { idKey: 'n1', title: 'First' },
+        { idKey: 'n2', title: 'Second' },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    render(wrap(<NotificationList />));
+    expect(screen.getByTestId('notif-n1')).toBeInTheDocument();
+    expect(screen.getByTestId('notif-n2')).toBeInTheDocument();
+  });
+
+  it('prefers onNotificationClick prop callback when provided', async () => {
+    mockUseNotifications.mockReturnValue({
+      data: [{ idKey: 'n1', title: 'First', actionUrl: '/somewhere' }],
+      isLoading: false,
+      error: null,
+    });
+    const user = userEvent.setup();
+    const onNotificationClick = vi.fn();
+    render(wrap(<NotificationList onNotificationClick={onNotificationClick} />));
+    await user.click(screen.getByText('click'));
+    expect(onNotificationClick).toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to actionUrl when no callback is provided', async () => {
+    mockUseNotifications.mockReturnValue({
+      data: [{ idKey: 'n1', title: 'First', actionUrl: '/target' }],
+      isLoading: false,
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(wrap(<NotificationList />));
+    await user.click(screen.getByText('click'));
+    expect(mockNavigate).toHaveBeenCalledWith('/target');
+  });
+
+  it('does nothing on click when no callback and no actionUrl', async () => {
+    mockUseNotifications.mockReturnValue({
+      data: [{ idKey: 'n1', title: 'First' }],
+      isLoading: false,
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(wrap(<NotificationList />));
+    await user.click(screen.getByText('click'));
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('handleMarkAsRead invokes the markAsRead mutation', async () => {
+    mockUseNotifications.mockReturnValue({
+      data: [{ idKey: 'n1', title: 'First' }],
+      isLoading: false,
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(wrap(<NotificationList />));
+    await user.click(screen.getByText('read'));
+    expect(mockMarkMutate).toHaveBeenCalledWith('n1');
+  });
+
+  it('handleDelete invokes the delete mutation', async () => {
+    mockUseNotifications.mockReturnValue({
+      data: [{ idKey: 'n1', title: 'First' }],
+      isLoading: false,
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(wrap(<NotificationList />));
+    await user.click(screen.getByText('delete'));
+    expect(mockDeleteMutate).toHaveBeenCalledWith('n1');
+  });
+
+  it('passes unreadOnly + limit to the hook', () => {
+    mockUseNotifications.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+    render(wrap(<NotificationList unreadOnly limit={5} />));
+    expect(mockUseNotifications).toHaveBeenCalledWith(true, 5);
+  });
+});

--- a/src/web/src/features/authorized-pickup/__tests__/AuthorizedPickupList.test.tsx
+++ b/src/web/src/features/authorized-pickup/__tests__/AuthorizedPickupList.test.tsx
@@ -1,0 +1,305 @@
+/**
+ * AuthorizedPickupList tests
+ *
+ * Covers branches of the list:
+ *   - Error state renders the red error banner.
+ *   - Loading state renders the spinner.
+ *   - Empty state ("No authorized pickups") when list is [].
+ *   - Populated state: photo vs placeholder avatar, phone conditional, badges.
+ *   - Auto-populate button uses confirm() and only mutates when user confirms.
+ *   - Remove button uses confirm() and only mutates when user confirms.
+ *   - Add and Edit open the dialog with the appropriate pickup.
+ *   - Delete button disabled state propagates via isPending.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUseAuthorizedPickups = vi.fn();
+const mockDeleteMutate = vi.fn();
+const mockAutoPopulateMutate = vi.fn();
+const mockUseDeleteAuthorizedPickup = vi.fn();
+const mockUseAutoPopulateFamilyMembers = vi.fn();
+
+vi.mock('../hooks', () => ({
+  useAuthorizedPickups: (childIdKey: string) => mockUseAuthorizedPickups(childIdKey),
+  useDeleteAuthorizedPickup: () => mockUseDeleteAuthorizedPickup(),
+  useAutoPopulateFamilyMembers: () => mockUseAutoPopulateFamilyMembers(),
+}));
+
+vi.mock('../AddEditAuthorizedPickupDialog', () => ({
+  AddEditAuthorizedPickupDialog: ({
+    pickup,
+    onClose,
+  }: {
+    pickup: { idKey?: string } | null;
+    onClose: () => void;
+  }) => (
+    <div data-testid="add-edit-dialog">
+      <span>editing:{pickup?.idKey ?? 'new'}</span>
+      <button onClick={onClose}>dialog-close</button>
+    </div>
+  ),
+}));
+
+import { AuthorizedPickupList } from '../AuthorizedPickupList';
+import { AuthorizationLevel } from '../api';
+
+const basePickup = {
+  idKey: 'pk1',
+  childIdKey: 'c1',
+  authorizedPersonIdKey: 'ap1',
+  authorizedPersonName: 'Alice Pickup',
+  name: 'Alice Pickup',
+  authorizationLevel: AuthorizationLevel.Always,
+  phoneNumber: '5551234567',
+  photoUrl: null,
+  relationship: 0,
+};
+
+describe('AuthorizedPickupList', () => {
+  beforeEach(() => {
+    mockDeleteMutate.mockReset();
+    mockAutoPopulateMutate.mockReset();
+    mockUseDeleteAuthorizedPickup.mockReturnValue({
+      mutateAsync: mockDeleteMutate,
+      isPending: false,
+    });
+    mockUseAutoPopulateFamilyMembers.mockReturnValue({
+      mutateAsync: mockAutoPopulateMutate,
+      isPending: false,
+    });
+  });
+
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders the error banner when the list query errors', () => {
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('bad'),
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    expect(screen.getByText(/error loading authorized pickups/i)).toBeInTheDocument();
+    expect(screen.getByText('bad')).toBeInTheDocument();
+  });
+
+  it('falls back to a generic message when error has no Error shape', () => {
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: 'raw string',
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    expect(screen.getByText(/unknown error occurred/i)).toBeInTheDocument();
+  });
+
+  it('renders loading spinner while loading', () => {
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    expect(screen.getByText(/loading authorized pickups/i)).toBeInTheDocument();
+  });
+
+  it('renders empty state when list is empty', () => {
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    expect(screen.getByText(/no authorized pickups/i)).toBeInTheDocument();
+  });
+
+  it('renders the list with badges and phone numbers', () => {
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: [
+        { ...basePickup, idKey: 'pk1', photoUrl: 'https://img/x' },
+        {
+          ...basePickup,
+          idKey: 'pk2',
+          authorizedPersonName: 'Bob',
+          name: 'Bob',
+          authorizationLevel: AuthorizationLevel.EmergencyOnly,
+          phoneNumber: undefined,
+          photoUrl: null,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    expect(screen.getByText('Alice Pickup')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('Always Authorized')).toBeInTheDocument();
+    expect(screen.getByText('Emergency Only')).toBeInTheDocument();
+    // Photo branch: img with alt
+    expect(screen.getByRole('img', { name: 'Alice Pickup' })).toBeInTheDocument();
+    // Phone present for Alice
+    expect(screen.getByText('5551234567')).toBeInTheDocument();
+  });
+
+  it('Add button opens the dialog for a new pickup', async () => {
+    const user = userEvent.setup();
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    await user.click(screen.getByRole('button', { name: /add authorized pickup/i }));
+    expect(screen.getByTestId('add-edit-dialog')).toBeInTheDocument();
+    expect(screen.getByText('editing:new')).toBeInTheDocument();
+  });
+
+  it('Edit button opens the dialog with the clicked pickup', async () => {
+    const user = userEvent.setup();
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: [basePickup],
+      isLoading: false,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    await user.click(screen.getByRole('button', { name: /edit/i }));
+    expect(screen.getByText('editing:pk1')).toBeInTheDocument();
+  });
+
+  it('dialog close handler removes the dialog', async () => {
+    const user = userEvent.setup();
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    await user.click(screen.getByRole('button', { name: /add authorized pickup/i }));
+    await user.click(screen.getByText('dialog-close'));
+    expect(screen.queryByTestId('add-edit-dialog')).toBeNull();
+  });
+
+  it('Remove cancels when user rejects the confirm()', async () => {
+    const user = userEvent.setup();
+    const confirmFn = vi.fn().mockReturnValue(false);
+    vi.stubGlobal('confirm', confirmFn);
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: [basePickup],
+      isLoading: false,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+    expect(confirmFn).toHaveBeenCalled();
+    expect(mockDeleteMutate).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it('Remove mutates when user accepts the confirm()', async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    mockDeleteMutate.mockResolvedValueOnce(undefined);
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: [basePickup],
+      isLoading: false,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+    expect(mockDeleteMutate).toHaveBeenCalledWith({
+      pickupIdKey: 'pk1',
+      childIdKey: 'c1',
+    });
+    vi.unstubAllGlobals();
+  });
+
+  it('Remove swallows the rejected mutation without crashing', async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    mockDeleteMutate.mockRejectedValueOnce(new Error('server error'));
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: [basePickup],
+      isLoading: false,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    await user.click(screen.getByRole('button', { name: /remove/i }));
+    // Did not bubble; list still renders.
+    expect(screen.getByText('Alice Pickup')).toBeInTheDocument();
+    vi.unstubAllGlobals();
+  });
+
+  it('Auto-populate cancels when user rejects the confirm()', async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(false));
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    await user.click(screen.getByRole('button', { name: /auto-populate/i }));
+    expect(mockAutoPopulateMutate).not.toHaveBeenCalled();
+    vi.unstubAllGlobals();
+  });
+
+  it('Auto-populate mutates with childIdKey on accept', async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    mockAutoPopulateMutate.mockResolvedValueOnce(undefined);
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    await user.click(screen.getByRole('button', { name: /auto-populate/i }));
+    expect(mockAutoPopulateMutate).toHaveBeenCalledWith('c1');
+    vi.unstubAllGlobals();
+  });
+
+  it('Auto-populate swallows a mutation error', async () => {
+    const user = userEvent.setup();
+    vi.stubGlobal('confirm', vi.fn().mockReturnValue(true));
+    mockAutoPopulateMutate.mockRejectedValueOnce(new Error('no family'));
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    await user.click(screen.getByRole('button', { name: /auto-populate/i }));
+    // Component still rendered.
+    expect(screen.getByText(/authorized pickups for/i)).toBeInTheDocument();
+    vi.unstubAllGlobals();
+  });
+
+  it('Remove is disabled while delete mutation is pending', () => {
+    mockUseDeleteAuthorizedPickup.mockReturnValue({
+      mutateAsync: mockDeleteMutate,
+      isPending: true,
+    });
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: [basePickup],
+      isLoading: false,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    expect(screen.getByRole('button', { name: /removing/i })).toBeDisabled();
+  });
+
+  it('Auto-populate button shows pending label when isPending', () => {
+    mockUseAutoPopulateFamilyMembers.mockReturnValue({
+      mutateAsync: mockAutoPopulateMutate,
+      isPending: true,
+    });
+    mockUseAuthorizedPickups.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+    render(<AuthorizedPickupList childIdKey="c1" childName="Kid" />);
+    expect(screen.getByRole('button', { name: /adding/i })).toBeDisabled();
+  });
+});

--- a/src/web/src/features/authorized-pickup/__tests__/PickupHistoryPanel.test.tsx
+++ b/src/web/src/features/authorized-pickup/__tests__/PickupHistoryPanel.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * PickupHistoryPanel tests
+ *
+ * Branches:
+ *   - Error branch (red banner) for both Error and non-Error values.
+ *   - Loading branch.
+ *   - Empty branch when history = [].
+ *   - Table branch with Authorized / Not Authorized badges.
+ *   - supervisorOverride banner with and without supervisorName.
+ *   - Notes fallback to "-" when empty.
+ *   - Date-range buttons re-invoke the hook with new from/to.
+ *   - Pluralization "1 pickup" vs "N pickups".
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUsePickupHistory = vi.fn();
+
+vi.mock('../hooks', () => ({
+  usePickupHistory: (
+    childIdKey: string,
+    fromDate: string | undefined,
+    toDate: string | undefined
+  ) => mockUsePickupHistory(childIdKey, fromDate, toDate),
+}));
+
+import { PickupHistoryPanel } from '../PickupHistoryPanel';
+
+const baseLog = {
+  idKey: 'l1',
+  childIdKey: 'c1',
+  pickupPersonName: 'Alice',
+  checkoutDateTime: '2026-04-22T10:00:00Z',
+  wasAuthorized: true,
+  supervisorOverride: false,
+  supervisorName: null,
+  notes: '',
+};
+
+describe('PickupHistoryPanel', () => {
+  beforeEach(() => {
+    mockUsePickupHistory.mockReset();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders Error branch with Error.message', () => {
+    mockUsePickupHistory.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('bang'),
+    });
+    render(<PickupHistoryPanel childIdKey="c1" childName="Kid" />);
+    expect(screen.getByText(/error loading pickup history/i)).toBeInTheDocument();
+    expect(screen.getByText('bang')).toBeInTheDocument();
+  });
+
+  it('renders generic message when error has no .message', () => {
+    mockUsePickupHistory.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: 'raw',
+    });
+    render(<PickupHistoryPanel childIdKey="c1" childName="Kid" />);
+    expect(screen.getByText(/unknown error occurred/i)).toBeInTheDocument();
+  });
+
+  it('renders loading spinner', () => {
+    mockUsePickupHistory.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+    });
+    render(<PickupHistoryPanel childIdKey="c1" childName="Kid" />);
+    expect(screen.getByText(/loading history/i)).toBeInTheDocument();
+  });
+
+  it('renders empty state when data is []', () => {
+    mockUsePickupHistory.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+    render(<PickupHistoryPanel childIdKey="c1" childName="Kid" />);
+    expect(screen.getByText(/no pickup history/i)).toBeInTheDocument();
+  });
+
+  it('renders Authorized + Not Authorized + Supervisor Override + supervisorName', () => {
+    mockUsePickupHistory.mockReturnValue({
+      data: [
+        { ...baseLog, idKey: 'l1' },
+        {
+          ...baseLog,
+          idKey: 'l2',
+          wasAuthorized: false,
+          supervisorOverride: true,
+          supervisorName: 'Supervisor Bob',
+          notes: 'late pickup',
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    render(<PickupHistoryPanel childIdKey="c1" childName="Kid" />);
+    expect(screen.getByText('Authorized')).toBeInTheDocument();
+    expect(screen.getByText('Not Authorized')).toBeInTheDocument();
+    expect(screen.getByText('Supervisor Override')).toBeInTheDocument();
+    expect(screen.getByText(/by: supervisor bob/i)).toBeInTheDocument();
+    expect(screen.getByText('late pickup')).toBeInTheDocument();
+    expect(screen.getByText(/showing/i)).toBeInTheDocument();
+    // 2 entries -> plural "pickups"
+    expect(screen.getByText(/pickups/i)).toBeInTheDocument();
+  });
+
+  it('falls back to "-" when notes is empty', () => {
+    mockUsePickupHistory.mockReturnValue({
+      data: [baseLog],
+      isLoading: false,
+      error: null,
+    });
+    render(<PickupHistoryPanel childIdKey="c1" childName="Kid" />);
+    expect(screen.getByText('-')).toBeInTheDocument();
+  });
+
+  it('date-range buttons re-invoke the hook with new bounds', async () => {
+    mockUsePickupHistory.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(<PickupHistoryPanel childIdKey="c1" childName="Kid" />);
+    mockUsePickupHistory.mockClear();
+    await user.click(screen.getByRole('button', { name: /last 7 days/i }));
+    // After clicking, hook is invoked again during next render.
+    expect(mockUsePickupHistory).toHaveBeenCalled();
+
+    await user.click(screen.getByRole('button', { name: /last 90 days/i }));
+    expect(mockUsePickupHistory).toHaveBeenCalled();
+  });
+
+  it('singular "1 pickup" label when list has 1 entry', () => {
+    mockUsePickupHistory.mockReturnValue({
+      data: [baseLog],
+      isLoading: false,
+      error: null,
+    });
+    const { container } = render(<PickupHistoryPanel childIdKey="c1" childName="Kid" />);
+    // Summary says "pickup" (singular), not "pickups"
+    expect(container.textContent).toMatch(/Showing\s+1\s+pickup\b/);
+    expect(container.textContent).not.toMatch(/pickups/);
+  });
+});

--- a/src/web/src/features/followups/__tests__/FollowUpCard.test.tsx
+++ b/src/web/src/features/followups/__tests__/FollowUpCard.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * FollowUpCard tests
+ *
+ * Catches regressions in:
+ *   - Status badge label matches the status enum branch.
+ *   - Notes preview shows "No notes yet" fallback when empty.
+ *   - Edit Notes toggle swaps the notes display with a textarea.
+ *   - Cancel restores original notes and exits edit mode.
+ *   - Save Notes invokes mutate with preserved status.
+ *   - Update Status panel exposes 4 status buttons; clicking one mutates.
+ *   - Update Status button is disabled when status is Connected/Declined.
+ *   - Timestamps (contactedDateTime / completedDateTime) render only when set.
+ */
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mutate = vi.fn();
+vi.mock('../hooks', () => ({
+  useUpdateFollowUpStatus: () => ({
+    mutate,
+    isPending: false,
+  }),
+}));
+
+import { FollowUpCard } from '../FollowUpCard';
+import { FollowUpStatus } from '../api';
+
+const baseFollowUp = {
+  idKey: 'fu1',
+  personIdKey: 'p1',
+  personName: 'Alice Example',
+  assignedToIdKey: 'u1',
+  assignedToName: 'Bob Assignee',
+  status: FollowUpStatus.Pending,
+  notes: '',
+  createdDateTime: '2026-01-01T10:00:00Z',
+  contactedDateTime: null,
+  completedDateTime: null,
+};
+
+describe('FollowUpCard', () => {
+  beforeEach(() => {
+    mutate.mockReset();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('shows the Pending badge label', () => {
+    render(<FollowUpCard followUp={baseFollowUp as never} />);
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('Alice Example')).toBeInTheDocument();
+  });
+
+  it('renders "No notes yet" when notes is empty', () => {
+    render(<FollowUpCard followUp={baseFollowUp as never} />);
+    expect(screen.getByText(/no notes yet/i)).toBeInTheDocument();
+  });
+
+  it('renders the notes text when provided', () => {
+    render(<FollowUpCard followUp={{ ...baseFollowUp, notes: 'tried calling' } as never} />);
+    expect(screen.getByText('tried calling')).toBeInTheDocument();
+  });
+
+  it('switches to editing mode and displays a textarea', async () => {
+    const user = userEvent.setup();
+    render(<FollowUpCard followUp={baseFollowUp as never} />);
+    await user.click(screen.getByRole('button', { name: /edit notes/i }));
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save notes/i })).toBeInTheDocument();
+  });
+
+  it('Cancel from edit mode restores original notes and hides textarea', async () => {
+    const user = userEvent.setup();
+    render(<FollowUpCard followUp={{ ...baseFollowUp, notes: 'orig' } as never} />);
+    await user.click(screen.getByRole('button', { name: /edit notes/i }));
+    const textarea = screen.getByRole('textbox');
+    await user.clear(textarea);
+    await user.type(textarea, 'new text');
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    // Back in preview mode showing the original notes.
+    expect(screen.queryByRole('textbox')).toBeNull();
+    expect(screen.getByText('orig')).toBeInTheDocument();
+  });
+
+  it('Save Notes calls mutate with preserved status and current notes', async () => {
+    const user = userEvent.setup();
+    render(<FollowUpCard followUp={baseFollowUp as never} />);
+    await user.click(screen.getByRole('button', { name: /edit notes/i }));
+    await user.type(screen.getByRole('textbox'), 'added a note');
+    await user.click(screen.getByRole('button', { name: /save notes/i }));
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        idKey: 'fu1',
+        status: FollowUpStatus.Pending,
+        notes: 'added a note',
+      }),
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+  });
+
+  it('Update Status opens action panel with 4 status buttons', async () => {
+    const user = userEvent.setup();
+    render(<FollowUpCard followUp={baseFollowUp as never} />);
+    await user.click(screen.getByRole('button', { name: /update status/i }));
+    expect(screen.getByRole('button', { name: /mark contacted/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /mark connected/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /no response/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /declined/i })).toBeInTheDocument();
+  });
+
+  it('clicking Mark Contacted mutates with Contacted status', async () => {
+    const user = userEvent.setup();
+    render(<FollowUpCard followUp={baseFollowUp as never} />);
+    await user.click(screen.getByRole('button', { name: /update status/i }));
+    await user.click(screen.getByRole('button', { name: /mark contacted/i }));
+    expect(mutate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: FollowUpStatus.Contacted }),
+      expect.any(Object)
+    );
+  });
+
+  it('Update Status is disabled for Connected', () => {
+    render(
+      <FollowUpCard
+        followUp={{ ...baseFollowUp, status: FollowUpStatus.Connected } as never}
+      />
+    );
+    const btn = screen.getByRole('button', { name: /update status/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('Update Status is disabled for Declined', () => {
+    render(
+      <FollowUpCard
+        followUp={{ ...baseFollowUp, status: FollowUpStatus.Declined } as never}
+      />
+    );
+    const btn = screen.getByRole('button', { name: /update status/i });
+    expect(btn).toBeDisabled();
+  });
+
+  it('renders Contacted and Completed timestamps only when present', () => {
+    const { rerender } = render(
+      <FollowUpCard followUp={baseFollowUp as never} />
+    );
+    expect(screen.queryByText(/contacted:/i)).toBeNull();
+    expect(screen.queryByText(/completed:/i)).toBeNull();
+
+    rerender(
+      <FollowUpCard
+        followUp={
+          {
+            ...baseFollowUp,
+            contactedDateTime: '2026-02-01T10:00:00Z',
+            completedDateTime: '2026-03-01T10:00:00Z',
+          } as never
+        }
+      />
+    );
+    expect(screen.getByText(/contacted:/i)).toBeInTheDocument();
+    expect(screen.getByText(/completed:/i)).toBeInTheDocument();
+  });
+
+  it('shows the Assigned to line only when assignedToName is set', () => {
+    const { rerender } = render(
+      <FollowUpCard followUp={{ ...baseFollowUp, assignedToName: undefined } as never} />
+    );
+    expect(screen.queryByText(/assigned to:/i)).toBeNull();
+    rerender(<FollowUpCard followUp={baseFollowUp as never} />);
+    expect(screen.getByText(/assigned to:/i)).toBeInTheDocument();
+  });
+
+  it('Cancel in status panel closes it without mutating', async () => {
+    const user = userEvent.setup();
+    render(<FollowUpCard followUp={baseFollowUp as never} />);
+    await user.click(screen.getByRole('button', { name: /update status/i }));
+    // Find "Cancel" within the action panel.
+    const cancels = screen.getAllByRole('button', { name: /cancel/i });
+    await user.click(cancels[cancels.length - 1]);
+    expect(mutate).not.toHaveBeenCalled();
+    // Status panel is gone.
+    expect(screen.queryByRole('button', { name: /mark contacted/i })).toBeNull();
+  });
+
+  it('renders distinct badge for each known status', () => {
+    const statuses: Array<[FollowUpStatus, string]> = [
+      [FollowUpStatus.Pending, 'Pending'],
+      [FollowUpStatus.Contacted, 'Contacted'],
+      [FollowUpStatus.NoResponse, 'No Response'],
+      [FollowUpStatus.Connected, 'Connected'],
+      [FollowUpStatus.Declined, 'Declined'],
+    ];
+    for (const [status, label] of statuses) {
+      const { unmount, container } = render(
+        <FollowUpCard followUp={{ ...baseFollowUp, status } as never} />
+      );
+      expect(within(container).getByText(label)).toBeInTheDocument();
+      unmount();
+    }
+  });
+});

--- a/src/web/src/features/followups/__tests__/FollowUpQueue.test.tsx
+++ b/src/web/src/features/followups/__tests__/FollowUpQueue.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * FollowUpQueue tests
+ *
+ * Covers:
+ *   - Loading branch: spinner visible while isLoading=true.
+ *   - Error branch: red panel + Try Again button triggers refetch().
+ *   - Empty branch: nice empty state when followUps is empty.
+ *   - Stats bar shows counts per status.
+ *   - Clicking a status filter narrows the list.
+ *   - Filtering to a status with no items shows "No follow-ups match the filter"
+ *     + a "Clear Filter" button that resets to all.
+ *   - "all" selected by default renders every item.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUsePendingFollowUps = vi.fn();
+const mockRefetch = vi.fn();
+
+vi.mock('../hooks', () => ({
+  usePendingFollowUps: (assignedToIdKey?: string) =>
+    mockUsePendingFollowUps(assignedToIdKey),
+  useUpdateFollowUpStatus: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+import { FollowUpQueue } from '../FollowUpQueue';
+import { FollowUpStatus } from '../api';
+
+const makeFollowUp = (status: FollowUpStatus, idKey: string) => ({
+  idKey,
+  personIdKey: 'p1',
+  personName: `Person ${idKey}`,
+  assignedToIdKey: null,
+  assignedToName: null,
+  status,
+  notes: '',
+  createdDateTime: '2026-04-01T10:00:00Z',
+  contactedDateTime: null,
+  completedDateTime: null,
+});
+
+describe('FollowUpQueue', () => {
+  beforeEach(() => {
+    mockUsePendingFollowUps.mockReset();
+    mockRefetch.mockReset();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders loading state', () => {
+    mockUsePendingFollowUps.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: mockRefetch,
+    });
+    render(<FollowUpQueue />);
+    expect(screen.getByText(/loading follow-ups/i)).toBeInTheDocument();
+  });
+
+  it('renders error state with Try Again invoking refetch', async () => {
+    const user = userEvent.setup();
+    mockUsePendingFollowUps.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('boom'),
+      refetch: mockRefetch,
+    });
+    render(<FollowUpQueue />);
+    expect(screen.getByText(/error loading follow-ups/i)).toBeInTheDocument();
+    expect(screen.getByText('boom')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /try again/i }));
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+
+  it('renders generic error fallback when error is not an Error', () => {
+    mockUsePendingFollowUps.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: 'raw',
+      refetch: mockRefetch,
+    });
+    render(<FollowUpQueue />);
+    expect(screen.getByText(/unknown error occurred/i)).toBeInTheDocument();
+  });
+
+  it('renders empty state when no follow-ups', () => {
+    mockUsePendingFollowUps.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    render(<FollowUpQueue />);
+    expect(screen.getByText(/no follow-ups/i)).toBeInTheDocument();
+    expect(screen.getByText(/no pending follow-ups/i)).toBeInTheDocument();
+  });
+
+  it('renders full queue with stats bar and cards', () => {
+    const followUps = [
+      makeFollowUp(FollowUpStatus.Pending, 'fu1'),
+      makeFollowUp(FollowUpStatus.Pending, 'fu2'),
+      makeFollowUp(FollowUpStatus.Contacted, 'fu3'),
+      makeFollowUp(FollowUpStatus.Connected, 'fu4'),
+      makeFollowUp(FollowUpStatus.NoResponse, 'fu5'),
+    ];
+    mockUsePendingFollowUps.mockReturnValue({
+      data: followUps,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    render(<FollowUpQueue />);
+    // Header + stats
+    expect(screen.getByRole('heading', { name: /follow-up queue/i })).toBeInTheDocument();
+    // Total count
+    expect(screen.getByText('Total')).toBeInTheDocument();
+    // One card per item
+    expect(screen.getByText('Person fu1')).toBeInTheDocument();
+    expect(screen.getByText('Person fu2')).toBeInTheDocument();
+    expect(screen.getByText('Person fu3')).toBeInTheDocument();
+  });
+
+  it('filters by status when a stat button is clicked', async () => {
+    const followUps = [
+      makeFollowUp(FollowUpStatus.Pending, 'fu1'),
+      makeFollowUp(FollowUpStatus.Contacted, 'fu2'),
+      makeFollowUp(FollowUpStatus.Connected, 'fu3'),
+    ];
+    mockUsePendingFollowUps.mockReturnValue({
+      data: followUps,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    const user = userEvent.setup();
+    render(<FollowUpQueue />);
+    // Click "Contacted" filter
+    await user.click(screen.getByRole('button', { name: /contacted/i }));
+    // Only fu2 (Contacted) should be visible
+    expect(screen.queryByText('Person fu1')).toBeNull();
+    expect(screen.getByText('Person fu2')).toBeInTheDocument();
+    expect(screen.queryByText('Person fu3')).toBeNull();
+  });
+
+  it('shows "no follow-ups match" + Clear Filter resets', async () => {
+    const followUps = [makeFollowUp(FollowUpStatus.Pending, 'fu1')];
+    mockUsePendingFollowUps.mockReturnValue({
+      data: followUps,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    const user = userEvent.setup();
+    render(<FollowUpQueue />);
+    // Click Connected — there are zero. Expect "no follow-ups match".
+    await user.click(screen.getByRole('button', { name: /connected/i }));
+    expect(screen.getByText(/no follow-ups match the selected filter/i)).toBeInTheDocument();
+    // Clear filter restores
+    await user.click(screen.getByRole('button', { name: /clear filter/i }));
+    expect(screen.getByText('Person fu1')).toBeInTheDocument();
+  });
+
+  it('passes assignedToIdKey to the query hook', () => {
+    mockUsePendingFollowUps.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    render(<FollowUpQueue assignedToIdKey="u1" />);
+    expect(mockUsePendingFollowUps).toHaveBeenCalledWith('u1');
+  });
+
+  it('No Response filter narrows correctly', async () => {
+    const followUps = [
+      makeFollowUp(FollowUpStatus.Pending, 'fu1'),
+      makeFollowUp(FollowUpStatus.NoResponse, 'fu2'),
+    ];
+    mockUsePendingFollowUps.mockReturnValue({
+      data: followUps,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    const user = userEvent.setup();
+    render(<FollowUpQueue />);
+    await user.click(screen.getByRole('button', { name: /no response/i }));
+    expect(screen.queryByText('Person fu1')).toBeNull();
+    expect(screen.getByText('Person fu2')).toBeInTheDocument();
+  });
+
+  it('Pending filter narrows correctly', async () => {
+    const followUps = [
+      makeFollowUp(FollowUpStatus.Pending, 'fu1'),
+      makeFollowUp(FollowUpStatus.Contacted, 'fu2'),
+    ];
+    mockUsePendingFollowUps.mockReturnValue({
+      data: followUps,
+      isLoading: false,
+      error: null,
+      refetch: mockRefetch,
+    });
+    const user = userEvent.setup();
+    render(<FollowUpQueue />);
+    await user.click(screen.getByRole('button', { name: /pending/i }));
+    expect(screen.getByText('Person fu1')).toBeInTheDocument();
+    expect(screen.queryByText('Person fu2')).toBeNull();
+  });
+});

--- a/src/web/src/features/pager/__tests__/PageHistory.test.tsx
+++ b/src/web/src/features/pager/__tests__/PageHistory.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * PageHistory tests
+ *
+ * Branches covered:
+ *   - No pagerNumber -> "Select a pager" prompt.
+ *   - isLoading -> spinner.
+ *   - error -> red banner.
+ *   - history is undefined/null -> "No history found".
+ *   - history with zero messages -> "No messages sent yet".
+ *   - All 4 PagerMessageStatus branches (Delivered/Sent/Pending/Failed) render
+ *     their respective labels.
+ *   - deliveredDateTime conditional rendering.
+ *   - Pluralization of "N messages sent" / "1 message sent".
+ *   - parentPhoneNumber conditional rendering.
+ */
+import { render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockUsePageHistory = vi.fn();
+
+vi.mock('../hooks', () => ({
+  usePageHistory: (pagerNumber: number | null) => mockUsePageHistory(pagerNumber),
+}));
+
+import { PageHistory } from '../PageHistory';
+import { PagerMessageStatus, PagerMessageType } from '../api';
+
+describe('PageHistory', () => {
+  beforeEach(() => {
+    mockUsePageHistory.mockReset();
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('prompts to select a pager when pagerNumber is null', () => {
+    mockUsePageHistory.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    render(<PageHistory pagerNumber={null} />);
+    expect(screen.getByText(/select a pager/i)).toBeInTheDocument();
+  });
+
+  it('renders loading state', () => {
+    mockUsePageHistory.mockReturnValue({ data: undefined, isLoading: true, error: null });
+    render(<PageHistory pagerNumber={127} />);
+    expect(screen.getByText(/loading history/i)).toBeInTheDocument();
+  });
+
+  it('renders error banner on failure', () => {
+    mockUsePageHistory.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('x'),
+    });
+    render(<PageHistory pagerNumber={127} />);
+    expect(screen.getByText(/failed to load page history/i)).toBeInTheDocument();
+  });
+
+  it('renders "No history found" when history is nullish', () => {
+    mockUsePageHistory.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    });
+    render(<PageHistory pagerNumber={127} />);
+    expect(screen.getByText(/no history found/i)).toBeInTheDocument();
+  });
+
+  it('renders "No messages sent yet" when history has no messages', () => {
+    mockUsePageHistory.mockReturnValue({
+      data: {
+        idKey: 'h1',
+        pagerNumber: 127,
+        childName: 'Kid',
+        parentPhoneNumber: '5551234567',
+        messages: [],
+      },
+      isLoading: false,
+      error: null,
+    });
+    render(<PageHistory pagerNumber={127} />);
+    expect(screen.getByText(/no messages sent yet/i)).toBeInTheDocument();
+    expect(screen.getByText('Kid')).toBeInTheDocument();
+    expect(screen.getByText('5551234567')).toBeInTheDocument();
+  });
+
+  it('hides the parent phone line when missing', () => {
+    mockUsePageHistory.mockReturnValue({
+      data: {
+        idKey: 'h1',
+        pagerNumber: 127,
+        childName: 'Kid',
+        parentPhoneNumber: '',
+        messages: [],
+      },
+      isLoading: false,
+      error: null,
+    });
+    render(<PageHistory pagerNumber={127} />);
+    expect(screen.queryByText(/555/)).toBeNull();
+  });
+
+  it('renders all 4 status branches of the status display', () => {
+    mockUsePageHistory.mockReturnValue({
+      data: {
+        idKey: 'h1',
+        pagerNumber: 127,
+        childName: 'Kid',
+        parentPhoneNumber: '',
+        messages: [
+          {
+            idKey: 'm1',
+            messageType: PagerMessageType.PickupNeeded,
+            messageText: 'Msg 1',
+            status: PagerMessageStatus.Delivered,
+            sentDateTime: '2026-04-22T10:00:00Z',
+            deliveredDateTime: '2026-04-22T10:01:00Z',
+            sentByPersonName: 'Alice',
+          },
+          {
+            idKey: 'm2',
+            messageType: PagerMessageType.NeedsAttention,
+            messageText: 'Msg 2',
+            status: PagerMessageStatus.Sent,
+            sentDateTime: '2026-04-22T10:02:00Z',
+            deliveredDateTime: null,
+            sentByPersonName: 'Bob',
+          },
+          {
+            idKey: 'm3',
+            messageType: PagerMessageType.Custom,
+            messageText: 'Msg 3',
+            status: PagerMessageStatus.Pending,
+            sentDateTime: '2026-04-22T10:03:00Z',
+            deliveredDateTime: null,
+            sentByPersonName: 'Carol',
+          },
+          {
+            idKey: 'm4',
+            messageType: PagerMessageType.ServiceEnding,
+            messageText: 'Msg 4',
+            status: PagerMessageStatus.Failed,
+            sentDateTime: '2026-04-22T10:04:00Z',
+            deliveredDateTime: null,
+            sentByPersonName: 'Dave',
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+    render(<PageHistory pagerNumber={127} />);
+    expect(screen.getByText('Delivered')).toBeInTheDocument();
+    expect(screen.getByText('Sent')).toBeInTheDocument();
+    expect(screen.getByText('Pending')).toBeInTheDocument();
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+    // Only Delivered message exposes "Delivered at"
+    expect(screen.getByText(/delivered at/i)).toBeInTheDocument();
+    // 4 messages plural
+    expect(screen.getByText(/4 messages sent/i)).toBeInTheDocument();
+  });
+
+  it('uses singular "1 message sent" for a single entry', () => {
+    mockUsePageHistory.mockReturnValue({
+      data: {
+        idKey: 'h1',
+        pagerNumber: 128,
+        childName: 'Kid',
+        parentPhoneNumber: '',
+        messages: [
+          {
+            idKey: 'm1',
+            messageType: PagerMessageType.PickupNeeded,
+            messageText: 'Only Msg',
+            status: PagerMessageStatus.Delivered,
+            sentDateTime: '2026-04-22T10:00:00Z',
+            deliveredDateTime: '2026-04-22T10:01:00Z',
+            sentByPersonName: 'Alice',
+          },
+        ],
+      },
+      isLoading: false,
+      error: null,
+    });
+    const { container } = render(<PageHistory pagerNumber={128} />);
+    expect(within(container).getByText(/1 message sent/i)).toBeInTheDocument();
+  });
+});

--- a/src/web/src/features/pager/__tests__/PagerSearch.test.tsx
+++ b/src/web/src/features/pager/__tests__/PagerSearch.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * PagerSearch tests
+ *
+ * Covers the key visible branches of the search component:
+ *   - Renders input with autoFocus.
+ *   - Loading branch renders spinner while isLoading=true.
+ *   - Error branch renders the "Failed to search pagers" message.
+ *   - Empty-results branch distinguishes between "no pagers today" and
+ *     "no pagers match your search".
+ *   - Result branch shows pluralized count + all fields.
+ *   - Parent phone fallback ("No phone number") only when missing.
+ *   - Messages-sent badge only renders when count > 0 and uses orange
+ *     color for 2+ messages.
+ *   - onSelectPager invoked when row clicked.
+ *   - Normalization: "P-127" and "p127" strip the prefix before searching.
+ */
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MockResult = {
+  data?: unknown;
+  isLoading: boolean;
+  error: unknown;
+};
+
+const mockUsePagerSearch = vi.fn<(term: string | undefined) => MockResult>();
+
+vi.mock('../hooks', () => ({
+  usePagerSearch: (term?: string) => mockUsePagerSearch(term),
+}));
+
+import { PagerSearch } from '../PagerSearch';
+
+describe('PagerSearch', () => {
+  beforeEach(() => {
+    mockUsePagerSearch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the autofocused search input', () => {
+    mockUsePagerSearch.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    render(<PagerSearch onSelectPager={vi.fn()} />);
+    const input = screen.getByPlaceholderText(/search by pager number/i) as HTMLInputElement;
+    expect(input).toBeInTheDocument();
+    expect(input.value).toBe('');
+  });
+
+  it('renders the loading branch when isLoading is true', () => {
+    mockUsePagerSearch.mockReturnValue({ data: undefined, isLoading: true, error: null });
+    render(<PagerSearch onSelectPager={vi.fn()} />);
+    expect(screen.getByText(/searching/i)).toBeInTheDocument();
+  });
+
+  it('renders the error branch when error is present', () => {
+    mockUsePagerSearch.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('x'),
+    });
+    render(<PagerSearch onSelectPager={vi.fn()} />);
+    expect(screen.getByText(/failed to search pagers/i)).toBeInTheDocument();
+  });
+
+  it('renders "No active pagers today" when empty & no query', () => {
+    mockUsePagerSearch.mockReturnValue({ data: [], isLoading: false, error: null });
+    render(<PagerSearch onSelectPager={vi.fn()} />);
+    expect(screen.getByText(/no active pagers today/i)).toBeInTheDocument();
+  });
+
+  it('renders "No pagers found" when empty & has query', async () => {
+    mockUsePagerSearch.mockReturnValue({ data: [], isLoading: false, error: null });
+    const user = userEvent.setup();
+    render(<PagerSearch onSelectPager={vi.fn()} />);
+    await user.type(screen.getByPlaceholderText(/search by pager number/i), '127');
+    await waitFor(
+      () => expect(screen.getByText(/no pagers found/i)).toBeInTheDocument(),
+      { timeout: 2000 }
+    );
+  });
+
+  it('renders result list with singular count', () => {
+    mockUsePagerSearch.mockReturnValue({
+      data: [
+        {
+          idKey: 'p1',
+          pagerNumber: 127,
+          childName: 'Kid One',
+          groupName: 'K-1',
+          locationName: 'Room 1',
+          parentPhoneNumber: '5551234567',
+          checkedInAt: '2026-04-22T10:00:00Z',
+          messagesSentCount: 0,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    render(<PagerSearch onSelectPager={vi.fn()} />);
+    expect(screen.getByText(/1 pager found/i)).toBeInTheDocument();
+    expect(screen.getByText('Kid One')).toBeInTheDocument();
+    expect(screen.getByText('P-127')).toBeInTheDocument();
+    expect(screen.getByText('K-1')).toBeInTheDocument();
+  });
+
+  it('renders result list with plural count + 2+ messages badge in orange', () => {
+    mockUsePagerSearch.mockReturnValue({
+      data: [
+        {
+          idKey: 'p1',
+          pagerNumber: 127,
+          childName: 'Kid One',
+          groupName: 'K-1',
+          locationName: 'Room 1',
+          parentPhoneNumber: '5551234567',
+          checkedInAt: '2026-04-22T10:00:00Z',
+          messagesSentCount: 3,
+        },
+        {
+          idKey: 'p2',
+          pagerNumber: 128,
+          childName: 'Kid Two',
+          groupName: 'K-1',
+          locationName: 'Room 1',
+          parentPhoneNumber: null,
+          checkedInAt: '2026-04-22T10:00:00Z',
+          messagesSentCount: 0,
+        },
+      ],
+      isLoading: false,
+      error: null,
+    });
+    render(<PagerSearch onSelectPager={vi.fn()} />);
+    expect(screen.getByText(/2 pagers found/i)).toBeInTheDocument();
+    // Orange badge for >=2 messages
+    const badge = screen.getByText(/3 messages sent/i);
+    expect(badge.className).toMatch(/orange/);
+    // No-phone-number fallback for the second pager
+    expect(screen.getByText(/no phone number/i)).toBeInTheDocument();
+  });
+
+  it('onSelectPager receives the full pager when its row is clicked', async () => {
+    const onSelectPager = vi.fn();
+    const pager = {
+      idKey: 'p1',
+      pagerNumber: 127,
+      childName: 'Kid One',
+      groupName: 'K-1',
+      locationName: 'Room 1',
+      parentPhoneNumber: '5551234567',
+      checkedInAt: '2026-04-22T10:00:00Z',
+      messagesSentCount: 1,
+    };
+    mockUsePagerSearch.mockReturnValue({
+      data: [pager],
+      isLoading: false,
+      error: null,
+    });
+    const user = userEvent.setup();
+    render(<PagerSearch onSelectPager={onSelectPager} />);
+    // singular "1 message sent" branch
+    expect(screen.getByText(/1 message sent/i)).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /kid one/i }));
+    expect(onSelectPager).toHaveBeenCalledWith(pager);
+  });
+
+  it('strips the P- prefix from the search term before querying', async () => {
+    mockUsePagerSearch.mockReturnValue({ data: [], isLoading: false, error: null });
+    const user = userEvent.setup();
+    render(<PagerSearch onSelectPager={vi.fn()} />);
+    await user.type(
+      screen.getByPlaceholderText(/search by pager number/i),
+      'P-127'
+    );
+    await waitFor(() => {
+      const called = mockUsePagerSearch.mock.calls.map((c) => c[0]);
+      expect(called).toContain('127');
+    }, { timeout: 2000 });
+  });
+
+  it('strips the lower-case p prefix too', async () => {
+    mockUsePagerSearch.mockReturnValue({ data: [], isLoading: false, error: null });
+    const user = userEvent.setup();
+    render(<PagerSearch onSelectPager={vi.fn()} />);
+    await user.type(
+      screen.getByPlaceholderText(/search by pager number/i),
+      'p127'
+    );
+    await waitFor(() => {
+      const called = mockUsePagerSearch.mock.calls.map((c) => c[0]);
+      expect(called).toContain('127');
+    }, { timeout: 2000 });
+  });
+
+  it('passes undefined to the hook when the input is empty', () => {
+    mockUsePagerSearch.mockReturnValue({ data: undefined, isLoading: false, error: null });
+    render(<PagerSearch onSelectPager={vi.fn()} />);
+    expect(mockUsePagerSearch).toHaveBeenCalledWith(undefined);
+  });
+});

--- a/src/web/src/features/pager/__tests__/SendPageDialog.test.tsx
+++ b/src/web/src/features/pager/__tests__/SendPageDialog.test.tsx
@@ -1,0 +1,256 @@
+/**
+ * SendPageDialog tests
+ *
+ * Branches:
+ *   - Returns null when pager is null.
+ *   - Renders pager info + child name + default message type preview.
+ *   - No phone warning renders when parentPhoneNumber is missing.
+ *   - Rate-limit warnings: approaching (2 msgs) and exceeded (3+ msgs).
+ *   - Selecting "Custom" reveals textarea; preview uses textarea content.
+ *   - Send button disabled conditions: no phone, over limit, empty custom,
+ *     mutation pending.
+ *   - handleSend mutates with pagerNumber as string and the right message
+ *     type; Custom passes customMessage; non-Custom passes undefined.
+ *   - Error display shows mutation.error message; falls back to generic text.
+ *   - Success display shows when mutation.isSuccess=true.
+ *   - handleClose resets state + calls onClose; backdrop click also closes.
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let mutationState: {
+  mutateAsync: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+  isPending: boolean;
+  isError: boolean;
+  isSuccess: boolean;
+  error: unknown;
+};
+
+vi.mock('../hooks', () => ({
+  useSendPage: () => mutationState,
+}));
+
+import { SendPageDialog } from '../SendPageDialog';
+
+const basePager = {
+  idKey: 'p1',
+  pagerNumber: 127,
+  attendanceIdKey: 'a1',
+  childName: 'Kid One',
+  groupName: 'K-1',
+  locationName: 'Room 1',
+  parentPhoneNumber: '5551234567',
+  checkedInAt: '2026-04-22T10:00:00Z',
+  messagesSentCount: 0,
+};
+
+describe('SendPageDialog', () => {
+  beforeEach(() => {
+    mutationState = {
+      mutateAsync: vi.fn().mockResolvedValue(undefined),
+      reset: vi.fn(),
+      isPending: false,
+      isError: false,
+      isSuccess: false,
+      error: null,
+    };
+  });
+  afterEach(() => vi.clearAllMocks());
+
+  it('renders null when pager is null', () => {
+    const { container } = render(
+      <SendPageDialog pager={null} onClose={vi.fn()} onSuccess={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders header and default Pickup Needed preview', () => {
+    render(
+      <SendPageDialog pager={basePager} onClose={vi.fn()} onSuccess={vi.fn()} />
+    );
+    expect(screen.getByText('P-127')).toBeInTheDocument();
+    expect(screen.getByText('Kid One')).toBeInTheDocument();
+    // Preview defaults to Pickup Needed template
+    expect(screen.getByText(/please come pick up your child/i)).toBeInTheDocument();
+  });
+
+  it('shows No Phone warning when pager has no phone', () => {
+    render(
+      <SendPageDialog
+        pager={{ ...basePager, parentPhoneNumber: null }}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/no phone number/i)).toBeInTheDocument();
+  });
+
+  it('shows approaching-limit banner when messagesSentCount === 2', () => {
+    render(
+      <SendPageDialog
+        pager={{ ...basePager, messagesSentCount: 2 }}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/approaching rate limit/i)).toBeInTheDocument();
+  });
+
+  it('shows rate-limit-exceeded banner when messagesSentCount >= 3', () => {
+    render(
+      <SendPageDialog
+        pager={{ ...basePager, messagesSentCount: 3 }}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/rate limit exceeded/i)).toBeInTheDocument();
+  });
+
+  it('selecting Custom reveals textarea and uses its content in preview', async () => {
+    const user = userEvent.setup();
+    render(
+      <SendPageDialog pager={basePager} onClose={vi.fn()} onSuccess={vi.fn()} />
+    );
+    // Click the "Custom Message" radio option.
+    await user.click(screen.getByLabelText(/custom message/i));
+    const textarea = screen.getByPlaceholderText(/enter your custom message/i);
+    await user.type(textarea, 'hello there');
+    // Preview reflects the typed text.
+    expect(screen.getAllByText(/hello there/i).length).toBeGreaterThan(0);
+  });
+
+  it('Send is disabled when no phone number', () => {
+    render(
+      <SendPageDialog
+        pager={{ ...basePager, parentPhoneNumber: null }}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+    const send = screen.getByRole('button', { name: /send page/i });
+    expect(send).toBeDisabled();
+  });
+
+  it('Send is disabled when rate limit reached', () => {
+    render(
+      <SendPageDialog
+        pager={{ ...basePager, messagesSentCount: 3 }}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /send page/i })).toBeDisabled();
+  });
+
+  it('Send is disabled with empty custom message', async () => {
+    const user = userEvent.setup();
+    render(
+      <SendPageDialog pager={basePager} onClose={vi.fn()} onSuccess={vi.fn()} />
+    );
+    await user.click(screen.getByLabelText(/custom message/i));
+    expect(screen.getByRole('button', { name: /send page/i })).toBeDisabled();
+  });
+
+  it('Send enabled with non-empty custom, mutates with customMessage', async () => {
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <SendPageDialog pager={basePager} onClose={onClose} onSuccess={onSuccess} />
+    );
+    await user.click(screen.getByLabelText(/custom message/i));
+    await user.type(screen.getByPlaceholderText(/enter your custom/i), 'urgent');
+    await user.click(screen.getByRole('button', { name: /send page/i }));
+    expect(mutationState.mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pagerNumber: '127',
+        customMessage: 'urgent',
+      })
+    );
+    expect(onSuccess).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('non-Custom messageType sends undefined customMessage', async () => {
+    const user = userEvent.setup();
+    render(
+      <SendPageDialog pager={basePager} onClose={vi.fn()} onSuccess={vi.fn()} />
+    );
+    await user.click(screen.getByRole('button', { name: /send page/i }));
+    expect(mutationState.mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ customMessage: undefined })
+    );
+  });
+
+  it('handleSend swallows rejections without invoking onSuccess', async () => {
+    mutationState.mutateAsync = vi.fn().mockRejectedValue(new Error('nope'));
+    const onSuccess = vi.fn();
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <SendPageDialog pager={basePager} onClose={onClose} onSuccess={onSuccess} />
+    );
+    await user.click(screen.getByRole('button', { name: /send page/i }));
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('error display uses mutation.error message when Error', () => {
+    mutationState.isError = true;
+    mutationState.error = new Error('sms boom');
+    render(
+      <SendPageDialog pager={basePager} onClose={vi.fn()} onSuccess={vi.fn()} />
+    );
+    expect(screen.getByText(/sms boom/)).toBeInTheDocument();
+  });
+
+  it('error display falls back to generic when error is not Error', () => {
+    mutationState.isError = true;
+    mutationState.error = 'raw';
+    render(
+      <SendPageDialog pager={basePager} onClose={vi.fn()} onSuccess={vi.fn()} />
+    );
+    expect(screen.getByText(/failed to send page/i)).toBeInTheDocument();
+  });
+
+  it('success banner renders when mutation.isSuccess=true', () => {
+    mutationState.isSuccess = true;
+    render(
+      <SendPageDialog pager={basePager} onClose={vi.fn()} onSuccess={vi.fn()} />
+    );
+    expect(screen.getByText(/page sent successfully/i)).toBeInTheDocument();
+  });
+
+  it('Cancel button closes & resets', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <SendPageDialog pager={basePager} onClose={onClose} onSuccess={vi.fn()} />
+    );
+    await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+    expect(mutationState.reset).toHaveBeenCalled();
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('close X button closes', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <SendPageDialog pager={basePager} onClose={onClose} onSuccess={vi.fn()} />
+    );
+    await user.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('Send button shows loading when isPending', () => {
+    mutationState.isPending = true;
+    render(
+      <SendPageDialog pager={basePager} onClose={vi.fn()} onSuccess={vi.fn()} />
+    );
+    const send = screen.getByRole('button', { name: /send page/i });
+    expect(send).toBeDisabled();
+  });
+});

--- a/src/web/src/hooks/__tests__/usePrintBridgeConnection.test.tsx
+++ b/src/web/src/hooks/__tests__/usePrintBridgeConnection.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * usePrintBridgeConnection tests
+ *
+ * Drives the PrintBridge polling state-machine:
+ *   - Initial status = 'checking'.
+ *   - Health success + printer found -> 'available' + printer set.
+ *   - Health success + printer data=null -> 'no-printer'.
+ *   - Health failure with "Cannot connect" -> 'unavailable' + error.type='not-running'.
+ *   - Health failure with "timeout" -> 'unavailable' + error.type='timeout'.
+ *   - getDefaultZebraPrinter failure -> 'unavailable' + error.
+ *   - retry() calls checkHealth immediately.
+ *
+ * We mock printBridgeClient and use fake timers to control the polling loop.
+ */
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/printing/PrintBridgeClient', () => ({
+  printBridgeClient: {
+    checkHealth: vi.fn(),
+    getDefaultZebraPrinter: vi.fn(),
+  },
+}));
+
+import { printBridgeClient } from '@/services/printing/PrintBridgeClient';
+import { usePrintBridgeConnection } from '../usePrintBridgeConnection';
+
+const zebraDefault = {
+  name: 'ZD420',
+  status: 'idle',
+  isDefault: true,
+  isZebraPrinter: true,
+  driverName: '',
+  portName: '',
+};
+
+describe('usePrintBridgeConnection', () => {
+  beforeEach(() => {
+    vi.mocked(printBridgeClient.checkHealth).mockReset();
+    vi.mocked(printBridgeClient.getDefaultZebraPrinter).mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts with status=checking and transitions to available when healthy', async () => {
+    vi.mocked(printBridgeClient.checkHealth).mockResolvedValue({
+      success: true,
+      data: { status: 'ok', version: '1', timestamp: 't' },
+    });
+    vi.mocked(printBridgeClient.getDefaultZebraPrinter).mockResolvedValue({
+      success: true,
+      data: zebraDefault,
+    });
+
+    const { result, unmount } = renderHook(() => usePrintBridgeConnection());
+    expect(result.current.status).toBe('checking');
+    await waitFor(() => expect(result.current.status).toBe('available'));
+    expect(result.current.printer).toEqual(zebraDefault);
+    expect(result.current.error).toBeNull();
+    unmount();
+  });
+
+  it('sets status=no-printer when no Zebra printer is attached', async () => {
+    vi.mocked(printBridgeClient.checkHealth).mockResolvedValue({
+      success: true,
+      data: { status: 'ok', version: '1', timestamp: 't' },
+    });
+    vi.mocked(printBridgeClient.getDefaultZebraPrinter).mockResolvedValue({
+      success: true,
+      data: null,
+    });
+
+    const { result, unmount } = renderHook(() => usePrintBridgeConnection());
+    await waitFor(() => expect(result.current.status).toBe('no-printer'));
+    expect(result.current.error?.type).toBe('no-printer');
+    unmount();
+  });
+
+  it('categorizes "Cannot connect" as not-running', async () => {
+    vi.mocked(printBridgeClient.checkHealth).mockResolvedValue({
+      success: false,
+      error: 'Cannot connect to print bridge: is it running?',
+    });
+
+    const { result, unmount } = renderHook(() => usePrintBridgeConnection());
+    await waitFor(() => expect(result.current.status).toBe('unavailable'));
+    expect(result.current.error?.type).toBe('not-running');
+    unmount();
+  });
+
+  it('categorizes "timeout" as timeout', async () => {
+    vi.mocked(printBridgeClient.checkHealth).mockResolvedValue({
+      success: false,
+      error: 'Print bridge connection timeout - is it running?',
+    });
+
+    const { result, unmount } = renderHook(() => usePrintBridgeConnection());
+    await waitFor(() => expect(result.current.status).toBe('unavailable'));
+    // "timeout" wins over "is it running" because includes('timeout') fires first.
+    expect(result.current.error?.type).toBe('timeout');
+    unmount();
+  });
+
+  it('categorizes arbitrary messages as unknown', async () => {
+    vi.mocked(printBridgeClient.checkHealth).mockResolvedValue({
+      success: false,
+      error: 'weird thing happened',
+    });
+
+    const { result, unmount } = renderHook(() => usePrintBridgeConnection());
+    await waitFor(() => expect(result.current.status).toBe('unavailable'));
+    expect(result.current.error?.type).toBe('unknown');
+    unmount();
+  });
+
+  it('surfaces getDefaultZebraPrinter failures as unavailable', async () => {
+    vi.mocked(printBridgeClient.checkHealth).mockResolvedValue({
+      success: true,
+      data: { status: 'ok', version: '1', timestamp: 't' },
+    });
+    vi.mocked(printBridgeClient.getDefaultZebraPrinter).mockResolvedValue({
+      success: false,
+      error: 'Cannot connect to print bridge',
+    });
+
+    const { result, unmount } = renderHook(() => usePrintBridgeConnection());
+    await waitFor(() => expect(result.current.status).toBe('unavailable'));
+    expect(result.current.error?.type).toBe('not-running');
+    unmount();
+  });
+
+  it('retry() triggers a new health check', async () => {
+    vi.mocked(printBridgeClient.checkHealth).mockResolvedValue({
+      success: false,
+      error: 'Cannot connect',
+    });
+
+    const { result, unmount } = renderHook(() => usePrintBridgeConnection());
+    await waitFor(() => expect(result.current.status).toBe('unavailable'));
+    const callCountBefore = vi.mocked(printBridgeClient.checkHealth).mock.calls.length;
+
+    act(() => result.current.retry());
+    // Another call should fire.
+    await waitFor(() => {
+      expect(vi.mocked(printBridgeClient.checkHealth).mock.calls.length).toBeGreaterThan(
+        callCountBefore
+      );
+    });
+    unmount();
+  });
+});

--- a/src/web/src/services/__tests__/errorTracking.test.ts
+++ b/src/web/src/services/__tests__/errorTracking.test.ts
@@ -1,0 +1,121 @@
+/**
+ * errorTracking.ts tests
+ *
+ * The module wraps Sentry for opt-in production error reporting. The key
+ * behaviours we need to catch in regression:
+ *   - initErrorTracking skips init when no DSN (or explicit enabled:false).
+ *   - initErrorTracking calls Sentry.init when provided an explicit DSN
+ *     with enabled:true.
+ *   - captureError / setUserContext / clearUserContext / addBreadcrumb /
+ *     captureMessage are gated on (!DEV && VITE_SENTRY_DSN). In vitest
+ *     (DEV=true by default), they must be no-ops.
+ *
+ * Strategy: mock @sentry/react and assert which functions were invoked.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock Sentry module BEFORE importing the code under test.
+vi.mock('@sentry/react', () => ({
+  init: vi.fn(),
+  browserTracingIntegration: vi.fn(() => 'browserTracing'),
+  replayIntegration: vi.fn(() => 'replay'),
+  withScope: vi.fn((cb: (scope: unknown) => void) => {
+    const scope = { setContext: vi.fn() };
+    cb(scope);
+  }),
+  captureException: vi.fn(),
+  setUser: vi.fn(),
+  addBreadcrumb: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+import * as Sentry from '@sentry/react';
+import {
+  addBreadcrumb,
+  captureError,
+  captureMessage,
+  clearUserContext,
+  initErrorTracking,
+  setUserContext,
+} from '../errorTracking';
+
+describe('errorTracking', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('initErrorTracking', () => {
+    it('is a no-op when no DSN is provided and env has none', () => {
+      const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+      initErrorTracking({ enabled: true, dsn: undefined });
+      expect(Sentry.init).not.toHaveBeenCalled();
+      info.mockRestore();
+    });
+
+    it('is a no-op when explicitly disabled', () => {
+      const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+      initErrorTracking({ enabled: false, dsn: 'https://example.sentry/1' });
+      expect(Sentry.init).not.toHaveBeenCalled();
+      info.mockRestore();
+    });
+
+    it('initializes Sentry when DSN present and enabled:true', () => {
+      const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+      initErrorTracking({
+        dsn: 'https://example.sentry/1',
+        environment: 'staging',
+        enabled: true,
+        tracesSampleRate: 0.25,
+      });
+      expect(Sentry.init).toHaveBeenCalledTimes(1);
+      const call = (Sentry.init as ReturnType<typeof vi.fn>).mock.calls[0][0];
+      expect(call.dsn).toBe('https://example.sentry/1');
+      expect(call.environment).toBe('staging');
+      expect(call.tracesSampleRate).toBe(0.25);
+      // beforeSend filter should be a function; DEV mode returns null.
+      expect(typeof call.beforeSend).toBe('function');
+      expect(call.beforeSend({ event: 'x' })).toBeNull();
+      info.mockRestore();
+    });
+  });
+
+  describe('captureError / setUserContext / clearUserContext', () => {
+    // In vitest (DEV=true by default), these are ALL guarded off. Calling
+    // them proves the guards function (no Sentry calls are made).
+    it('captureError is a no-op in DEV', () => {
+      captureError(new Error('x'));
+      expect(Sentry.withScope).not.toHaveBeenCalled();
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it('setUserContext is a no-op in DEV', () => {
+      setUserContext({ id: '1', email: 'a@b' });
+      expect(Sentry.setUser).not.toHaveBeenCalled();
+    });
+
+    it('clearUserContext is a no-op in DEV', () => {
+      clearUserContext();
+      expect(Sentry.setUser).not.toHaveBeenCalled();
+    });
+
+    it('addBreadcrumb is a no-op in DEV', () => {
+      addBreadcrumb('m', 'c', 'info');
+      expect(Sentry.addBreadcrumb).not.toHaveBeenCalled();
+    });
+
+    it('captureMessage is a no-op in DEV', () => {
+      captureMessage('hi', 'warning');
+      expect(Sentry.captureMessage).not.toHaveBeenCalled();
+    });
+
+  });
+
+  // initErrorTracking's beforeSend filter is a function we can execute
+  // regardless of DEV flags. Verifying it returns the event in non-DEV
+  // environments is hard here (Vite's DEV is compile-time constant), so
+  // we only assert the init-branch behaviour via initErrorTracking above.
+});

--- a/src/web/src/services/printing/__tests__/PrintBridgeClient.test.ts
+++ b/src/web/src/services/printing/__tests__/PrintBridgeClient.test.ts
@@ -1,0 +1,349 @@
+/**
+ * PrintBridgeClient tests
+ *
+ * The client proxies to a local desktop app at http://localhost:9632.
+ * Every public method has the same three failure modes:
+ *   - network ok=false with JSON error body -> error.message
+ *   - network ok=false with JSON missing message -> default string
+ *   - fetch throws -> error message wrapped
+ *   - AbortError (timeout on checkHealth) -> "connection timeout"
+ *
+ * The happy path returns `{ success: true, data }`. These tests exercise
+ * both branches of each method so we catch regressions in error handling.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PrintBridgeClient } from '../PrintBridgeClient';
+
+const okJson = (body: unknown): Response =>
+  ({
+    ok: true,
+    status: 200,
+    json: async () => body,
+  }) as unknown as Response;
+
+const errJson = (status: number, body: unknown): Response =>
+  ({
+    ok: false,
+    status,
+    json: async () => body,
+  }) as unknown as Response;
+
+describe('PrintBridgeClient', () => {
+  let client: PrintBridgeClient;
+  const fetchSpy = vi.fn();
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+    vi.stubGlobal('fetch', fetchSpy);
+    client = new PrintBridgeClient('http://localhost:9999');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // ---------------------------------------------------------------------------
+  // checkHealth
+  // ---------------------------------------------------------------------------
+  describe('checkHealth', () => {
+    it('returns success + data when health endpoint returns 200', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        okJson({ status: 'ok', version: '1.0.0', timestamp: 'now' })
+      );
+      const res = await client.checkHealth();
+      expect(res.success).toBe(true);
+      if (res.success) expect(res.data.status).toBe('ok');
+      expect(fetchSpy).toHaveBeenCalledWith(
+        'http://localhost:9999/health',
+        expect.objectContaining({ method: 'GET' })
+      );
+    });
+
+    it('returns error when response is not ok', async () => {
+      fetchSpy.mockResolvedValueOnce(errJson(500, {}));
+      const res = await client.checkHealth();
+      expect(res.success).toBe(false);
+      if (!res.success) expect(res.error).toMatch(/error status/i);
+    });
+
+    it('returns timeout error when AbortError is thrown', async () => {
+      const err = new Error('aborted');
+      err.name = 'AbortError';
+      fetchSpy.mockRejectedValueOnce(err);
+      const res = await client.checkHealth();
+      expect(res.success).toBe(false);
+      if (!res.success) expect(res.error).toMatch(/timeout/i);
+    });
+
+    it('returns wrapped connection error on other Error', async () => {
+      fetchSpy.mockRejectedValueOnce(new Error('connection refused'));
+      const res = await client.checkHealth();
+      expect(res.success).toBe(false);
+      if (!res.success) expect(res.error).toMatch(/Cannot connect.*connection refused/i);
+    });
+
+    it('returns generic connect error on non-Error throw', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fetchSpy.mockRejectedValueOnce('boom' as any);
+      const res = await client.checkHealth();
+      expect(res.success).toBe(false);
+      if (!res.success) expect(res.error).toBe('Cannot connect to print bridge');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getPrinters
+  // ---------------------------------------------------------------------------
+  describe('getPrinters', () => {
+    it('returns printer list on success', async () => {
+      const printers = { printers: [], count: 0, zebraCount: 0 };
+      fetchSpy.mockResolvedValueOnce(okJson(printers));
+      const res = await client.getPrinters();
+      expect(res.success).toBe(true);
+      if (res.success) expect(res.data).toEqual(printers);
+    });
+
+    it('uses error body message on failure', async () => {
+      fetchSpy.mockResolvedValueOnce(errJson(500, { error: 'x', message: 'no printers' }));
+      const res = await client.getPrinters();
+      if (!res.success) expect(res.error).toBe('no printers');
+    });
+
+    it('falls back to default error when message is missing', async () => {
+      fetchSpy.mockResolvedValueOnce(errJson(500, {}));
+      const res = await client.getPrinters();
+      if (!res.success) expect(res.error).toMatch(/Failed to get printers/);
+    });
+
+    it('wraps thrown errors', async () => {
+      fetchSpy.mockRejectedValueOnce(new Error('offline'));
+      const res = await client.getPrinters();
+      if (!res.success) expect(res.error).toMatch(/offline/);
+    });
+
+    it('returns generic error on non-Error throw', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fetchSpy.mockRejectedValueOnce('oops' as any);
+      const res = await client.getPrinters();
+      if (!res.success) expect(res.error).toBe('Failed to get printers');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // refreshPrinters
+  // ---------------------------------------------------------------------------
+  describe('refreshPrinters', () => {
+    it('returns success + data on 200', async () => {
+      fetchSpy.mockResolvedValueOnce(okJson({ message: 'refreshed', count: 3 }));
+      const res = await client.refreshPrinters();
+      expect(res.success).toBe(true);
+      if (res.success) expect(res.data.count).toBe(3);
+    });
+
+    it('propagates error message from body', async () => {
+      fetchSpy.mockResolvedValueOnce(errJson(500, { message: 'refresh failed' }));
+      const res = await client.refreshPrinters();
+      if (!res.success) expect(res.error).toBe('refresh failed');
+    });
+
+    it('falls back to default error text when body missing', async () => {
+      fetchSpy.mockResolvedValueOnce(errJson(500, {}));
+      const res = await client.refreshPrinters();
+      if (!res.success) expect(res.error).toMatch(/refresh/);
+    });
+
+    it('wraps thrown Error', async () => {
+      fetchSpy.mockRejectedValueOnce(new Error('network'));
+      const res = await client.refreshPrinters();
+      if (!res.success) expect(res.error).toMatch(/network/);
+    });
+
+    it('returns generic error on non-Error throw', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fetchSpy.mockRejectedValueOnce(123 as any);
+      const res = await client.refreshPrinters();
+      if (!res.success) expect(res.error).toBe('Failed to refresh printers');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // printTestLabel
+  // ---------------------------------------------------------------------------
+  describe('printTestLabel', () => {
+    it('sends printerName in body and returns data', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        okJson({ success: true, message: 'ok', printerName: 'ZD420' })
+      );
+      const res = await client.printTestLabel('ZD420');
+      expect(res.success).toBe(true);
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(JSON.parse(init.body)).toEqual({ printerName: 'ZD420' });
+    });
+
+    it('uses body error message on failure', async () => {
+      fetchSpy.mockResolvedValueOnce(errJson(400, { message: 'no such printer' }));
+      const res = await client.printTestLabel('missing');
+      if (!res.success) expect(res.error).toBe('no such printer');
+    });
+
+    it('falls back to default when body has no message', async () => {
+      fetchSpy.mockResolvedValueOnce(errJson(400, {}));
+      const res = await client.printTestLabel('x');
+      if (!res.success) expect(res.error).toMatch(/test label/);
+    });
+
+    it('wraps Error throws', async () => {
+      fetchSpy.mockRejectedValueOnce(new Error('oops'));
+      const res = await client.printTestLabel('x');
+      if (!res.success) expect(res.error).toMatch(/oops/);
+    });
+
+    it('generic message on non-Error throw', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fetchSpy.mockRejectedValueOnce(null as any);
+      const res = await client.printTestLabel('x');
+      if (!res.success) expect(res.error).toBe('Failed to print test label');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // printLabel
+  // ---------------------------------------------------------------------------
+  describe('printLabel', () => {
+    it('sends printerName and zplContent', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        okJson({ success: true, message: 'ok', printerName: 'ZD420' })
+      );
+      await client.printLabel('ZD420', '^XA^XZ');
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(JSON.parse(init.body)).toEqual({
+        printerName: 'ZD420',
+        zplContent: '^XA^XZ',
+      });
+    });
+
+    it('returns body message on failure', async () => {
+      fetchSpy.mockResolvedValueOnce(errJson(400, { message: 'nope' }));
+      const res = await client.printLabel('x', 'zpl');
+      if (!res.success) expect(res.error).toBe('nope');
+    });
+
+    it('default error when no body message', async () => {
+      fetchSpy.mockResolvedValueOnce(errJson(500, {}));
+      const res = await client.printLabel('x', 'zpl');
+      if (!res.success) expect(res.error).toMatch(/print label/);
+    });
+
+    it('wraps Error throws', async () => {
+      fetchSpy.mockRejectedValueOnce(new Error('no route'));
+      const res = await client.printLabel('x', 'zpl');
+      if (!res.success) expect(res.error).toMatch(/no route/);
+    });
+
+    it('generic message on non-Error throw', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fetchSpy.mockRejectedValueOnce(undefined as any);
+      const res = await client.printLabel('x', 'zpl');
+      if (!res.success) expect(res.error).toBe('Failed to print label');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // printBatch
+  // ---------------------------------------------------------------------------
+  describe('printBatch', () => {
+    it('sends array of zplContents', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        okJson({ success: true, message: 'ok', printerName: 'x', labelCount: 2 })
+      );
+      await client.printBatch('x', ['a', 'b']);
+      const [, init] = fetchSpy.mock.calls[0];
+      expect(JSON.parse(init.body)).toEqual({
+        printerName: 'x',
+        zplContents: ['a', 'b'],
+      });
+    });
+
+    it('body message used on failure', async () => {
+      fetchSpy.mockResolvedValueOnce(errJson(400, { message: 'batch bad' }));
+      const res = await client.printBatch('x', ['a']);
+      if (!res.success) expect(res.error).toBe('batch bad');
+    });
+
+    it('default message when body missing message', async () => {
+      fetchSpy.mockResolvedValueOnce(errJson(500, {}));
+      const res = await client.printBatch('x', ['a']);
+      if (!res.success) expect(res.error).toMatch(/print labels/);
+    });
+
+    it('wraps Error throws', async () => {
+      fetchSpy.mockRejectedValueOnce(new Error('dead'));
+      const res = await client.printBatch('x', ['a']);
+      if (!res.success) expect(res.error).toMatch(/dead/);
+    });
+
+    it('generic message on non-Error throw', async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      fetchSpy.mockRejectedValueOnce({} as any);
+      const res = await client.printBatch('x', ['a']);
+      if (!res.success) expect(res.error).toBe('Failed to print labels');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // getDefaultZebraPrinter
+  // ---------------------------------------------------------------------------
+  describe('getDefaultZebraPrinter', () => {
+    const zebraDefault = {
+      name: 'ZD420',
+      status: 'idle',
+      isDefault: true,
+      isZebraPrinter: true,
+      driverName: '',
+      portName: '',
+    };
+    const zebraOther = { ...zebraDefault, name: 'ZD220', isDefault: false };
+    const nonZebra = { ...zebraDefault, name: 'HPx', isZebraPrinter: false };
+
+    it('returns default Zebra when present', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        okJson({ printers: [zebraOther, zebraDefault, nonZebra], count: 3, zebraCount: 2 })
+      );
+      const res = await client.getDefaultZebraPrinter();
+      expect(res.success).toBe(true);
+      if (res.success) expect(res.data?.name).toBe('ZD420');
+    });
+
+    it('falls back to first Zebra when no default Zebra', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        okJson({ printers: [nonZebra, zebraOther], count: 2, zebraCount: 1 })
+      );
+      const res = await client.getDefaultZebraPrinter();
+      expect(res.success).toBe(true);
+      if (res.success) expect(res.data?.name).toBe('ZD220');
+    });
+
+    it('returns data: null when no Zebra printers', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        okJson({ printers: [nonZebra], count: 1, zebraCount: 0 })
+      );
+      const res = await client.getDefaultZebraPrinter();
+      expect(res.success).toBe(true);
+      if (res.success) expect(res.data).toBeNull();
+    });
+
+    it('propagates getPrinters failure', async () => {
+      fetchSpy.mockRejectedValueOnce(new Error('offline'));
+      const res = await client.getDefaultZebraPrinter();
+      expect(res.success).toBe(false);
+      if (!res.success) expect(res.error).toMatch(/offline/);
+    });
+  });
+
+  it('default constructor uses localhost:9632', async () => {
+    const defaultClient = new PrintBridgeClient();
+    fetchSpy.mockResolvedValueOnce(okJson({ status: 'ok', version: '1', timestamp: 't' }));
+    await defaultClient.checkHealth();
+    expect(fetchSpy.mock.calls[0][0]).toBe('http://localhost:9632/health');
+  });
+});

--- a/src/web/vitest.config.ts
+++ b/src/web/vitest.config.ts
@@ -31,23 +31,36 @@ export default defineConfig({
         'src/vite-env.d.ts',
       ],
       thresholds: {
-        // Honest-denominator floor. Wave 3 (#498) added a shared
-        // renderHookWithQuery harness and tests for ~24 TanStack Query hook
-        // modules (campuses/families/people/groups/schedules/locations/
-        // giving/settings/profile/notifications/security-roles/auditLogs/
-        // devices/comms/comm-templates/checkin/personMerge/publicGroups/
-        // supervisorMode/supervisorAttendance/globalSearch/import/import-jobs/
-        // myGroups/checkinOperations/mutationWithToast + the 4 features/*
-        // api+hooks pairs (admin/defined-types, followups, pager,
-        // authorized-pickup) + deeper services/api coverage.
-        //   lines 32.15, statements 32.07, functions 36.82, branches 19.35
-        // Thresholds set ~1-2 pts below the achieved number (small buffer so
-        // minor churn does not break CI). No coverage.exclude changes — every
-        // point of movement comes from real tests.
-        lines: 30,
-        statements: 30,
-        functions: 34,
-        branches: 18,
+        // Honest-denominator floor. Wave 4 (#498) reached the realistic unit
+        // ceiling by testing the remaining branch-rich, low-dependency code:
+        //   - services/printing/PrintBridgeClient.ts (7 methods, 24 branches)
+        //   - api/client.ts (auth + 401 handling)
+        //   - services/errorTracking.ts (Sentry guards)
+        //   - components/RouteErrorBoundary.tsx (4 status branches + JS path)
+        //   - features/followups/{FollowUpCard,FollowUpQueue}.tsx
+        //   - features/pager/{PagerSearch,PageHistory,SendPageDialog}.tsx
+        //   - features/authorized-pickup/{AuthorizedPickupList,
+        //     PickupHistoryPanel}.tsx
+        //   - components/groups/{GroupCard,PendingRequestsList,
+        //     RequestToJoinModal}.tsx
+        //   - components/common/PhotoUpload.tsx
+        //   - components/notifications/NotificationList.tsx
+        //   - hooks/usePrintBridgeConnection.ts
+        //
+        // Achieved wave-4 floor:
+        //   lines 37.60, statements 37.84, functions 41.09, branches 25.50
+        // Thresholds set ~2 pts below achieved (small buffer so minor churn
+        // does not break CI). No coverage.exclude changes — every point of
+        // movement comes from real tests.
+        //
+        // The remaining gap to higher coverage is E2E territory: full admin
+        // pages (pages/admin/**, pages/communications/**, pages/settings/**)
+        // and large stateful modals that require a router + multiple hook
+        // providers.
+        lines: 35,
+        statements: 35,
+        functions: 38,
+        branches: 23,
         // Critical path: offline services must stay well tested.
         // These are higher than the global floor because offline queue bugs
         // cause silent check-in data loss.


### PR DESCRIPTION
## Summary

Wave 4 raises honest frontend coverage from **32.15% → 37.60% lines** and
**19.35% → 25.50% branches** by testing the remaining branch-rich,
low-dependency modules. This is the realistic unit-test ceiling for #498;
everything left belongs to Playwright E2E.

- **No production source changes.** Only new tests + the vitest threshold bump.
- **No `coverage.exclude` / `coverage.include` / `coverage.all` changes.** Every point came from real tests.
- **No tests were modified.** 17 new test files, zero edits to existing specs.

## BEFORE vs AFTER (global)

| Metric     | BEFORE (wave 3) | AFTER (wave 4) | Δ         |
|------------|-----------------|----------------|-----------|
| Lines      | 32.15%          | **37.60%**     | +5.45 pts |
| Statements | 32.07%          | **37.84%**     | +5.77 pts |
| Functions  | 36.82%          | **41.09%**     | +4.27 pts |
| Branches   | 19.35%          | **25.50%**     | +6.15 pts |

Both targets hit with buffer: 37%+ lines (achieved 37.60), 25%+ branches (achieved 25.50).

## Per-directory deltas

| Directory               | BEFORE lines | AFTER lines | Notes |
|-------------------------|--------------|-------------|-------|
| `api/`                  | 0%           | **100%**    | new `client.test.ts` |
| `services/printing/`    | 0%           | **100%**    | new `PrintBridgeClient.test.ts` (7 methods × 4-5 branches each) |
| `services/`             | 0%           | **55.55%**  | `errorTracking.test.ts` (Sentry guards) |
| `components/common/`    | 0%           | **30.48%**  | `PhotoUpload.test.tsx`; `ImageCropper.tsx` intentionally deferred (350 lines, browser Canvas API) |
| `components/groups/`    | 17.96%       | **65.62%**  | `GroupCard.test.tsx`, `PendingRequestsList.test.tsx`, `RequestToJoinModal.test.tsx` |
| `components/notifications/` | 25.58%   | ~44%        | `NotificationList.test.tsx` (NotificationBell deferred — too many hook deps) |
| `features/followups/`   | 36.58%       | **91.46%**  | `FollowUpCard.test.tsx`, `FollowUpQueue.test.tsx` |
| `features/pager/`       | 43.63%       | **99.09%**  | `PagerSearch.test.tsx`, `PageHistory.test.tsx`, `SendPageDialog.test.tsx` |
| `features/authorized-pickup/` | 34.71% | **60.10%**  | `AuthorizedPickupList.test.tsx`, `PickupHistoryPanel.test.tsx`; `PickupVerification.tsx` + `AddEditAuthorizedPickupDialog.tsx` deferred as too-large form-heavy modals |
| `hooks/`                | 69.31%       | **76.14%**  | `usePrintBridgeConnection.test.tsx` (state-machine with 4 outcome branches + exponential backoff) |
| `components/RouteErrorBoundary.tsx` | 0% | **100%** | 4 HTTP-status branches + JS error path |

## Test files added (17)

- `src/api/__tests__/client.test.ts` — 14 tests, ApiException + auth + 401 handling
- `src/components/__tests__/RouteErrorBoundary.test.tsx` — 6 tests (404/403/500/other/JS)
- `src/components/common/__tests__/PhotoUpload.test.tsx` — 9 tests (drag-drop, validation, preview)
- `src/components/groups/__tests__/GroupCard.test.tsx` — 15 tests (branches for Open/Full, capacity, onClick variants)
- `src/components/groups/__tests__/PendingRequestsList.test.tsx` — 8 tests
- `src/components/groups/__tests__/RequestToJoinModal.test.tsx` — 12 tests (submit/error/success/close/escape)
- `src/components/notifications/__tests__/NotificationList.test.tsx` — 11 tests (loading/error/empty/navigate/mutate)
- `src/features/authorized-pickup/__tests__/AuthorizedPickupList.test.tsx` — 16 tests (confirm gates, error paths)
- `src/features/authorized-pickup/__tests__/PickupHistoryPanel.test.tsx` — 8 tests
- `src/features/followups/__tests__/FollowUpCard.test.tsx` — 14 tests (all 5 status badges, edit/save/update paths)
- `src/features/followups/__tests__/FollowUpQueue.test.tsx` — 10 tests (filter buttons, empty-filter state)
- `src/features/pager/__tests__/PageHistory.test.tsx` — 8 tests (all 4 Sent/Delivered/Pending/Failed branches)
- `src/features/pager/__tests__/PagerSearch.test.tsx` — 11 tests (debounce, normalize P-prefix, result variants)
- `src/features/pager/__tests__/SendPageDialog.test.tsx` — 18 tests (rate limits, disable conditions, success/error)
- `src/hooks/__tests__/usePrintBridgeConnection.test.tsx` — 7 tests (all 3 error categorisations + no-printer + retry)
- `src/services/__tests__/errorTracking.test.ts` — 8 tests (DEV-mode no-op guards + init DSN paths)
- `src/services/printing/__tests__/PrintBridgeClient.test.ts` — 35 tests (7 methods × happy/body-error/default-error/Error-throw/non-Error-throw)

Total new tests: **210**. Global: 141 files / 1292 tests.

## New thresholds

Set ~2 pts below achieved floor (matches wave-3 pattern):

```
lines:      35  (was 30)  — achieved 37.60
statements: 35  (was 30)  — achieved 37.84
functions:  38  (was 34)  — achieved 41.09
branches:   23  (was 18)  — achieved 25.50
```

`services/offline/**` path threshold unchanged (lines:80 / branches:50 / funcs:85); achieved still 84/57/89.

## Honest final assessment — what is the unit-test ceiling?

**The realistic unit-test ceiling for this codebase is ~38-42% lines / 26-30% branches.**
Wave 4 is within 1-2 points of that ceiling. Pushing higher on unit tests alone would require either:

1. Testing full admin pages (500-700 line files with router + 10+ hooks each), which requires heavy mocking (>5 modules) and fails the "every test catches a real behaviour regression" bar; or
2. Inflating with smoke tests that just render-and-assert-defined (explicitly forbidden).

### What is intentionally NOT covered (deferred to Playwright E2E)

**Full admin pages (0% each — `pages/admin/**`, `pages/communications/**`, `pages/profile/**`, `pages/public/**`, `pages/settings/**`):**
- `pages/admin/people/PersonDetailPage.tsx` (308 lines), `PersonFormPage.tsx` (459), `PersonListPage.tsx` (252), `PersonHistoryPage.tsx` (169), `PersonReviewPage.tsx` (239)
- `pages/admin/schedules/{ScheduleDetailPage,ScheduleFormPage,ScheduleListPage}.tsx` (315/399/211)
- `pages/admin/settings/{SecurityRolesPage,GroupTypesPage,FundsPage,AuditLogsPage,CampusesPage}.tsx` (708/602/393/254/118)
- `pages/admin/import/{BulkImportPage,ImportHistoryPage,DonationsImportPage}.tsx` (304/212/283)
- `pages/admin/analytics/VolunteersTreePage.tsx` (168), `pages/communications/*.tsx` (321/266/321/332)
- `pages/CheckinPage.tsx`, `pages/public/GroupFinderPage.tsx`, `pages/SearchResultsPage.tsx`

**Full-page admin components (4.71% dir coverage):**
- `components/admin/Sidebar.tsx` (271), `Header.tsx` (201), `GlobalSearchModal.tsx` (392)
- `components/admin/people/{PersonFormPage-adjacent}.tsx` families/groups/notes/etc. sections (200-500 lines each)
- `components/admin/people/mergeWizard.tsx` (494)

**Large form/modal components requiring full-provider trees:**
- `features/admin/DataExportsPage.tsx` (486)
- `features/authorized-pickup/AddEditAuthorizedPickupDialog.tsx` (259, heavy form)
- `features/authorized-pickup/PickupVerification.tsx` (364, depends on useAuth + 2 feature hooks + security-code flow)
- `components/giving/*` (many large donation/split/table components)
- `components/import/*` (all ~200 lines each, file-upload + CSV-mapping heavy)
- `components/common/ImageCropper.tsx` (350, Canvas API)
- `components/mygroups/*`, `components/settings/*`

**Hooks with heavy browser-API integration:**
- `hooks/useQrScanner.ts` (0%) — camera MediaStream API
- `hooks/useNotificationHub.ts` (0%) — SignalR subscription
- `hooks/useOfflineCheckin.ts` (0%) — IndexedDB + service worker messaging

These are all much better exercised end-to-end through real user flows (Playwright), where the router tree, TanStack Query providers, and auth context are the real deal.

### Recommendation for the PM

**#498 is ready to close at the unit ceiling.** Further unit waves would produce diminishing returns (every remaining file requires ≥5 module mocks or full router/auth scaffolding, which violates the test-bar rules established in waves 2/3). The right next investment is:

- **Expanding Playwright coverage** to cover the admin pages and form-heavy modals listed above (issue #482 started this for the live check-in dashboard; similar specs for People/Groups/Schedules/Settings admin flows would move the overall product coverage well above 50% without gaming the unit floor).

A hypothetical wave 5 could squeeze out maybe 1-2 more unit points by cherry-picking `AddEditAuthorizedPickupDialog`, `PickupVerification`, and 1-2 settings sections — but it would not move the needle meaningfully compared to a focused E2E sprint.

## Test plan

- [x] `docker run node:20-alpine npx vitest run --coverage` — 141 files / 1292 tests pass; thresholds met (37.60/37.84/41.09/25.50 vs 35/35/38/23).
- [x] `npx tsc --noEmit` — 0 errors.
- [x] `dotnet build koinon-rms.sln` — green.
- [x] `git diff --name-only origin/dev` — only test files + `vitest.config.ts`.

Do NOT close #498 — PM handles.