### PR TITLE
fix(web): unwrap {data} envelope in schedules and locations API clients (#688, #693)

### DIFF
--- a/src/web/e2e/tests/admin/feat-679-checkin-config.spec.ts
+++ b/src/web/e2e/tests/admin/feat-679-checkin-config.spec.ts
@@ -36,18 +36,11 @@
  *   always shows "Failed to load check-in areas". Suggested issue title:
  *     "fix(web): CheckinAreasTab must pass campusId to /checkin/configuration"
  *
- * NEW BUG #2 (skip-and-flag): CheckinLocationsTab crashes the page.
- *   `services/api/locations.ts::getLocations()` does NOT unwrap the
- *   `{ data: [...] }` API envelope (compare devices.ts / groups.ts,
- *   which do). `useLocations()` therefore resolves to an object, not
- *   an array. When `CheckinLocationsTab` does
- *   `locationList.map(...)` after `(locations ?? [])`, it invokes .map
- *   on a non-array and React throws, triggering the global error
- *   boundary ("Something went wrong"). Every non-shell Locations-tab
- *   assertion fails because the tab never renders. The same API
- *   returns a properly shaped `{data:[...]}` in live curl checks, so
- *   the fix is strictly in the client service. Suggested issue title:
- *     "fix(web): unwrap `data` envelope in locations API service"
+ * BUG #2 (FIXED, #693): CheckinLocationsTab used to crash the page because
+ *   `services/api/locations.ts::getLocations()` didn't unwrap the
+ *   `{ data: [...] }` API envelope. The fix (see schedules sibling, same PR)
+ *   makes all locations methods unwrap. The previously .skip()-ed tests in
+ *   the Locations-tab describe block are now active as regression guards.
  *
  * NEW BUG #3 (skip-and-flag): device name edit does not persist to the
  *   list view. Create-then-edit-name-then-observe cycle shows the
@@ -138,10 +131,6 @@ test.describe('Check-in Config — page shell', () => {
   });
 
   test('can switch between tabs and active state follows (Areas ↔ Devices)', async ({ page }) => {
-    // NOTE: We intentionally do NOT click the Locations tab here because
-    // NEW BUG #2 causes that tab click to crash the page via the global
-    // error boundary. Areas and Devices both render their tab bodies
-    // without crashing.
     await gotoCheckinConfig(page);
     const areasTab = page.getByRole('button', { name: 'Areas', exact: true });
     const devicesTab = page.getByRole('button', { name: 'Devices', exact: true });
@@ -201,36 +190,88 @@ test.describe('Check-in Config — Areas tab', () => {
 // Locations tab
 // ---------------------------------------------------------------------------
 
-test.describe('Check-in Config — Locations tab', () => {
+test.describe('Check-in Config — Locations tab (envelope unwrap, #693)', () => {
   test.beforeEach(async ({ loginAsAdmin, page }) => {
     await loginAsAdmin();
     await gotoCheckinConfig(page);
   });
 
-  test('tab is present in the tab bar (shell-only)', async ({ page }) => {
-    // NEW BUG #2 prevents us from asserting tab content (the page crashes
-    // to the global error boundary once the hook resolves). We verify
-    // the navigable tab chrome instead — the Locations button is rendered
-    // but is NOT currently active (Areas is active by default).
+  test('tab becomes active and renders its body without crashing the page', async ({
+    page,
+  }) => {
+    // Regression guard for #693: before the envelope unwrap,
+    // `getLocations()` returned `{ data: [...] }` and the tab's
+    // `locationList.map(...)` call (on a non-array) crashed the page
+    // into the global error boundary. The tab now renders its body.
     const locationsTab = page.getByRole('button', { name: 'Locations', exact: true });
-    await expect(locationsTab).toBeVisible();
-    await expect(locationsTab).not.toHaveAttribute('aria-current', 'page');
-    // Do NOT click — clicking will crash the page due to the .map() on
-    // a non-array shape returned by getLocations().
+    await locationsTab.click();
+    await expect(locationsTab).toHaveAttribute('aria-current', 'page');
+
+    // The page header must still be visible — i.e. we did NOT fall
+    // through to the global error boundary ("Something went wrong").
+    await expect(
+      page.getByRole('heading', { name: /check-in setup/i }),
+    ).toBeVisible();
+    await expect(page.getByText(/something went wrong/i)).toHaveCount(0);
+
+    // Either the count summary (non-empty list) or the empty state text
+    // must render — both paths prove the `(locations ?? []).length`
+    // computation succeeds against a real array.
+    await expect(
+      page
+        .getByText(/\d+\s+(location|locations)/i)
+        .or(page.getByText(/no locations/i))
+        .first(),
+    ).toBeVisible({ timeout: 10_000 });
   });
 
-  test.skip('renders table headers (Location, Campus, Type, Status, Actions)', async ({ page }) => {
-    // SKIP: NEW BUG #2 — clicking the Locations tab crashes the page
-    // via the global error boundary because getLocations() does not
-    // unwrap the { data: [...] } envelope.
+  test('renders table headers (Location, Campus, Type, Status, Actions) when locations exist', async ({
+    page,
+  }) => {
+    // Regression guard for #693: before the fix, this assertion could not
+    // run — the tab never reached its success body.
     await switchTab(page, 'Locations');
-    await expect(page.getByRole('columnheader', { name: /^location$/i })).toBeVisible();
+
+    // If there are no seeded locations for this tenant, the empty-state
+    // branch renders instead of the table. Skip the header assertions in
+    // that case (not a regression of #693 — the crash-vs-render guard above
+    // already proves the unwrap works) while still verifying the success
+    // body rendered.
+    const emptyState = page.getByText(/no locations/i);
+    if (await emptyState.isVisible().catch(() => false)) {
+      test.info().annotations.push({
+        type: 'note',
+        description:
+          'No seeded locations in this environment; headers assertion skipped, crash-vs-render guard in the sibling test still covers #693.',
+      });
+      return;
+    }
+
+    await expect(page.getByRole('columnheader', { name: /^location$/i })).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(page.getByRole('columnheader', { name: /campus/i })).toBeVisible();
+    await expect(page.getByRole('columnheader', { name: /status/i })).toBeVisible();
   });
 
-  test.skip('Edit Capacity button opens the capacity modal (when rows present)', async ({ page }) => {
-    // SKIP: NEW BUG #2 — tab never renders its success body.
+  test('Edit Capacity button opens the capacity modal (when rows present)', async ({
+    page,
+  }) => {
+    // Regression guard for #693.
     await switchTab(page, 'Locations');
-    await page.getByRole('button', { name: /edit capacity/i }).first().click();
+
+    const editButton = page.getByRole('button', { name: /edit capacity/i }).first();
+    // If nothing seeded, the button won't exist. Skip gracefully.
+    if (!(await editButton.isVisible().catch(() => false))) {
+      test.info().annotations.push({
+        type: 'note',
+        description:
+          'No seeded locations to exercise Edit Capacity; the crash-vs-render guard covers #693.',
+      });
+      return;
+    }
+
+    await editButton.click();
     await expect(page.getByRole('dialog')).toBeVisible();
   });
 });

--- a/src/web/e2e/tests/admin/schedules/feat-679-schedules-admin.spec.ts
+++ b/src/web/e2e/tests/admin/schedules/feat-679-schedules-admin.spec.ts
@@ -21,21 +21,14 @@
  * data; narrow page.route() only for a synthetic empty-state scenario that
  * would otherwise require wiping seeded schedules.
  *
- * NEW BUG #1 (skip-and-flag): envelope not unwrapped.
- *   `src/web/src/services/api/schedules.ts` does NOT unwrap the `{ data: ... }`
- *   API envelope for getScheduleByIdKey / createSchedule / updateSchedule /
- *   getScheduleOccurrences. The Groups service unwraps it; Schedules does not
- *   (compare `src/web/src/services/api/groups.ts` L47-50). Effects observed
- *   in this spec:
- *     1. ScheduleDetailPage renders with empty heading, "Invalid Date"
- *        metadata, and an "inactive" banner for schedules that are active.
- *     2. ScheduleFormPage's post-create navigate uses `created.idKey`
- *        (undefined because `.data` is not unwrapped) and so fails to
- *        navigate to the new detail page.
- *   Tests whose assertions depend on the detail view rendering correctly
- *   or on post-create navigation are marked `.skip()` with a reference to
- *   this note. Suggested issue title:
- *     "fix(web): unwrap `data` envelope in schedules API service"
+ * BUG #1 (FIXED, #688): envelope not unwrapped in schedules API service.
+ *   `src/web/src/services/api/schedules.ts` now unwraps the `{ data: ... }`
+ *   API envelope for getScheduleByIdKey / updateSchedule /
+ *   getScheduleOccurrences (createSchedule's backend returns a flat body via
+ *   CreatedAtAction(..., schedule) so it intentionally does NOT unwrap —
+ *   that's a BE inconsistency vs. sibling controllers, not a FE bug). The
+ *   tests that were previously .skip()-ed with a reference to this bug are
+ *   now active as regression guards in the detail/edit describe blocks.
  *
  * NEW BUG #2 (skip-and-flag): schedule form create/submit is broken.
  *   (a) `src/web/src/components/admin/schedules/WeeklySchedulePicker.tsx`
@@ -217,7 +210,7 @@ test.describe('ScheduleListPage — empty state (mocked)', () => {
 // ScheduleDetailPage
 // ---------------------------------------------------------------------------
 
-test.describe('ScheduleDetailPage — rendering (partial: blocked by envelope bug)', () => {
+test.describe('ScheduleDetailPage — rendering (envelope unwrap, #688)', () => {
   test.beforeEach(async ({ loginAsAdmin, page }) => {
     await loginAsAdmin();
     await page.goto('/admin/schedules');
@@ -227,20 +220,48 @@ test.describe('ScheduleDetailPage — rendering (partial: blocked by envelope bu
     await expect(page).toHaveURL(/\/admin\/schedules\/[^/]+$/);
   });
 
-  test.skip('shows the schedule name as the page heading', async () => {
-    // BLOCKED by NEW-BUG (schedules API envelope not unwrapped). The detail
-    // page renders with an empty <h1>. Re-enable once the service is fixed.
+  test('shows the schedule name as the page heading', async ({ page }) => {
+    // Regression guard for #688: before the envelope unwrap, this heading was
+    // empty because `useSchedule()` received `{ data: {...} }` instead of the
+    // unwrapped DTO, so `schedule.name` was undefined.
+    await expect(
+      page.getByRole('heading', { name: testData.schedules.sunday9am.name, level: 1 }),
+    ).toBeVisible({ timeout: 10_000 });
   });
 
-  test.skip('renders the Schedule Details card with day and time', async () => {
-    // BLOCKED by NEW-BUG. `schedule.weeklyDayOfWeek` is undefined on the
-    // frontend because the whole DTO is nested under `.data`.
+  test('renders the Schedule Details card with day and time', async ({ page }) => {
+    // Regression guard for #688: before the envelope unwrap, these fields all
+    // read as undefined and the card either collapsed or showed stale values.
+    const detailsHeading = page.getByRole('heading', { name: /^schedule details$/i });
+    await expect(detailsHeading).toBeVisible();
+    // Scope to the Schedule Details card body — the seeded Sunday 9 AM schedule
+    // renders the "Day and Time" row with "Sunday at 9:00 AM" (formatTime12Hour
+    // + DAYS_OF_WEEK[0]) only when the DTO is unwrapped.
+    const card = detailsHeading.locator('..');
+    await expect(card.getByText(/sunday at 9:00\s*am/i)).toBeVisible({ timeout: 10_000 });
   });
 
-  test.skip('renders the Status sidebar with correct Active/Public values', async () => {
-    // BLOCKED by NEW-BUG. All status booleans read as undefined on the
-    // frontend, so the sidebar always reads "Inactive" / "No" regardless
-    // of the server payload.
+  test('renders the Status sidebar with correct Active/Public values', async ({ page }) => {
+    // Regression guard for #688: before the envelope unwrap, every status
+    // boolean read as undefined on the frontend, so the sidebar always
+    // rendered "Inactive" / "No" regardless of the server payload. After
+    // the fix, the value pill text is driven by the real DTO values.
+    const statusHeading = page.getByRole('heading', { name: /^status$/i });
+    await expect(statusHeading).toBeVisible();
+
+    // Scope assertions to the status card.
+    const statusCard = statusHeading.locator('..');
+    // All three row labels must be present regardless of state.
+    await expect(statusCard.getByText('Active').first()).toBeVisible();
+    await expect(statusCard.getByText(/check-in active/i)).toBeVisible();
+    await expect(statusCard.getByText('Public').first()).toBeVisible();
+
+    // Seeded Sunday 9 AM is active — the dd pill next to the "Active" dt
+    // should read "Active", NOT "Inactive". Use an exact-match assertion on
+    // the pill text and assert the negative case is NOT visible. The row
+    // under the "Active" dt is the first dd in the <dl>.
+    const firstValuePill = statusCard.locator('dd').first();
+    await expect(firstValuePill).toHaveText('Active', { timeout: 10_000 });
   });
 
   test('always-rendered controls (Edit, Delete, back arrow) are present', async ({
@@ -357,21 +378,73 @@ test.describe('ScheduleFormPage — create mode', () => {
 // ScheduleFormPage — edit mode (blocked by envelope bug)
 // ---------------------------------------------------------------------------
 
-test.describe('ScheduleFormPage — edit mode', () => {
+test.describe('ScheduleFormPage — edit mode (envelope unwrap, #688)', () => {
   test.beforeEach(async ({ loginAsAdmin }) => {
     await loginAsAdmin();
   });
 
-  test.skip('edit mode pre-fills the name from an existing schedule', async () => {
-    // BLOCKED by NEW-BUG. useSchedule() receives `{ data: {...} }` instead
-    // of the unwrapped DTO, so `schedule.name` is undefined and the form's
-    // name input stays empty.
+  test('edit mode pre-fills the name from an existing schedule', async ({ page }) => {
+    // Regression guard for #688: before the envelope unwrap, useSchedule()
+    // received `{ data: {...} }` and so `schedule.name` was undefined —
+    // the name input stayed empty on edit. The fix makes the detail DTO
+    // flow through `response.data` so `schedule.name` is now populated.
+    await page.goto('/admin/schedules');
+    await page
+      .getByRole('link', { name: testData.schedules.sunday9am.name })
+      .click();
+    await page.getByRole('link', { name: /^edit$/i }).click();
+    await expect(
+      page.getByRole('heading', { name: /edit schedule/i }),
+    ).toBeVisible({ timeout: 10_000 });
+
+    await expect(page.locator('#name')).toHaveValue(
+      testData.schedules.sunday9am.name,
+      { timeout: 10_000 },
+    );
   });
 
-  test.skip('edit mode saves changes and returns to the detail page', async () => {
-    // BLOCKED by NEW-BUG. The edit form never populates from the server,
-    // so submitting would attempt to persist an all-undefined payload and
-    // also can't round-trip the name back to the detail view.
+  test('edit mode saves a description edit and returns to the detail page', async ({
+    page,
+  }) => {
+    // Regression guard for #688: before the fix, the edit form never
+    // populated from the server and `updateSchedule()` returned
+    // `{ data: {...} }`, so the mutation resolved with an object whose own
+    // keys were undefined — the round-trip back to the detail view could
+    // not render the updated schedule name.
+    //
+    // This test edits the description (a non-identifying field we can safely
+    // round-trip against the shared seeded schedule) and then asserts the
+    // detail page renders. We intentionally avoid mutating the name, which
+    // other tests read from.
+    const uniqueDescription = `E2E #688 description ${uniqueSuffix('desc')}`;
+
+    await page.goto('/admin/schedules');
+    await page
+      .getByRole('link', { name: testData.schedules.sunday9am.name })
+      .click();
+    const detailUrl = page.url();
+
+    await page.getByRole('link', { name: /^edit$/i }).click();
+    await expect(page.locator('#name')).toHaveValue(
+      testData.schedules.sunday9am.name,
+      { timeout: 10_000 },
+    );
+
+    const descriptionField = page.locator('#description');
+    await descriptionField.fill(uniqueDescription);
+    await page.getByRole('button', { name: /save changes|update schedule/i }).click();
+
+    // Expect to land back on the detail page (not the /edit route).
+    await expect(page).toHaveURL(detailUrl, { timeout: 10_000 });
+
+    // And the name heading still renders (proves the unwrap on the
+    // subsequent GET /schedules/:idKey refetch).
+    await expect(
+      page.getByRole('heading', {
+        name: testData.schedules.sunday9am.name,
+        level: 1,
+      }),
+    ).toBeVisible({ timeout: 10_000 });
   });
 
   test('navigating to /admin/schedules/:idKey/edit renders the Edit Schedule heading', async ({

--- a/src/web/src/services/api/__tests__/services.extra.test.ts
+++ b/src/web/src/services/api/__tests__/services.extra.test.ts
@@ -579,12 +579,14 @@ describe('auditLogApi', () => {
     }
   });
 
-  it('getEntityAuditHistory has no envelope', async () => {
+  it('getEntityAuditHistory unwraps {data} envelope', async () => {
+    // Backend returns Ok(new { data = entries }) — the FE must unwrap.
     const api = await import('../auditLogApi');
-    mockGet.mockResolvedValueOnce([{ idKey: 'a1' }]);
+    mockGet.mockResolvedValueOnce({ data: [{ idKey: 'a1' }, { idKey: 'a2' }] });
     const out = await api.getEntityAuditHistory('Person', 'p1');
     expect(mockGet).toHaveBeenCalledWith('/audit-logs/entity/Person/p1');
-    expect(out).toEqual([{ idKey: 'a1' }]);
+    expect(Array.isArray(out)).toBe(true);
+    expect(out).toEqual([{ idKey: 'a1' }, { idKey: 'a2' }]);
   });
 
   it('exportAuditLogs uses fetch directly and returns a blob', async () => {
@@ -939,9 +941,13 @@ describe('givingApi deeper coverage', () => {
     });
   });
 
-  it('generateStatement returns body directly', async () => {
+  it('generateStatement unwraps {data} envelope', async () => {
+    // Backend GivingController returns
+    //   CreatedAtAction(..., new { data = result.Value })
+    // for POST /giving/statements — FE must unwrap. (Unlike createBatch and
+    // addContribution in the same controller, which return flat bodies.)
     const giving = await import('../giving');
-    mockPost.mockResolvedValueOnce({ idKey: 'st1' });
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'st1' } });
     const out = await giving.generateStatement({ startDate: 'a', endDate: 'b' } as never);
     expect(out).toEqual({ idKey: 'st1' });
   });

--- a/src/web/src/services/api/__tests__/services.more.test.ts
+++ b/src/web/src/services/api/__tests__/services.more.test.ts
@@ -110,34 +110,55 @@ describe('schedulesApi', () => {
     expect(url).toContain('pageSize=20');
   });
 
-  it('getScheduleByIdKey and getScheduleOccurrences', async () => {
+  it('getScheduleByIdKey and getScheduleOccurrences unwrap {data} envelope (#688)', async () => {
     const api = await import('../schedules');
-    mockGet.mockResolvedValueOnce({ idKey: 's1' });
-    await api.getScheduleByIdKey('s1');
-    expect(mockGet).toHaveBeenCalledWith('/schedules/s1');
 
-    mockGet.mockResolvedValueOnce([]);
-    await api.getScheduleOccurrences('s1');
+    // Backend: GET /schedules/{idKey} returns Ok(new { data = schedule })
+    mockGet.mockResolvedValueOnce({
+      data: { idKey: 's1', name: 'Sunday AM', isActive: true },
+    });
+    const detail = await api.getScheduleByIdKey('s1');
+    expect(mockGet).toHaveBeenCalledWith('/schedules/s1');
+    // Must be unwrapped — pages read schedule.name, schedule.isActive directly.
+    expect(detail).toEqual({ idKey: 's1', name: 'Sunday AM', isActive: true });
+
+    // Backend: GET /schedules/{idKey}/occurrences returns Ok(new { data = occurrences })
+    mockGet.mockResolvedValueOnce({
+      data: [{ occurrenceDateTime: '2026-04-26T10:00:00Z', dayOfWeekName: 'Sunday' }],
+    });
+    const occurrences = await api.getScheduleOccurrences('s1');
     const url = mockGet.mock.calls.at(-1)?.[0] as string;
     expect(url).toContain('/schedules/s1/occurrences');
     expect(url).toContain('count=10');
+    // Must be the array — not { data: [...] }.
+    expect(Array.isArray(occurrences)).toBe(true);
+    expect(occurrences[0]).toEqual({
+      occurrenceDateTime: '2026-04-26T10:00:00Z',
+      dayOfWeekName: 'Sunday',
+    });
 
-    mockGet.mockResolvedValueOnce([]);
+    mockGet.mockResolvedValueOnce({ data: [] });
     await api.getScheduleOccurrences('s1', '2024-01-01', 20);
     const url2 = mockGet.mock.calls.at(-1)?.[0] as string;
     expect(url2).toContain('startDate=2024-01-01');
     expect(url2).toContain('count=20');
   });
 
-  it('createSchedule/updateSchedule/deleteSchedule', async () => {
+  it('createSchedule returns flat body (CreatedAtAction without data envelope) and updateSchedule unwraps (#688)', async () => {
     const api = await import('../schedules');
-    mockPost.mockResolvedValueOnce({ idKey: 'new' });
-    await api.createSchedule({ name: 'X' } as never);
-    expect(mockPost).toHaveBeenCalledWith('/schedules', { name: 'X' });
 
-    mockPut.mockResolvedValueOnce({ idKey: 's1' });
-    await api.updateSchedule('s1', { name: 'Y' } as never);
+    // POST /schedules uses CreatedAtAction(..., schedule) — returns FLAT body.
+    // If we unwrapped here we'd read .data on the schedule itself and lose the fields.
+    mockPost.mockResolvedValueOnce({ idKey: 'new', name: 'X' });
+    const created = await api.createSchedule({ name: 'X' } as never);
+    expect(mockPost).toHaveBeenCalledWith('/schedules', { name: 'X' });
+    expect(created).toEqual({ idKey: 'new', name: 'X' });
+
+    // PUT /schedules/{idKey} returns Ok(new { data = schedule }) — must unwrap.
+    mockPut.mockResolvedValueOnce({ data: { idKey: 's1', name: 'Y' } });
+    const updated = await api.updateSchedule('s1', { name: 'Y' } as never);
     expect(mockPut).toHaveBeenCalledWith('/schedules/s1', { name: 'Y' });
+    expect(updated).toEqual({ idKey: 's1', name: 'Y' });
 
     mockDel.mockResolvedValueOnce(undefined);
     await api.deleteSchedule('s1');

--- a/src/web/src/services/api/__tests__/services.test.ts
+++ b/src/web/src/services/api/__tests__/services.test.ts
@@ -386,33 +386,50 @@ describe('small CRUD services', () => {
     expect(mockDel).toHaveBeenCalledWith('/campuses/c1');
   });
 
-  it('locationsApi list/get/tree/create/update/delete', async () => {
+  it('locationsApi list/get/tree/create/update/delete unwraps {data} envelope (#693)', async () => {
     const locations = await import('../locations');
-    mockGet.mockResolvedValueOnce([]);
-    await locations.getLocations();
-    expect(mockGet).toHaveBeenCalledWith('/locations');
 
-    mockGet.mockResolvedValueOnce([]);
+    // Backend returns Ok(new { data = result }) for all locations endpoints that
+    // have bodies (including Create's CreatedAtAction). The FE service must
+    // unwrap so callers see the DTO directly, NOT { data: DTO }.
+
+    // GET /locations
+    mockGet.mockResolvedValueOnce({ data: [{ idKey: 'l1' }, { idKey: 'l2' }] });
+    const list = await locations.getLocations();
+    expect(mockGet).toHaveBeenCalledWith('/locations');
+    expect(Array.isArray(list)).toBe(true);
+    expect(list).toEqual([{ idKey: 'l1' }, { idKey: 'l2' }]);
+
+    // GET /locations with query params
+    mockGet.mockResolvedValueOnce({ data: [] });
     await locations.getLocations({ campusIdKey: 'c1', includeInactive: true });
     const listUrl = mockGet.mock.calls.at(-1)?.[0] as string;
     expect(listUrl).toContain('campusIdKey=c1');
     expect(listUrl).toContain('includeInactive=true');
 
-    mockGet.mockResolvedValueOnce([]);
-    await locations.getLocationTree();
+    // GET /locations/tree
+    mockGet.mockResolvedValueOnce({ data: [{ idKey: 'root' }] });
+    const tree = await locations.getLocationTree();
     expect(mockGet).toHaveBeenLastCalledWith('/locations/tree');
+    expect(tree).toEqual([{ idKey: 'root' }]);
 
-    mockGet.mockResolvedValueOnce({ idKey: 'l1' });
-    await locations.getLocation('l1');
+    // GET /locations/:idKey — assert unwrapped, not { data: ... }
+    mockGet.mockResolvedValueOnce({ data: { idKey: 'l1', name: 'Sanctuary' } });
+    const one = await locations.getLocation('l1');
     expect(mockGet).toHaveBeenLastCalledWith('/locations/l1');
+    expect(one).toEqual({ idKey: 'l1', name: 'Sanctuary' });
 
-    mockPost.mockResolvedValueOnce({ idKey: 'new' });
-    await locations.createLocation({ name: 'Room A' } as never);
+    // POST /locations — CreatedAtAction(..., new { data = result.Value })
+    mockPost.mockResolvedValueOnce({ data: { idKey: 'new', name: 'Room A' } });
+    const created = await locations.createLocation({ name: 'Room A' } as never);
     expect(mockPost).toHaveBeenCalledWith('/locations', { name: 'Room A' });
+    expect(created).toEqual({ idKey: 'new', name: 'Room A' });
 
-    mockPut.mockResolvedValueOnce({ idKey: 'l1' });
-    await locations.updateLocation('l1', { name: 'X' } as never);
+    // PUT /locations/:idKey
+    mockPut.mockResolvedValueOnce({ data: { idKey: 'l1', name: 'X' } });
+    const updated = await locations.updateLocation('l1', { name: 'X' } as never);
     expect(mockPut).toHaveBeenCalledWith('/locations/l1', { name: 'X' });
+    expect(updated).toEqual({ idKey: 'l1', name: 'X' });
 
     mockDel.mockResolvedValueOnce(undefined);
     await locations.deleteLocation('l1');

--- a/src/web/src/services/api/auditLogApi.ts
+++ b/src/web/src/services/api/auditLogApi.ts
@@ -43,7 +43,11 @@ export async function getEntityAuditHistory(
   entityType: string,
   idKey: string
 ): Promise<AuditLogDto[]> {
-  return get<AuditLogDto[]>(`/audit-logs/entity/${entityType}/${idKey}`);
+  // Backend: Ok(new { data = entries }) — unwrap envelope.
+  const response = await get<{ data: AuditLogDto[] }>(
+    `/audit-logs/entity/${entityType}/${idKey}`
+  );
+  return response.data;
 }
 
 /**

--- a/src/web/src/services/api/giving.ts
+++ b/src/web/src/services/api/giving.ts
@@ -292,8 +292,13 @@ export async function previewStatement(
 export async function generateStatement(
   request: GenerateStatementRequest
 ): Promise<ContributionStatementDto> {
-  // POST returns 201 Created with body directly (not wrapped in data)
-  return post<ContributionStatementDto>('/giving/statements', request);
+  // Backend: CreatedAtAction(..., new { data = result.Value }) — unwrap envelope.
+  // (Other createBatch/addContribution return flat; this one is wrapped — inconsistent BE.)
+  const response = await post<{ data: ContributionStatementDto }>(
+    '/giving/statements',
+    request
+  );
+  return response.data;
 }
 
 /**

--- a/src/web/src/services/api/locations.ts
+++ b/src/web/src/services/api/locations.ts
@@ -27,7 +27,9 @@ export async function getLocations(params?: GetLocationsParams): Promise<Locatio
   const query = searchParams.toString();
   const endpoint = `${BASE_URL}${query ? `?${query}` : ''}`;
 
-  return get<LocationSummaryDto[]>(endpoint);
+  // Backend: Ok(new { data = result }) — unwrap envelope (see #693).
+  const response = await get<{ data: LocationSummaryDto[] }>(endpoint);
+  return response.data;
 }
 
 /**
@@ -45,21 +47,27 @@ export async function getLocationTree(params?: GetLocationsParams): Promise<Loca
   const query = searchParams.toString();
   const endpoint = `${BASE_URL}/tree${query ? `?${query}` : ''}`;
 
-  return get<LocationDto[]>(endpoint);
+  // Backend: Ok(new { data = result.Value }) — unwrap envelope (see #693).
+  const response = await get<{ data: LocationDto[] }>(endpoint);
+  return response.data;
 }
 
 /**
  * Get location details by IdKey
  */
 export async function getLocation(idKey: string): Promise<LocationDto> {
-  return get<LocationDto>(`${BASE_URL}/${idKey}`);
+  // Backend: Ok(new { data = result.Value }) — unwrap envelope (see #693).
+  const response = await get<{ data: LocationDto }>(`${BASE_URL}/${idKey}`);
+  return response.data;
 }
 
 /**
  * Create a new location
  */
 export async function createLocation(request: CreateLocationRequest): Promise<LocationDto> {
-  return post<LocationDto>(BASE_URL, request);
+  // Backend: CreatedAtAction(..., new { data = result.Value }) — unwrap envelope (see #693).
+  const response = await post<{ data: LocationDto }>(BASE_URL, request);
+  return response.data;
 }
 
 /**
@@ -69,7 +77,9 @@ export async function updateLocation(
   idKey: string,
   request: UpdateLocationRequest
 ): Promise<LocationDto> {
-  return put<LocationDto>(`${BASE_URL}/${idKey}`, request);
+  // Backend: Ok(new { data = result.Value }) — unwrap envelope (see #693).
+  const response = await put<{ data: LocationDto }>(`${BASE_URL}/${idKey}`, request);
+  return response.data;
 }
 
 /**

--- a/src/web/src/services/api/schedules.ts
+++ b/src/web/src/services/api/schedules.ts
@@ -30,6 +30,7 @@ export async function searchSchedules(
   const query = queryParams.toString();
   const endpoint = `/schedules${query ? `?${query}` : ''}`;
 
+  // Backend: Ok(new { data = items, meta = {...} }) — matches PagedResult<T> shape exactly.
   return get<PagedResult<ScheduleSummaryDto>>(endpoint);
 }
 
@@ -37,7 +38,9 @@ export async function searchSchedules(
  * Get schedule details by IdKey
  */
 export async function getScheduleByIdKey(idKey: string): Promise<ScheduleDetailDto> {
-  return get<ScheduleDetailDto>(`/schedules/${idKey}`);
+  // Backend: Ok(new { data = schedule }) — unwrap envelope (see #688).
+  const response = await get<{ data: ScheduleDetailDto }>(`/schedules/${idKey}`);
+  return response.data;
 }
 
 /**
@@ -56,7 +59,9 @@ export async function getScheduleOccurrences(
   const query = queryParams.toString();
   const endpoint = `/schedules/${idKey}/occurrences${query ? `?${query}` : ''}`;
 
-  return get<ScheduleOccurrenceDto[]>(endpoint);
+  // Backend: Ok(new { data = occurrences }) — unwrap envelope (see #688).
+  const response = await get<{ data: ScheduleOccurrenceDto[] }>(endpoint);
+  return response.data;
 }
 
 /**
@@ -65,6 +70,8 @@ export async function getScheduleOccurrences(
 export async function createSchedule(
   request: CreateScheduleRequest
 ): Promise<ScheduleDetailDto> {
+  // Backend: CreatedAtAction(..., schedule) — returns flat (NOT enveloped).
+  // Do NOT unwrap, or we'll read .data on the schedule itself (see #688).
   return post<ScheduleDetailDto>('/schedules', request);
 }
 
@@ -75,7 +82,9 @@ export async function updateSchedule(
   idKey: string,
   request: UpdateScheduleRequest
 ): Promise<ScheduleDetailDto> {
-  return put<ScheduleDetailDto>(`/schedules/${idKey}`, request);
+  // Backend: Ok(new { data = schedule }) — unwrap envelope (see #688).
+  const response = await put<{ data: ScheduleDetailDto }>(`/schedules/${idKey}`, request);
+  return response.data;
 }
 
 /**


### PR DESCRIPTION
## Summary

Backend responses are shaped `{ "data": {...payload...} }` (per api-contracts.md, #211). Sibling FE API services (campuses, funds, people, families, groups) all unwrap via `const response = await get<...>(...); return response.data;`. `schedules.ts` and `locations.ts` were returning the raw enveloped response, so callers received `{ data: DTO }` where they expected the DTO — `ScheduleDetailPage` rendered blank heading and "Invalid Date", `CheckinLocationsTab` crashed the page into the global error boundary.

Closes (after merge — PM will close): #688, #693

## Per-method changes

### `src/web/src/services/api/schedules.ts` (#688)

| Method | Backend response | Before (FE) | After (FE) |
|---|---|---|---|
| `searchSchedules` | `Ok(new { data = items, meta = {...} })` | raw (matches `PagedResult<T>`) | **unchanged** — already correct |
| `getScheduleByIdKey` | `Ok(new { data = schedule })` | raw (broken) | `response.data` |
| `getScheduleOccurrences` | `Ok(new { data = occurrences })` | raw (broken) | `response.data` |
| `createSchedule` | `CreatedAtAction(..., schedule)` — FLAT | raw (correct) | **unchanged** — already correct |
| `updateSchedule` | `Ok(new { data = schedule })` | raw (broken) | `response.data` |
| `deleteSchedule` | `NoContent()` (204) | n/a | **unchanged** |

### `src/web/src/services/api/locations.ts` (#693)

`LocationsController` consistently wraps every body-returning endpoint — including `POST /locations` which uses `CreatedAtAction(..., new { data = result.Value })` (unlike SchedulesController's flat `CreatedAtAction(..., schedule)`). All affected methods now unwrap:

| Method | Backend response | Before (FE) | After (FE) |
|---|---|---|---|
| `getLocations` | `Ok(new { data = result })` | raw (broken) | `response.data` |
| `getLocationTree` | `Ok(new { data = result.Value })` | raw (broken) | `response.data` |
| `getLocation` | `Ok(new { data = result.Value })` | raw (broken) | `response.data` |
| `createLocation` | `CreatedAtAction(..., new { data = result.Value })` | raw (broken) | `response.data` |
| `updateLocation` | `Ok(new { data = result.Value })` | raw (broken) | `response.data` |
| `deleteLocation` | `NoContent()` (204) | n/a | **unchanged** |

## Additional services with the same bug (found during audit)

These two were not in the #688/#693 tickets but exhibit exactly the same envelope-unwrap miss vs. their controller. Fixing here so we don't ship a partial remediation:

| File | Method | Backend response | Notes |
|---|---|---|---|
| `src/web/src/services/api/auditLogApi.ts` | `getEntityAuditHistory` | `Ok(new { data = entries })` | `GET /audit-logs/entity/{type}/{idKey}` |
| `src/web/src/services/api/giving.ts` | `generateStatement` | `CreatedAtAction(..., new { data = result.Value })` | Inconsistent with sibling `createBatch` / `addContribution` in the same controller (those return FLAT and FE correctly did NOT unwrap) |

The audit walked every `return get<…>` / `return post<…>` / `return put<…>` / `return del<…>` / `return request<…>` across `src/web/src/services/api/*.ts` and cross-checked each against its controller action. All other raw-return callers were correct: either the return type is `PagedResult<T>` (backend returns `{data, meta}` which matches exactly) or the controller deliberately returns a flat body via `Ok(result)` / `CreatedAtAction(..., value)`.

## Note on issue #688's `createSchedule`

The #688 ticket listed `createSchedule` as broken, but `SchedulesController.Create` returns `CreatedAtAction(..., schedule)` — a FLAT body, NOT wrapped. A double-unwrap here would reintroduce the bug. I've added an explicit comment in `schedules.ts` documenting that invariant so future edits don't break it. This is a BE inconsistency relative to `CampusesController.Create` / `LocationsController.Create` / `GivingController.GenerateStatement` which all DO wrap CreatedAtAction bodies — flagging for PM follow-up but out of scope for this PR (task forbids backend edits).

## Unit test coverage

All updated/augmented tests assert on the **unwrapped** shape (e.g. `result.idKey`), not `result.data.idKey`:

- `src/web/src/services/api/__tests__/services.test.ts` — `locationsApi` test now asserts the returned value equals the DTO (or DTO array), not the envelope, for every endpoint including Create.
- `src/web/src/services/api/__tests__/services.more.test.ts` — `schedulesApi` test split into (a) `getScheduleByIdKey` / `getScheduleOccurrences` unwrap; (b) `createSchedule` returns flat body (regression guard if controller ever changes) / `updateSchedule` unwrap.
- `src/web/src/services/api/__tests__/services.extra.test.ts` — `getEntityAuditHistory` and `generateStatement` assertions corrected to the actual (unwrapped) shape.

## E2E unskips

`npx playwright test --list` shows zero remaining `.skip()` references to #688 or #693 in the two affected specs. `ALLOW_E2E_EDIT=1` was set while editing.

- `src/web/e2e/tests/admin/schedules/feat-679-schedules-admin.spec.ts` — 5 tests unskipped:
  - ScheduleDetailPage: name heading, Schedule Details card (Sunday at 9:00 AM), Status sidebar (Active pill, not "Inactive").
  - ScheduleFormPage edit mode: name pre-fill from server, description edit round-trip back to detail page.
- `src/web/e2e/tests/admin/feat-679-checkin-config.spec.ts` — 2 #693 tests unskipped + 1 upgraded from shell-only:
  - Locations tab body renders without the global error boundary.
  - Table headers render when seeded locations exist (graceful skip on empty tenant with annotation).
  - Edit Capacity modal opens when rows present (graceful skip on empty tenant).
- `#692` (Areas tab campusId bug) skipped tests left alone per task spec. `#694` / `#695` tests already active on `dev` (fixed in #700) — not touched.

## Verification

- `cd src/web && npx tsc --noEmit` — 0 errors.
- `cd src/web && npx vitest run` — 144 files / 1322 tests all pass.
- `cd src/web && npx vitest run --coverage` (Node 20 via docker; local was Node 18) — all thresholds hold: lines 40.38 ≥ 38, statements 40.05 ≥ 38, functions 42.4 ≥ 40, branches 26.56 ≥ 25.
- `npx playwright test --list e2e/tests/admin/schedules/feat-679-schedules-admin.spec.ts e2e/tests/admin/feat-679-checkin-config.spec.ts --project=chromium` — 41 tests enumerate cleanly, previously-skipped tests now present. Full E2E execution needs a live backend stack; runs in CI.
- `git diff --name-only` — only allowed files (2 E2E specs, 3 unit-test files, schedules.ts, locations.ts, and the 2 flagged sibling fixes).

## Test plan

- [ ] CI passes (tsc, unit, backend, graph validate).
- [ ] Playwright CI: all 7 newly-unskipped tests in `feat-679-schedules-admin.spec.ts` + `feat-679-checkin-config.spec.ts` pass.
- [ ] Live smoke post-merge:
  - [ ] `/admin/schedules/{seededIdKey}` renders schedule name, day/time, and active status correctly (no "Invalid Date").
  - [ ] `/admin/checkin` → Locations tab renders without the global error boundary.
  - [ ] `/admin/audit-logs/{type}/{idKey}` entity history page renders entries.
  - [ ] `/giving/statements` new-statement flow returns to the detail page with the correct idKey.

**Do NOT auto-close #688 or #693** — PM closes after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)