### PR TITLE
fix(import): register IDataImportService in DI (#696)

### DIFF
--- a/src/Koinon.Application/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Koinon.Application/Extensions/ServiceCollectionExtensions.cs
@@ -175,6 +175,10 @@ public static class ServiceCollectionExtensions
         services.AddScoped<IExportFormatGenerator, CsvExportGenerator>();
         services.AddScoped<IExportFormatGenerator, ExcelExportGenerator>();
 
+        // Data Import Services (#696)
+        services.AddScoped<ICsvParserService, CsvParserService>();
+        services.AddScoped<IDataImportService, DataImportService>();
+
         // Configure QuestPDF license
         QuestPDF.Settings.License = QuestPDF.Infrastructure.LicenseType.Community;
 

--- a/src/web/e2e/tests/admin/feat-679-import-pages.spec.ts
+++ b/src/web/e2e/tests/admin/feat-679-import-pages.spec.ts
@@ -35,17 +35,19 @@
  *  - A tiny CSV (3 data rows) is uploaded via page.setInputFiles using a
  *    Buffer — no fixture file is written to disk.
  *
- * NEW BUG #1 (skip-and-flag): GET /api/v1/import/jobs returns HTTP 500.
- *   Live curl response:
- *     { "status": 500, "detail": "Unable to resolve service for type
- *       'Koinon.Application.Interfaces.IDataImportService' while
- *       attempting to activate 'Koinon.Api.Controllers.ImportController'" }
- *   The implementation registration for IDataImportService appears to be
- *   missing from DI. As a result, ImportHistoryPage's `useImportJobs` hook
- *   always errors and the page renders the ErrorState ("Failed to load
- *   import history") — filter changes, table, and empty-state paths never
- *   render. Suggested issue title:
- *     "fix(api): register IDataImportService in Koinon.Api DI container"
+ * Fixed in #696: IDataImportService is now registered in DI, so
+ *   GET /api/v1/import/jobs returns 200 (no longer the DI 500).
+ *
+ * SECOND BUG (not fixed in #696, flagged separately): the backend returns
+ *   `{ data: PagedResult<ImportJobDto> }` (i.e. `{ data: { items, totalCount, … } }`)
+ *   from GET /api/v1/import/jobs, but the frontend client
+ *   `getImportJobs()` in `src/web/src/services/api/import.ts` unwraps it as
+ *   `{ data: ImportJobDto[] }`. The mismatched shape causes the hook's
+ *   `data.filter()` call to throw and the page renders the global
+ *   ErrorState. We mock `**\/api/v1/import/jobs**` with an array-shaped
+ *   response so the page chrome tests can still run; filing this as a
+ *   follow-up issue (title suggestion: "fix(web): align getImportJobs
+ *   unwrapping with PagedResult<ImportJobDto> shape").
  *
  * Guardrails:
  *  - No data-testid attributes added to production code.
@@ -93,20 +95,20 @@ async function uploadCsv(page: Page, fileName: string, content: Buffer): Promise
 // ---------------------------------------------------------------------------
 // ImportHistoryPage
 //
-// NOTE: Because NEW BUG #1 makes GET /import/jobs return HTTP 500, every
-// ImportHistoryPage test that depends on rendered page chrome (filter,
-// table, empty state) would collapse into a global ErrorState render.
-// To exercise the UI chrome independently of the broken endpoint, we
-// mock `/import/jobs*` with an empty-array success response in these
-// specs. Mocking policy note: this matches the import-page exemption
-// ("If the import execution would trigger slow background jobs, mock
-// the import endpoint").
+// DI resolution for /import/jobs is fixed in #696 (endpoint no longer
+// returns 500). A separate shape mismatch between the controller's
+// PagedResult payload and the frontend's array-expectation remains open
+// (see SECOND BUG in the header). Until that is resolved, we mock the
+// jobs list with the shape the frontend currently expects so the page
+// chrome tests can exercise heading, filter, CTAs, and refresh.
 // ---------------------------------------------------------------------------
 
 test.describe('Import History page', () => {
   test.beforeEach(async ({ loginAsAdmin, page }) => {
     await loginAsAdmin();
-    // Mock jobs list so the page can render (see NEW BUG #1).
+    // Shape matches what getImportJobs() unwraps today: { data: ImportJobDto[] }.
+    // This mock is temporary; remove once the backend/frontend contract is
+    // aligned (see SECOND BUG in the spec header).
     await page.route('**/api/v1/import/jobs**', async (route) => {
       await route.fulfill({
         status: 200,


### PR DESCRIPTION
## Summary

Fixes #696. `GET /api/v1/import/jobs` was returning HTTP 500 with:

```
Unable to resolve service for type 'Koinon.Application.Interfaces.IDataImportService'
while attempting to activate 'Koinon.Api.Controllers.ImportController'
```

Neither `IDataImportService` nor its transitive dependency `ICsvParserService` had `AddScoped` registrations in `ServiceCollectionExtensions.cs`, even though both implementations (`DataImportService`, `CsvParserService`) live in the Application layer alongside the interfaces.

## Changes

- `src/Koinon.Application/Extensions/ServiceCollectionExtensions.cs` — adds two `AddScoped` registrations:
  - `ICsvParserService -> CsvParserService`
  - `IDataImportService -> DataImportService`
- `src/web/e2e/tests/admin/feat-679-import-pages.spec.ts` — drops the "skip-and-flag" note for this bug, retains the (now temporary) route mock for the Import History page describe block because of a separate follow-up bug documented below, and re-runs cleanly with `ALLOW_E2E_EDIT=1`.

### Extras (flagged for follow-up, NOT fixed here)

While auditing `src/Koinon.Application/Interfaces/*.cs` for other missing registrations, every other interface either:

- has its implementation in `Koinon.Infrastructure` and is registered there (`IBackgroundJobService`, `IEmailSender`, `IFileStorageService`, `ISessionCleanupService`, `ISmsService`, `ISmsQueueService`, `ISmsDeliveryStatusService`, `ITwilioSignatureValidator`), or
- is an integration point registered by the calling layer (`IApplicationDbContext`, `IUserContext`, `INotificationHubContext`), or
- is already registered as a multi-provider collection (`IExportDataProvider`, `IExportFormatGenerator`, `ICommunicationSender`, `IScheduledCommunicationProcessor`).

So the only Application-layer services missing DI were the two registered here.

**Separate bug (NOT in scope of #696, needs a follow-up issue):** the controller returns `{ data: PagedResult<ImportJobDto> }` (i.e. `{ data: { items, totalCount, page, … } }`), but the frontend client `getImportJobs()` in `src/web/src/services/api/import.ts` unwraps as `{ data: ImportJobDto[] }`, so `useImportJobs`'s `data.filter()` throws on the real response and the page renders its ErrorState. The Import History describe block still route-mocks `/import/jobs` with the array shape so the page-chrome tests run; remove that mock once the shape is reconciled. Suggested follow-up title: `fix(web): align getImportJobs unwrapping with PagedResult<ImportJobDto>`.

## Before / after

Live against `http://localhost:5000` with an admin JWT from the seeded `john.smith@example.com` user:

**Before (pre-fix, per live-verified review):**
```
$ curl -i http://localhost:5000/api/v1/import/jobs -H "Authorization: Bearer $TOKEN"
HTTP/1.1 500 Internal Server Error
{
  "status": 500,
  "detail": "Unable to resolve service for type
    'Koinon.Application.Interfaces.IDataImportService' while attempting
    to activate 'Koinon.Api.Controllers.ImportController'"
}
```

**After (this PR, rebuilt + restarted against the worktree):**
```
$ curl -s -o /tmp/jobs.json -w "HTTP %{http_code}\n" \
    http://localhost:5000/api/v1/import/jobs \
    -H "Authorization: Bearer $TOKEN"
HTTP 200

$ cat /tmp/jobs.json
{"data":{"items":[],"totalCount":0,"page":1,"pageSize":20,
 "totalPages":0,"hasPreviousPage":false,"hasNextPage":false}}
```

Also sanity-checked unauthenticated: `curl -o /dev/null -w "%{http_code}" /api/v1/import/jobs` returns `401` (was `500` before).

## Test plan

- [x] `dotnet build` — `Build succeeded. 0 Warning(s) 0 Error(s)`
- [x] `dotnet test tests/Koinon.Api.Tests` — `Passed! 323, Failed 0`
- [x] `dotnet test tests/Koinon.Application.Tests` — `Passed! 727, Failed 0` (30 performance tests intentionally skipped, unrelated)
- [x] API rebuild + restart, live `curl GET /api/v1/import/jobs` with admin JWT → HTTP 200 with the PagedResult body above (no DI 500)
- [x] `cd src/web && ALLOW_E2E_EDIT=1 npx playwright test e2e/tests/admin/feat-679-import-pages.spec.ts --project=chromium` → **14 passed** (all three describe blocks, including the previously blocked Import History page chrome)
- [x] `git diff --name-only` touches only the two allowed files

Do not close #696 on merge; handed back to PM.