### PR TITLE
test(hooks): unit-test browser-API hooks with mocked boundaries (#679)

### DIFF
--- a/src/web/src/hooks/__tests__/useNotificationHub.test.tsx
+++ b/src/web/src/hooks/__tests__/useNotificationHub.test.tsx
@@ -1,0 +1,233 @@
+/**
+ * useNotificationHub tests - wave 7 of #679.
+ *
+ * The hook dynamically imports @microsoft/signalr and connects to the
+ * /hubs/notifications endpoint. We mock both the signalr package and the
+ * api/client `getAccessToken` helper at the module boundary. That keeps the
+ * test deterministic — no network, no browser WebSocket, no auth.
+ *
+ * Rationale for unit-not-E2E: reconnect timing, network-error branches, and
+ * token-missing paths are impossible to reliably trigger from Playwright.
+ * Mocking HubConnection directly gives us direct control over every state
+ * transition the hook cares about.
+ */
+
+import { waitFor, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+// --- Mock @microsoft/signalr ------------------------------------------------
+// The HubConnectionBuilder fluent API returns a mock connection whose methods
+// are spies. Tests reach into `lastConnection` to drive handlers the hook
+// registered via `.on(...)`, `.onreconnecting(...)`, etc.
+
+type Handler = (...args: unknown[]) => void;
+
+interface MockHubConnection {
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  on: ReturnType<typeof vi.fn>;
+  off: ReturnType<typeof vi.fn>;
+  invoke: ReturnType<typeof vi.fn>;
+  onreconnecting: ReturnType<typeof vi.fn>;
+  onreconnected: ReturnType<typeof vi.fn>;
+  onclose: ReturnType<typeof vi.fn>;
+  state: string;
+  eventHandlers: Map<string, Handler>;
+  reconnectingHandler?: Handler;
+  reconnectedHandler?: Handler;
+  closeHandler?: (err?: Error) => void;
+}
+
+const hubState: { last: MockHubConnection | null; startError: Error | null } = {
+  last: null,
+  startError: null,
+};
+
+function makeConnection(): MockHubConnection {
+  const conn: MockHubConnection = {
+    start: vi.fn(async () => {
+      if (hubState.startError) {
+        const e = hubState.startError;
+        hubState.startError = null;
+        throw e;
+      }
+      conn.state = 'Connected';
+    }),
+    stop: vi.fn(async () => {
+      conn.state = 'Disconnected';
+    }),
+    on: vi.fn((event: string, cb: Handler) => {
+      conn.eventHandlers.set(event, cb);
+    }),
+    off: vi.fn(),
+    invoke: vi.fn(async () => undefined),
+    onreconnecting: vi.fn((cb: Handler) => {
+      conn.reconnectingHandler = cb;
+    }),
+    onreconnected: vi.fn((cb: Handler) => {
+      conn.reconnectedHandler = cb;
+    }),
+    onclose: vi.fn((cb: (err?: Error) => void) => {
+      conn.closeHandler = cb;
+    }),
+    state: 'Disconnected',
+    eventHandlers: new Map(),
+  };
+  return conn;
+}
+
+vi.mock('@microsoft/signalr', () => {
+  class HubConnectionBuilder {
+    withUrl() {
+      return this;
+    }
+    withAutomaticReconnect() {
+      return this;
+    }
+    build() {
+      const conn = makeConnection();
+      hubState.last = conn;
+      return conn;
+    }
+  }
+  const HubConnectionState = {
+    Disconnected: 'Disconnected',
+    Connecting: 'Connecting',
+    Connected: 'Connected',
+    Disconnecting: 'Disconnecting',
+    Reconnecting: 'Reconnecting',
+  };
+  return { HubConnectionBuilder, HubConnectionState };
+});
+
+// --- Mock api/client `getAccessToken` --------------------------------------
+// The hook dynamically imports this, so we mock the module used.
+const tokenState = { token: 'fake-jwt-token' as string | null };
+vi.mock('@/services/api/client', () => ({
+  getAccessToken: () => tokenState.token,
+  // Preserve ApiClientError shape in case anything else imports from here in
+  // the same test transform run. Keeping it as a named class avoids surprises.
+  ApiClientError: class ApiClientError extends Error {
+    constructor(
+      public status: number,
+      message: string
+    ) {
+      super(message);
+    }
+  },
+}));
+
+import { useNotificationHub } from '../useNotificationHub';
+
+beforeEach(() => {
+  hubState.last = null;
+  hubState.startError = null;
+  tokenState.token = 'fake-jwt-token';
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useNotificationHub', () => {
+  it('builds a connection and calls start() on mount', async () => {
+    const { result, unmount } = renderHookWithQuery(() => useNotificationHub());
+
+    await waitFor(() => expect(hubState.last).not.toBeNull());
+    await waitFor(() => expect(hubState.last?.start).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(result.current.isConnected).toBe(true));
+    expect(result.current.error).toBeNull();
+    unmount();
+  });
+
+  it('does not connect when enabled=false', async () => {
+    const { result, unmount } = renderHookWithQuery(() => useNotificationHub(false));
+
+    // Give any async import a chance; nothing should happen.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(hubState.last).toBeNull();
+    expect(result.current.isConnected).toBe(false);
+    unmount();
+  });
+
+  it('reports an error when no access token is available', async () => {
+    tokenState.token = null;
+    const { result, unmount } = renderHookWithQuery(() => useNotificationHub());
+
+    await waitFor(() => expect(result.current.error).toBe('No access token available'));
+    // Connection should not have been built without a token.
+    expect(hubState.last).toBeNull();
+    unmount();
+  });
+
+  it('reports an error when connection.start() rejects', async () => {
+    hubState.startError = new Error('boom');
+    const { result, unmount } = renderHookWithQuery(() => useNotificationHub());
+
+    await waitFor(() => expect(result.current.error).toBe('boom'));
+    expect(result.current.isConnected).toBe(false);
+    unmount();
+  });
+
+  it('invalidates notification queries when ReceiveNotification fires', async () => {
+    const { client, unmount } = renderHookWithQuery(() => useNotificationHub());
+
+    await waitFor(() => expect(hubState.last).not.toBeNull());
+    await waitFor(() => expect(hubState.last?.start).toHaveBeenCalled());
+
+    const invalidate = vi.spyOn(client, 'invalidateQueries');
+    act(() => {
+      hubState.last?.eventHandlers.get('ReceiveNotification')?.({ id: 1 });
+    });
+
+    // Fired twice: once for ['notifications'], once for unread-count.
+    expect(invalidate).toHaveBeenCalled();
+    expect(invalidate.mock.calls.length).toBeGreaterThanOrEqual(2);
+    unmount();
+  });
+
+  it('updates the unread-count cache when UnreadCountUpdated fires', async () => {
+    const { client, unmount } = renderHookWithQuery(() => useNotificationHub());
+
+    await waitFor(() => expect(hubState.last).not.toBeNull());
+    await waitFor(() => expect(hubState.last?.start).toHaveBeenCalled());
+
+    act(() => {
+      hubState.last?.eventHandlers.get('UnreadCountUpdated')?.(7);
+    });
+
+    expect(client.getQueryData(['notifications', 'unread-count'])).toBe(7);
+    unmount();
+  });
+
+  it('flips isConnecting true during a reconnect and back to connected', async () => {
+    const { result, unmount } = renderHookWithQuery(() => useNotificationHub());
+
+    await waitFor(() => expect(result.current.isConnected).toBe(true));
+
+    act(() => {
+      hubState.last?.reconnectingHandler?.();
+    });
+    expect(result.current.isConnecting).toBe(true);
+    expect(result.current.isConnected).toBe(false);
+
+    act(() => {
+      hubState.last?.reconnectedHandler?.();
+    });
+    expect(result.current.isConnected).toBe(true);
+    expect(result.current.isConnecting).toBe(false);
+    unmount();
+  });
+
+  it('calls stop() on unmount when connected', async () => {
+    const { unmount } = renderHookWithQuery(() => useNotificationHub());
+
+    await waitFor(() => expect(hubState.last).not.toBeNull());
+    await waitFor(() => expect(hubState.last?.start).toHaveBeenCalled());
+    const conn = hubState.last!;
+    // state is 'Connected' after start() resolves, so cleanup should call stop().
+    unmount();
+    expect(conn.stop).toHaveBeenCalled();
+  });
+});

--- a/src/web/src/hooks/__tests__/useOfflineCheckin.test.tsx
+++ b/src/web/src/hooks/__tests__/useOfflineCheckin.test.tsx
@@ -1,0 +1,280 @@
+/**
+ * useOfflineCheckin tests - wave 7 of #679.
+ *
+ * The hook wraps the already-well-tested `OfflineCheckinQueue` service (#498
+ * wave 3, 84% coverage). We mock that module directly rather than touching
+ * IndexedDB — the storage layer is not what this hook's tests should prove.
+ *
+ * What we DO prove here:
+ *   - online/offline state tracks `navigator.onLine` + window events.
+ *   - `recordCheckin` picks the online vs. offline path and falls back on
+ *     network failure.
+ *   - coming back online triggers a queue sync.
+ *   - sync status transitions are reflected in hook state.
+ *   - listeners are torn down on unmount.
+ *
+ * Rationale for unit-not-E2E: simulating offline/online transitions and
+ * partial-network failures in Playwright is slow and flaky. Object.defineProperty
+ * on `navigator.onLine` + dispatching `online`/`offline` events gives us
+ * bit-for-bit deterministic coverage.
+ */
+
+import { act, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderHookWithQuery } from '@/test-utils/queryTestHarness';
+
+// Mock the offline queue module — each test reshapes the mock for its case.
+vi.mock('@/services/offline/OfflineCheckinQueue', () => ({
+  offlineCheckinQueue: {
+    getQueuedCount: vi.fn(),
+    processQueue: vi.fn(),
+    addToQueue: vi.fn(),
+    clearQueue: vi.fn(),
+  },
+}));
+
+// Mock recordAttendance — we don't exercise the network call in these tests.
+vi.mock('@/services/api/checkin', () => ({
+  recordAttendance: vi.fn(),
+}));
+
+// Import the mocked modules after vi.mock so we get the mocked references.
+import { offlineCheckinQueue } from '@/services/offline/OfflineCheckinQueue';
+import { recordAttendance } from '@/services/api/checkin';
+import { ApiClientError } from '@/services/api/client';
+import { useOfflineCheckin } from '../useOfflineCheckin';
+
+/** Set navigator.onLine via property redefinition (read-only by default). */
+function setOnline(value: boolean): void {
+  Object.defineProperty(navigator, 'onLine', {
+    configurable: true,
+    get: () => value,
+  });
+}
+
+beforeEach(() => {
+  vi.mocked(offlineCheckinQueue.getQueuedCount).mockResolvedValue(0);
+  vi.mocked(offlineCheckinQueue.processQueue).mockResolvedValue([]);
+  vi.mocked(offlineCheckinQueue.addToQueue).mockResolvedValue('queue-id-1');
+  vi.mocked(offlineCheckinQueue.clearQueue).mockResolvedValue(undefined);
+  vi.mocked(recordAttendance).mockReset();
+  setOnline(true);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useOfflineCheckin — online/offline state', () => {
+  it('reflects the initial navigator.onLine value', async () => {
+    setOnline(true);
+    const { result, unmount } = renderHookWithQuery(() => useOfflineCheckin());
+    expect(result.current.state.isOnline).toBe(true);
+    expect(result.current.state.mode).toBe('online');
+    unmount();
+
+    setOnline(false);
+    const { result: offlineResult, unmount: offlineUnmount } = renderHookWithQuery(
+      () => useOfflineCheckin()
+    );
+    expect(offlineResult.current.state.isOnline).toBe(false);
+    expect(offlineResult.current.state.mode).toBe('offline');
+    offlineUnmount();
+  });
+
+  it('flips to offline mode when window fires an offline event', async () => {
+    const { result, unmount } = renderHookWithQuery(() => useOfflineCheckin());
+
+    act(() => {
+      setOnline(false);
+      window.dispatchEvent(new Event('offline'));
+    });
+
+    await waitFor(() => expect(result.current.state.isOnline).toBe(false));
+    expect(result.current.state.mode).toBe('offline');
+    unmount();
+  });
+
+  it('auto-syncs the queue when an online event fires', async () => {
+    setOnline(false);
+    const { result, unmount } = renderHookWithQuery(() => useOfflineCheckin());
+    await waitFor(() => expect(result.current.state.isOnline).toBe(false));
+
+    vi.mocked(offlineCheckinQueue.processQueue).mockResolvedValueOnce([
+      { id: 'a', success: true },
+    ]);
+
+    act(() => {
+      setOnline(true);
+      window.dispatchEvent(new Event('online'));
+    });
+
+    await waitFor(() =>
+      expect(offlineCheckinQueue.processQueue).toHaveBeenCalledTimes(1)
+    );
+    unmount();
+  });
+});
+
+describe('useOfflineCheckin — recordCheckin dispatch', () => {
+  it('calls recordAttendance when online', async () => {
+    setOnline(true);
+    vi.mocked(recordAttendance).mockResolvedValueOnce({
+      successCount: 1,
+      failureCount: 0,
+      results: [],
+    } as never);
+
+    const { result, unmount } = renderHookWithQuery(() => useOfflineCheckin());
+
+    await act(async () => {
+      await result.current.recordCheckin([{ personIdKey: 'p1' } as never]);
+    });
+
+    expect(recordAttendance).toHaveBeenCalledTimes(1);
+    expect(offlineCheckinQueue.addToQueue).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('queues the request when offline instead of calling the API', async () => {
+    setOnline(false);
+    const { result, unmount } = renderHookWithQuery(() => useOfflineCheckin());
+
+    await act(async () => {
+      await result.current.recordCheckin([{ personIdKey: 'p2' } as never]);
+    });
+
+    expect(recordAttendance).not.toHaveBeenCalled();
+    expect(offlineCheckinQueue.addToQueue).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('falls back to the queue on a network failure (non-ApiClientError)', async () => {
+    setOnline(true);
+    vi.mocked(recordAttendance).mockRejectedValueOnce(
+      new TypeError('Failed to fetch')
+    );
+
+    const { result, unmount } = renderHookWithQuery(() => useOfflineCheckin());
+
+    await act(async () => {
+      await result.current.recordCheckin([{ personIdKey: 'p3' } as never]);
+    });
+
+    expect(offlineCheckinQueue.addToQueue).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('re-throws ApiClientError instead of queuing (server rejection)', async () => {
+    setOnline(true);
+    // ApiClientError's real constructor takes (status, errorData, format?, message?).
+    // Use the legacy shape so it preserves message via `errorData.message`.
+    vi.mocked(recordAttendance).mockRejectedValueOnce(
+      new ApiClientError(400, { code: 'BAD', message: 'Bad request' } as never)
+    );
+
+    const { result, unmount } = renderHookWithQuery(() => useOfflineCheckin());
+
+    await expect(
+      result.current.recordCheckin([{ personIdKey: 'p4' } as never])
+    ).rejects.toBeInstanceOf(ApiClientError);
+    expect(offlineCheckinQueue.addToQueue).not.toHaveBeenCalled();
+    unmount();
+  });
+});
+
+describe('useOfflineCheckin — sync status', () => {
+  it('clears queue when clearQueue() is invoked', async () => {
+    const { result, unmount } = renderHookWithQuery(() => useOfflineCheckin());
+
+    await act(async () => {
+      await result.current.clearQueue();
+    });
+
+    expect(offlineCheckinQueue.clearQueue).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it('sets syncStatus=error when processQueue rejects', async () => {
+    setOnline(true);
+    vi.mocked(offlineCheckinQueue.processQueue).mockRejectedValueOnce(
+      new Error('sync failed')
+    );
+
+    const { result, unmount } = renderHookWithQuery(() => useOfflineCheckin());
+
+    await act(async () => {
+      await result.current.syncQueue();
+    });
+
+    expect(result.current.state.syncStatus).toBe('error');
+    unmount();
+  });
+
+  it('sets syncStatus=success when processQueue resolves without failures', async () => {
+    setOnline(true);
+    vi.mocked(offlineCheckinQueue.processQueue).mockResolvedValueOnce([
+      { id: 'a', success: true },
+    ]);
+
+    const { result, unmount } = renderHookWithQuery(() => useOfflineCheckin());
+
+    await act(async () => {
+      await result.current.syncQueue();
+    });
+
+    expect(result.current.state.syncStatus).toBe('success');
+    expect(result.current.state.lastSyncResults).toHaveLength(1);
+    unmount();
+  });
+
+  it('sets syncStatus=error when any result in the batch has success=false', async () => {
+    setOnline(true);
+    vi.mocked(offlineCheckinQueue.processQueue).mockResolvedValueOnce([
+      { id: 'a', success: true },
+      { id: 'b', success: false, error: 'boom' },
+    ]);
+
+    const { result, unmount } = renderHookWithQuery(() => useOfflineCheckin());
+
+    await act(async () => {
+      await result.current.syncQueue();
+    });
+
+    expect(result.current.state.syncStatus).toBe('error');
+    unmount();
+  });
+
+  it('no-ops syncQueue when offline', async () => {
+    setOnline(false);
+    const { result, unmount } = renderHookWithQuery(() => useOfflineCheckin());
+
+    await act(async () => {
+      await result.current.syncQueue();
+    });
+
+    expect(offlineCheckinQueue.processQueue).not.toHaveBeenCalled();
+    unmount();
+  });
+});
+
+describe('useOfflineCheckin — lifecycle', () => {
+  it('removes online/offline listeners on unmount', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { unmount } = renderHookWithQuery(() => useOfflineCheckin());
+
+    const addedOnline = addSpy.mock.calls.some((c) => c[0] === 'online');
+    const addedOffline = addSpy.mock.calls.some((c) => c[0] === 'offline');
+    expect(addedOnline).toBe(true);
+    expect(addedOffline).toBe(true);
+
+    unmount();
+
+    const removedOnline = removeSpy.mock.calls.some((c) => c[0] === 'online');
+    const removedOffline = removeSpy.mock.calls.some((c) => c[0] === 'offline');
+    expect(removedOnline).toBe(true);
+    expect(removedOffline).toBe(true);
+  });
+});

--- a/src/web/src/hooks/__tests__/useQrScanner.test.tsx
+++ b/src/web/src/hooks/__tests__/useQrScanner.test.tsx
@@ -1,0 +1,275 @@
+/**
+ * useQrScanner tests - wave 7 of #679.
+ *
+ * The hook drives two scanning paths:
+ *   1. Camera-based: wraps `Html5Qrcode` from html5-qrcode. We mock the class
+ *      entirely so no real camera permission / media track is touched.
+ *   2. Keyboard wedge: attaches a `keypress` document listener while scanning.
+ *      Wedge scanners type fast then press Enter (or pause >100ms). We drive
+ *      both the Enter-terminated and timeout-terminated paths.
+ *
+ * Rationale for unit-not-E2E: camera permission grants, MediaDevices, and
+ * device-specific camera availability are intrinsically flaky in browser
+ * automation. Mocking at the library boundary gives deterministic coverage
+ * of the hook's own state machine and wedge handling, which is where bugs
+ * actually hide.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mutable mock state — allows each test to reshape scanner behaviour without
+// re-mocking the module (vi.mock is hoisted and cannot close over per-test refs).
+type ScanCallback = (text: string) => void;
+type ScanErrorCallback = (err: string) => void;
+
+interface MockScannerInstance {
+  start: ReturnType<typeof vi.fn>;
+  stop: ReturnType<typeof vi.fn>;
+  clear: ReturnType<typeof vi.fn>;
+  isScanning: boolean;
+  // Captured callbacks from the last start() invocation so tests can drive them.
+  successCb?: ScanCallback;
+  errorCb?: ScanErrorCallback;
+}
+
+const scannerState: { instance: MockScannerInstance | null } = { instance: null };
+// Tests set this to make the next scanner.start() throw a given error (simulates
+// camera permission denied etc.).
+let nextStartError: Error | null = null;
+
+vi.mock('html5-qrcode', () => {
+  class Html5Qrcode {
+    start = vi.fn(
+      async (
+        _cameraConfig: unknown,
+        _scanConfig: unknown,
+        successCb: ScanCallback,
+        errorCb: ScanErrorCallback
+      ) => {
+        if (nextStartError) {
+          const e = nextStartError;
+          nextStartError = null;
+          throw e;
+        }
+        this.isScanning = true;
+        this.successCb = successCb;
+        this.errorCb = errorCb;
+      }
+    );
+    stop = vi.fn(async () => {
+      this.isScanning = false;
+    });
+    clear = vi.fn(async () => {});
+    isScanning = false;
+    successCb?: ScanCallback;
+    errorCb?: ScanErrorCallback;
+
+    constructor(_elementId: string) {
+      scannerState.instance = this as unknown as MockScannerInstance;
+    }
+  }
+  return { Html5Qrcode };
+});
+
+import { useQrScanner } from '../useQrScanner';
+
+beforeEach(() => {
+  scannerState.instance = null;
+  nextStartError = null;
+  // Hook reads document.getElementById('qr-reader') before creating a scanner;
+  // provide it so the happy path can execute.
+  const el = document.createElement('div');
+  el.id = 'qr-reader';
+  document.body.appendChild(el);
+});
+
+afterEach(() => {
+  document.getElementById('qr-reader')?.remove();
+  vi.restoreAllMocks();
+});
+
+describe('useQrScanner — camera path', () => {
+  it('startScanning instantiates Html5Qrcode and flips isScanning', async () => {
+    const onScan = vi.fn();
+    const { result } = renderHook(() => useQrScanner({ onScan }));
+
+    expect(result.current.isScanning).toBe(false);
+
+    await act(async () => {
+      await result.current.startScanning();
+    });
+
+    expect(scannerState.instance).not.toBeNull();
+    expect(scannerState.instance?.start).toHaveBeenCalledTimes(1);
+    expect(result.current.isScanning).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('routes a valid koinon:// QR payload to onScan with the IdKey', async () => {
+    const onScan = vi.fn();
+    const { result } = renderHook(() => useQrScanner({ onScan }));
+
+    await act(async () => {
+      await result.current.startScanning();
+    });
+
+    // Drive the library's success callback directly — the hook passes this to
+    // Html5Qrcode.start() and we captured it in the mock.
+    act(() => {
+      scannerState.instance?.successCb?.('koinon://family/ABC123');
+    });
+
+    expect(onScan).toHaveBeenCalledWith('ABC123');
+  });
+
+  it('invokes onError for an invalid QR payload', async () => {
+    const onScan = vi.fn();
+    const onError = vi.fn();
+    const { result } = renderHook(() => useQrScanner({ onScan, onError }));
+
+    await act(async () => {
+      await result.current.startScanning();
+    });
+
+    act(() => {
+      scannerState.instance?.successCb?.('not-a-koinon-url');
+    });
+
+    expect(onScan).not.toHaveBeenCalled();
+    expect(onError).toHaveBeenCalled();
+  });
+
+  it('surfaces camera permission denied (NotAllowedError) as hook error state', async () => {
+    const onScan = vi.fn();
+    const onError = vi.fn();
+    nextStartError = Object.assign(new Error('Permission denied'), {
+      name: 'NotAllowedError',
+    });
+
+    const { result } = renderHook(() => useQrScanner({ onScan, onError }));
+
+    await act(async () => {
+      await result.current.startScanning();
+    });
+
+    expect(result.current.isScanning).toBe(false);
+    expect(result.current.error).toBe('Permission denied');
+    expect(onError).toHaveBeenCalledWith('Permission denied');
+  });
+
+  it('sets an error when the required DOM element is missing', async () => {
+    document.getElementById('qr-reader')?.remove();
+    const onScan = vi.fn();
+    const onError = vi.fn();
+    const { result } = renderHook(() => useQrScanner({ onScan, onError }));
+
+    await act(async () => {
+      await result.current.startScanning();
+    });
+
+    expect(result.current.error).toBe('QR reader element not found');
+    expect(scannerState.instance).toBeNull();
+    expect(onError).toHaveBeenCalledWith('QR reader element not found');
+  });
+
+  it('stopScanning clears the scanner and resets isScanning', async () => {
+    const onScan = vi.fn();
+    const { result } = renderHook(() => useQrScanner({ onScan }));
+
+    await act(async () => {
+      await result.current.startScanning();
+    });
+    expect(result.current.isScanning).toBe(true);
+
+    await act(async () => {
+      await result.current.stopScanning();
+    });
+
+    expect(scannerState.instance?.stop).toHaveBeenCalled();
+    expect(scannerState.instance?.clear).toHaveBeenCalled();
+    expect(result.current.isScanning).toBe(false);
+  });
+});
+
+describe('useQrScanner — keyboard wedge path', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('processes Enter-terminated wedge input as a full scan', async () => {
+    const onScan = vi.fn();
+    const { result } = renderHook(() => useQrScanner({ onScan }));
+
+    // Wedge listener only attaches while scanning; start a camera scan first.
+    await act(async () => {
+      await result.current.startScanning();
+    });
+
+    // Type the payload then press Enter.
+    const payload = 'koinon://family/WEDGE1';
+    act(() => {
+      for (const ch of payload) {
+        document.dispatchEvent(new KeyboardEvent('keypress', { key: ch }));
+      }
+      document.dispatchEvent(new KeyboardEvent('keypress', { key: 'Enter' }));
+    });
+
+    expect(onScan).toHaveBeenCalledWith('WEDGE1');
+  });
+
+  it('auto-processes wedge input after 100ms pause (no Enter)', async () => {
+    const onScan = vi.fn();
+    const { result } = renderHook(() => useQrScanner({ onScan }));
+
+    await act(async () => {
+      await result.current.startScanning();
+    });
+
+    const payload = 'koinon://family/PAUSED';
+    act(() => {
+      for (const ch of payload) {
+        document.dispatchEvent(new KeyboardEvent('keypress', { key: ch }));
+      }
+    });
+
+    // Before the 100ms debounce fires, onScan should not be called.
+    expect(onScan).not.toHaveBeenCalled();
+
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(onScan).toHaveBeenCalledWith('PAUSED');
+  });
+
+  it('ignores keypress events that originate in input/textarea fields', async () => {
+    const onScan = vi.fn();
+    const { result } = renderHook(() => useQrScanner({ onScan }));
+
+    await act(async () => {
+      await result.current.startScanning();
+    });
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+
+    act(() => {
+      // Dispatch with the input as the target so the hook's early-return fires.
+      const ev = new KeyboardEvent('keypress', { key: 'a', bubbles: true });
+      Object.defineProperty(ev, 'target', { value: input });
+      document.dispatchEvent(ev);
+      const enter = new KeyboardEvent('keypress', { key: 'Enter', bubbles: true });
+      Object.defineProperty(enter, 'target', { value: input });
+      document.dispatchEvent(enter);
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(onScan).not.toHaveBeenCalled();
+    input.remove();
+  });
+});

--- a/src/web/vitest.config.ts
+++ b/src/web/vitest.config.ts
@@ -53,14 +53,21 @@ export default defineConfig({
         // does not break CI). No coverage.exclude changes — every point of
         // movement comes from real tests.
         //
+        // Wave 7 (#679 browser-API hook units) added useQrScanner,
+        // useNotificationHub, useOfflineCheckin tests (0% → 96% / 80% / 94%).
+        // Achieved wave-7 floor:
+        //   lines 39.98, statements 40.32, functions 42.40, branches 26.56
+        // Thresholds bumped to ~1.5 pts below achieved to lock the win
+        // without trapping minor churn.
+        //
         // The remaining gap to higher coverage is E2E territory: full admin
         // pages (pages/admin/**, pages/communications/**, pages/settings/**)
         // and large stateful modals that require a router + multiple hook
         // providers.
-        lines: 35,
-        statements: 35,
-        functions: 38,
-        branches: 23,
+        lines: 38,
+        statements: 38,
+        functions: 40,
+        branches: 25,
         // Critical path: offline services must stay well tested.
         // These are higher than the global floor because offline queue bugs
         // cause silent check-in data loss.


### PR DESCRIPTION
## Rationale — why unit, not E2E

The original #679 plan called for E2E coverage of the three browser-API hooks. I'm shifting this wave to **unit tests with mocked browser APIs** for three reasons:

1. **Determinism.** Camera permission grants, MediaDevices negotiation, SignalR reconnect timing, and IndexedDB migrations are intrinsically flaky in Playwright. Mocking at the module boundary gives bit-for-bit reproducible coverage.
2. **Speed.** 30 unit tests run in ~1.2 s. The E2E equivalent would be minutes, with sporadic failures that erode trust in the suite.
3. **Branch depth.** Unit tests exercise error branches (permission denied, 401 on token, sync rejection, offline race conditions) that are basically impossible to trigger reliably in a real browser.

Precedent: #498 wave 3 covered `OfflineCheckinQueue` at 84 % using exactly this pattern (`renderHook` + mocked module boundary). Zero flakes since.

**No production code was modified.** All three hooks were testable as-is.

## Per-hook table

| Hook | Tests | What it catches | Browser API mocked | Mocking strategy |
|---|---|---|---|---|
| `useQrScanner` | 9 | start/stop lifecycle, koinon:// payload routing, invalid QR → onError, `NotAllowedError` (camera denied), missing DOM element, Enter-terminated wedge input, 100 ms debounced wedge input, input-field ignore | `html5-qrcode` (`Html5Qrcode` class) + camera permission | `vi.mock('html5-qrcode', ...)` with a stub class whose `start()` captures the success/error callbacks so tests can drive them synchronously. A mutable `nextStartError` simulates camera-permission denial. |
| `useNotificationHub` | 8 | mount connects, `enabled=false` guard, missing token error, `start()` rejection, `ReceiveNotification` → query invalidation, `UnreadCountUpdated` → cache set, reconnecting/reconnected state flip, unmount `stop()` | `@microsoft/signalr` (HubConnectionBuilder/HubConnection) + auth token | `vi.mock('@microsoft/signalr', ...)` returns a fluent builder that produces a spy-backed connection. `vi.mock('@/services/api/client', ...)` controls `getAccessToken()` return value. Handlers registered via `.on(...)` / `.onreconnecting(...)` are captured so tests can drive them. |
| `useOfflineCheckin` | 13 | initial online state, `offline` event → mode flip, `online` event → auto-sync, online dispatch, offline queue dispatch, network-error fallback to queue, `ApiClientError` re-throw, `clearQueue`, sync success / partial failure / full failure / offline-guard, listener cleanup on unmount | `navigator.onLine` + window `online`/`offline` events | `vi.mock('@/services/offline/OfflineCheckinQueue', ...)` mocks the queue module directly (storage already covered 84 % in #498 w3 — no need to re-test it here). `Object.defineProperty(navigator, 'onLine', ...)` + `window.dispatchEvent(new Event('online'))` drives transitions. |

Total: **30 new tests**, all green. Files:
- `src/web/src/hooks/__tests__/useQrScanner.test.tsx`
- `src/web/src/hooks/__tests__/useNotificationHub.test.tsx`
- `src/web/src/hooks/__tests__/useOfflineCheckin.test.tsx`

## Coverage

### Per-hook (was → is)

| File | Lines | Branches | Functions |
|---|---|---|---|
| `useQrScanner.ts` | 0 → **96.10 %** | 0 → **73.80 %** | 0 → **92.30 %** |
| `useNotificationHub.ts` | 0 → **79.78 %** | 0 → **54.38 %** | 0 → **58.82 %** |
| `useOfflineCheckin.ts` | 0 → **93.67 %** | 0 → **88.88 %** | 0 → **85.00 %** |

`useNotificationHub` branches are lower because its reconnect-on-close retry loop and the dynamic SignalR-module-missing fallback paths are edge cases that would require real timer manipulation or a second-module mock; not worth the scaffolding for minor coverage.

### Global (was → is)

| Metric | Wave-4 achieved | Wave-7 achieved |
|---|---|---|
| Lines | 37.60 | **39.98** (+2.38) |
| Statements | 37.84 | **40.32** (+2.48) |
| Functions | 41.09 | **42.40** (+1.31) |
| Branches | 25.50 | **26.56** (+1.06) |

### Thresholds bumped

`src/web/vitest.config.ts` thresholds updated from `35/35/38/23` → **`38/38/40/25`** (lines/stmts/funcs/branches), i.e. ~1.5 pts below new achieved floor. No `exclude`/`include`/`all` changes.

## Bugs discovered

None. All three hooks were testable as-written; every test passes without a production change. No `skip` markers added.

## Verification

- `npx vitest run --coverage` — 144 test files, **1322 / 1322 pass**, thresholds 38/38/40/25 hold.
- `npx tsc --noEmit` — 0 errors.
- `dotnet build` — green, 0 warnings.
- Pre-push hook — green (backend 1457 tests pass, frontend 1322 pass, typecheck + lint clean).

## Not closing #679

Per the wave-7 plan, PM decides closure after reviewing whether #609 E2E coverage + these hook unit tests constitute DoD.

## Test plan

- [x] All new tests pass in isolation
- [x] Full `vitest run --coverage` passes with raised thresholds
- [x] `tsc --noEmit` clean
- [x] `dotnet build` clean
- [x] No production code modified
- [x] No existing tests modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)