### PR TITLE
fix(devices): persist name on PUT and complete delete on DELETE (#694, #695)

### DIFF
--- a/src/Koinon.Application/Services/DeviceService.cs
+++ b/src/Koinon.Application/Services/DeviceService.cs
@@ -142,7 +142,11 @@ public class DeviceService(
             return Result<DeviceDetailDto>.Failure(Error.NotFound("Device", idKey));
         }
 
-        var device = await context.Devices.FirstOrDefaultAsync(d => d.Id == id, ct);
+        // AsTracking required: global QueryTrackingBehavior is NoTracking (see PostgreSqlProvider),
+        // so without it SaveChanges would not persist the mutations below.
+        var device = await context.Devices
+            .AsTracking()
+            .FirstOrDefaultAsync(d => d.Id == id, ct);
         if (device == null)
         {
             return Result<DeviceDetailDto>.Failure(Error.NotFound("Device", idKey));
@@ -239,7 +243,11 @@ public class DeviceService(
             return Result.Failure(Error.NotFound("Device", idKey));
         }
 
-        var device = await context.Devices.FirstOrDefaultAsync(d => d.Id == id, ct);
+        // AsTracking required: global QueryTrackingBehavior is NoTracking (see PostgreSqlProvider),
+        // so without it SaveChanges would not persist the soft-delete mutation below.
+        var device = await context.Devices
+            .AsTracking()
+            .FirstOrDefaultAsync(d => d.Id == id, ct);
         if (device == null)
         {
             return Result.Failure(Error.NotFound("Device", idKey));
@@ -260,7 +268,11 @@ public class DeviceService(
             return Result<GenerateKioskTokenResponseDto>.Failure(Error.NotFound("Device", idKey));
         }
 
-        var device = await context.Devices.FirstOrDefaultAsync(d => d.Id == id, ct);
+        // AsTracking required: global QueryTrackingBehavior is NoTracking (see PostgreSqlProvider),
+        // so without it SaveChanges would not persist the token mutation below.
+        var device = await context.Devices
+            .AsTracking()
+            .FirstOrDefaultAsync(d => d.Id == id, ct);
         if (device == null)
         {
             return Result<GenerateKioskTokenResponseDto>.Failure(Error.NotFound("Device", idKey));

--- a/src/web/e2e/tests/admin/feat-679-checkin-config.spec.ts
+++ b/src/web/e2e/tests/admin/feat-679-checkin-config.spec.ts
@@ -288,10 +288,9 @@ test.describe('Check-in Config — Devices tab', () => {
     await expect(createdRow).toContainText('10.0.0.99');
   });
 
-  test.skip('delete removes the device row from the list', async ({ page }) => {
-    // SKIP: NEW BUG #4 — DELETE /api/v1/devices/{idKey} returns 204 but
-    // the device persists in the GET response, so the row never
-    // disappears even after clicking Confirm in the delete dialog.
+  test('delete removes the device row from the list', async ({ page }) => {
+    // Fixed in #695: DELETE now actually persists the soft-delete, so
+    // the row disappears from the (default IsActive=true) list query.
     const name = uniqueSuffix('E2E Wave 6 Delete Kiosk');
     await page.getByRole('button', { name: /^add device$/i }).first().click();
     const createDialog = page.getByRole('dialog', { name: /add device/i });
@@ -307,12 +306,9 @@ test.describe('Check-in Config — Devices tab', () => {
     });
   });
 
-  test.skip('device name edit persists to the devices list', async ({ page }) => {
-    // SKIP: NEW BUG #3 — edit modal opens and Save Changes appears to
-    // submit successfully, but the row in the devices list still shows
-    // the pre-edit name after the modal closes and the list re-renders.
-    // Behavior likely lives in either the backend UpdateDevice handler
-    // or the client cache invalidation; needs further triage.
+  test('device name edit persists to the devices list', async ({ page }) => {
+    // Fixed in #694: backend UpdateDeviceAsync now loads the entity with
+    // AsTracking() so SaveChanges actually persists the Name mutation.
     const originalName = uniqueSuffix('E2E Wave 6 Kiosk');
     const renamedName = `${originalName}-edited`;
 

--- a/tests/Koinon.Application.Tests/Services/DeviceServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/DeviceServiceTests.cs
@@ -1,0 +1,232 @@
+using AutoMapper;
+using FluentAssertions;
+using FluentValidation;
+using Koinon.Application.DTOs.Requests;
+using Koinon.Application.Mapping;
+using Koinon.Application.Services;
+using Koinon.Application.Validators;
+using Koinon.Domain.Entities;
+using Koinon.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Application.Tests.Services;
+
+/// <summary>
+/// Tests for DeviceService.
+///
+/// IMPORTANT: The in-memory DbContext is configured with
+/// <see cref="QueryTrackingBehavior.NoTracking"/> to mirror the production
+/// PostgreSqlProvider default. This is critical: without it, these tests
+/// would silently pass even if the service forgot to call
+/// <c>AsTracking()</c> — which was the root cause of bugs #694 and #695.
+/// </summary>
+public class DeviceServiceTests : IDisposable
+{
+    private readonly KoinonDbContext _context;
+    private readonly IMapper _mapper;
+    private readonly IValidator<CreateDeviceRequest> _createValidator;
+    private readonly IValidator<UpdateDeviceRequest> _updateValidator;
+    private readonly Mock<ILogger<DeviceService>> _mockLogger;
+    private readonly DeviceService _service;
+
+    public DeviceServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<KoinonDbContext>()
+            .UseInMemoryDatabase(databaseName: $"KoinonTestDb_{Guid.NewGuid()}")
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _context = new KoinonDbContext(options);
+        _context.Database.EnsureCreated();
+
+        var mapperConfig = new MapperConfiguration(cfg =>
+        {
+            cfg.AddProfile<DeviceMappingProfile>();
+        });
+        _mapper = mapperConfig.CreateMapper();
+
+        _createValidator = new CreateDeviceRequestValidator();
+        _updateValidator = new UpdateDeviceRequestValidator();
+
+        _mockLogger = new Mock<ILogger<DeviceService>>();
+
+        _service = new DeviceService(
+            _context,
+            _mapper,
+            _createValidator,
+            _updateValidator,
+            _mockLogger.Object
+        );
+
+        SeedTestData();
+    }
+
+    private void SeedTestData()
+    {
+        var device1 = new Device
+        {
+            Id = 1,
+            Name = "Main Lobby Kiosk",
+            Description = "Primary check-in kiosk",
+            IpAddress = "10.0.0.11",
+            IsActive = true,
+            CreatedDateTime = DateTime.UtcNow
+        };
+        _context.Devices.Add(device1);
+
+        var device2 = new Device
+        {
+            Id = 2,
+            Name = "Childrens Wing Kiosk",
+            IpAddress = "10.0.0.12",
+            IsActive = true,
+            CreatedDateTime = DateTime.UtcNow
+        };
+        _context.Devices.Add(device2);
+
+        _context.SaveChanges();
+    }
+
+    // ---------------------------------------------------------------------
+    // Bug #694 — UpdateAsync must persist the Name field.
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateAsync_Name_PersistsToDatabase()
+    {
+        // Arrange
+        var device = await _context.Devices.AsNoTracking().FirstAsync(d => d.Id == 1);
+        var idKey = device.IdKey;
+        var request = new UpdateDeviceRequest { Name = "Renamed Kiosk" };
+
+        // Act
+        var result = await _service.UpdateAsync(idKey, request);
+
+        // Assert — response reflects new name
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Name.Should().Be("Renamed Kiosk");
+
+        // Assert — DB actually has the new name (fresh read bypasses any local tracking)
+        var reloaded = await _context.Devices.AsNoTracking().FirstAsync(d => d.Id == 1);
+        reloaded.Name.Should().Be("Renamed Kiosk");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Name_IsReflectedInSubsequentGetByIdKey()
+    {
+        // Arrange
+        var device = await _context.Devices.AsNoTracking().FirstAsync(d => d.Id == 1);
+        var idKey = device.IdKey;
+        var request = new UpdateDeviceRequest { Name = "renamed-test" };
+
+        // Act
+        await _service.UpdateAsync(idKey, request);
+        var getResult = await _service.GetByIdKeyAsync(idKey);
+
+        // Assert — regression guard for the #694 curl repro
+        getResult.IsSuccess.Should().BeTrue();
+        getResult.Value!.Name.Should().Be("renamed-test");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Name_PreservesOtherFields()
+    {
+        // Arrange
+        var device = await _context.Devices.AsNoTracking().FirstAsync(d => d.Id == 1);
+        var idKey = device.IdKey;
+        var originalIp = device.IpAddress;
+        var originalDescription = device.Description;
+        var originalIsActive = device.IsActive;
+
+        var request = new UpdateDeviceRequest { Name = "Only Name Changed" };
+
+        // Act
+        var result = await _service.UpdateAsync(idKey, request);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+
+        var reloaded = await _context.Devices.AsNoTracking().FirstAsync(d => d.Id == 1);
+        reloaded.Name.Should().Be("Only Name Changed");
+        reloaded.IpAddress.Should().Be(originalIp);
+        reloaded.Description.Should().Be(originalDescription);
+        reloaded.IsActive.Should().Be(originalIsActive);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithInvalidIdKey_ReturnsNotFound()
+    {
+        // Act
+        var result = await _service.UpdateAsync("INVALID", new UpdateDeviceRequest { Name = "x" });
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("NOT_FOUND");
+    }
+
+    // ---------------------------------------------------------------------
+    // Bug #695 — DeleteAsync must actually mutate the row so the device
+    // is absent from the subsequent list query (which filters on IsActive).
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task DeleteAsync_SoftDeletes_AndIsAbsentFromDefaultList()
+    {
+        // Arrange
+        var device = await _context.Devices.AsNoTracking().FirstAsync(d => d.Id == 1);
+        var idKey = device.IdKey;
+
+        // Act
+        var result = await _service.DeleteAsync(idKey);
+
+        // Assert — command succeeded
+        result.IsSuccess.Should().BeTrue();
+
+        // Assert — row is actually deactivated in the DB (not just a 204 no-op)
+        var reloaded = await _context.Devices.AsNoTracking().FirstAsync(d => d.Id == 1);
+        reloaded.IsActive.Should().BeFalse();
+        reloaded.ModifiedDateTime.Should().NotBeNull();
+
+        // Assert — default list query (includeInactive=false) no longer returns it.
+        // This is the regression guard for the #695 curl repro.
+        var list = await _service.GetAllAsync(campusIdKey: null, includeInactive: false);
+        list.Should().NotContain(d => d.IdKey == idKey);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_PreservesRowForIncludeInactiveList()
+    {
+        // Arrange
+        var device = await _context.Devices.AsNoTracking().FirstAsync(d => d.Id == 2);
+        var idKey = device.IdKey;
+
+        // Act
+        await _service.DeleteAsync(idKey);
+
+        // Assert — soft-delete keeps the row visible when includeInactive=true
+        var list = await _service.GetAllAsync(campusIdKey: null, includeInactive: true);
+        list.Should().Contain(d => d.IdKey == idKey);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_WithInvalidIdKey_ReturnsNotFound()
+    {
+        // Act
+        var result = await _service.DeleteAsync("INVALID");
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("NOT_FOUND");
+    }
+
+    public void Dispose()
+    {
+        _context.Database.EnsureDeleted();
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
Closes (via manual PM close) #694 and #695.

## Root cause (shared)

Both bugs have the same root cause — the same class of bug that was fixed for `BatchDonationEntryService` in #664.

`PostgreSqlProvider` sets the global `QueryTrackingBehavior` to `NoTracking` for performance:

```csharp
// src/Koinon.Infrastructure/Providers/PostgreSqlProvider.cs:44
optionsBuilder.UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking);
```

`DeviceService.UpdateAsync`, `DeleteAsync`, and `GenerateKioskTokenAsync` reloaded the entity without `.AsTracking()`, so the mutations (`Name`, `IsActive`, `KioskToken`, etc.) were never persisted by `SaveChangesAsync` — silent no-op.

- **#694 PUT silently ignores name** — `UpdateAsync` sets `device.Name = request.Name.Trim()` on an untracked entity → discarded.
- **#695 DELETE returns 204 but device persists** — `DeleteAsync` sets `device.IsActive = false` on an untracked entity → discarded → default list query (filters `IsActive = true`) still returns the row.

## Fix

Add `.AsTracking()` to all three reload queries in `DeviceService.cs` with an inline comment explaining the global NoTracking default. Surgical 3-line change, no schema change, no DTO change, no controller change.

I also fixed `GenerateKioskTokenAsync` — same file, same latent bug, not yet user-reported but would have been next.

## Verification

### Live curl (#694 PUT)
```
PUT /api/v1/devices/DAAAAA -d '{"name":"renamed-test"}'
  response.data.name: renamed-test    (before: original name)
GET /api/v1/devices/DAAAAA
  data.name:          renamed-test    (before: original name)
```

### Live curl (#695 DELETE)
```
DELETE /api/v1/devices/DAAAAA                    -> HTTP 204
GET    /api/v1/devices                           -> device absent  (before: still present)
GET    /api/v1/devices?includeInactive=true      -> isActive: false (soft-delete row preserved)
```

### Unit tests

`tests/Koinon.Application.Tests/Services/DeviceServiceTests.cs` — 7 new tests, all passing.

Critical: the test fixture configures the in-memory `DbContext` with `QueryTrackingBehavior.NoTracking` to mirror production. Without that config, the tests would silently pass against the buggy code (the default in-memory behavior is tracking). Confirmed by stashing the fix → 4 of 7 tests fail; restoring the fix → all 7 pass.

### Full suites
- `dotnet build koinon-rms.sln` — 0 errors, 0 warnings.
- `dotnet test tests/Koinon.Application.Tests` — 734 passed, 30 skipped (performance), 0 failed.
- `dotnet test tests/Koinon.Api.Tests` — 323 passed, 0 failed.

### E2E (previously skipped on #694/#695)
```
npx playwright test e2e/tests/admin/feat-679-checkin-config.spec.ts --project=chromium
  15 [chromium] Devices tab › delete removes the device row from the list       PASS
  16 [chromium] Devices tab › device name edit persists to the devices list     PASS
  14 passed, 4 skipped (the 4 remaining skips are unrelated — areas/locations).
```

## Files touched

- `src/Koinon.Application/Services/DeviceService.cs` (+3 `AsTracking()` calls, inline comments)
- `src/web/e2e/tests/admin/feat-679-checkin-config.spec.ts` (unskipped two tests, updated comments)
- `tests/Koinon.Application.Tests/Services/DeviceServiceTests.cs` (new, 7 tests)

## Test plan
- [x] Backend build clean
- [x] Backend unit tests green (Application + Api)
- [x] Curl against live API confirms PUT rename persists
- [x] Curl against live API confirms DELETE removes from default list, preserves on `includeInactive=true`
- [x] E2E tests #694/#695 unskipped and passing
- [x] `git diff --name-only` lists only allowed files

Issues #694 and #695 are left OPEN per instructions — PM closes after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)