### PR TITLE
fix(schedules): align time format + correct weekly-schedule superRefine (#689)

### DIFF
--- a/src/web/e2e/tests/admin/schedules/feat-679-schedules-admin.spec.ts
+++ b/src/web/e2e/tests/admin/schedules/feat-679-schedules-admin.spec.ts
@@ -30,22 +30,22 @@
  *   tests that were previously .skip()-ed with a reference to this bug are
  *   now active as regression guards in the detail/edit describe blocks.
  *
- * NEW BUG #2 (skip-and-flag): schedule form create/submit is broken.
+ * BUG #2 (FIXED, #689): schedule form weekly create/submit.
  *   (a) `src/web/src/components/admin/schedules/WeeklySchedulePicker.tsx`
- *       produces `HH:MM:SS` values via `generateTimeOptions()`, but
- *       `src/web/src/schemas/schedule.schema.ts` validates `timeOfDay` with
- *       a regex that only accepts `HH:MM`. Any selected time fails client
- *       validation, so the form refuses to POST.
- *   (b) The server (`POST /api/v1/schedules`) requires both
- *       `weeklyDayOfWeek` and `weeklyTimeOfDay` for weekly schedules but
- *       the client schema's `superRefine` for this is a tautological
- *       no-op — it lets empty submissions through, which then 400 from
- *       the server without user-visible feedback.
- *   Because of (a) and (b), an end-to-end create flow is not achievable
- *   from the UI as written. The form's static chrome, disabled-when-empty
- *   submit guard, day/time picker interactions, and cancel flow ARE all
- *   assertable and covered below. Suggested issue title:
- *     "fix(web): schedule form cannot submit valid weekly schedules"
+ *       produces `HH:MM:SS` values via `generateTimeOptions()` — the
+ *       backend `TimeSpan?` DTO strictly deserializes that format, so
+ *       that output is correct. The schema's `timeOfDay` regex was too
+ *       narrow (HH:MM only) and has been broadened to accept HH:MM(:SS)?.
+ *   (b) The `superRefine` predicate enforcing the day+time pair used to be
+ *       tautological `(A||B) && (!A && !B)` — always false. It is now a
+ *       correct XOR: both set OR both unset is valid, exactly one set is
+ *       an error flagged inline on the missing field. Previously empty
+ *       submissions slipped past the FE and 400'd from the server without
+ *       user-visible feedback.
+ *   With both fixed, an end-to-end weekly-schedule create flow is
+ *   achievable — a regression guard lives in the create-mode describe
+ *   below. The pre-existing picker-interactivity test remains as a guard
+ *   against styling/value-binding regressions in the picker itself.
  *
  * Guardrails:
  *  - No data-testid attributes added to production code.
@@ -349,18 +349,9 @@ test.describe('ScheduleFormPage — create mode', () => {
   });
 
   test('day buttons and time selector are interactive', async ({ page }) => {
-    // We cannot exercise a full submit flow end-to-end here because the form
-    // is blocked by TWO additional pre-existing bugs (see "NEW BUG #2" in the
-    // module doc at the top of this file):
-    //   (a) WeeklySchedulePicker emits HH:MM:SS values but the zod schema
-    //       only accepts HH:MM, so the form's client-side validation
-    //       rejects any selected time.
-    //   (b) The server requires both weeklyDayOfWeek and weeklyTimeOfDay
-    //       for weekly schedules, but the frontend schema does not enforce
-    //       that pair-wise requirement, so submitting with neither results
-    //       in a 400 that the form doesn't surface to the user.
-    // This test at least confirms the day/time controls respond to clicks
-    // — a regression in the picker itself would still be caught.
+    // Regression guard on the picker controls themselves: a regression in
+    // the day-button styling contract or the time-select value binding
+    // would be caught here regardless of submit-path regressions.
     await page.locator('#name').fill(`E2E Wave5 PickerCheck ${uniqueSuffix('sch')}`);
 
     const monBtn = page.getByRole('button', { name: 'Mon' });
@@ -371,6 +362,50 @@ test.describe('ScheduleFormPage — create mode', () => {
     const timeSelect = page.locator('#timeOfDay');
     await timeSelect.selectOption('10:00:00');
     await expect(timeSelect).toHaveValue('10:00:00');
+  });
+
+  test('submits a valid weekly schedule end-to-end and lands on the detail page (#689)', async ({
+    page,
+  }) => {
+    // Regression guard for #689: before the fix the form could not submit.
+    //   - WeeklySchedulePicker emits HH:MM:SS, the zod regex now accepts it.
+    //   - superRefine is now a real XOR check on (dayOfWeek, timeOfDay).
+    // This test fills a minimal valid weekly schedule, submits, and asserts
+    // the app navigates to the detail page for the created schedule.
+    const name = `E2E #689 Weekly ${uniqueSuffix('sch')}`;
+    await page.locator('#name').fill(name);
+
+    // Pick a weekday (Tuesday) and 10:00 AM.
+    await page.getByRole('button', { name: 'Tue' }).click();
+    await page.locator('#timeOfDay').selectOption('10:00:00');
+
+    await page.getByRole('button', { name: /^create schedule$/i }).click();
+
+    // Expect navigation to the detail route and the name heading to render.
+    await expect(page).toHaveURL(/\/admin\/schedules\/[^/]+$/, { timeout: 10_000 });
+    await expect(
+      page.getByRole('heading', { name, level: 1 }),
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('blocks submit when weekly time is picked without a day (#689)', async ({
+    page,
+  }) => {
+    // Regression guard for #689 Bug C: previously the tautological
+    // superRefine let mismatched day/time submissions through to the server
+    // without inline feedback. The corrected XOR predicate now causes
+    // safeParse to fail on the client and the form stays on /new instead
+    // of navigating to the created-schedule detail page.
+    await page.locator('#name').fill(`E2E #689 PairCheck ${uniqueSuffix('sch')}`);
+    await page.locator('#timeOfDay').selectOption('11:30:00');
+
+    // Submit — schema must reject and keep us on the form (no navigation).
+    await page.getByRole('button', { name: /^create schedule$/i }).click();
+
+    // Give any would-be navigation a chance to settle, then assert we
+    // are still on the new-schedule URL.
+    await page.waitForTimeout(250);
+    await expect(page).toHaveURL(/\/admin\/schedules\/new$/);
   });
 });
 

--- a/src/web/src/schemas/__tests__/schedule.schema.test.ts
+++ b/src/web/src/schemas/__tests__/schedule.schema.test.ts
@@ -98,8 +98,23 @@ describe('scheduleFormSchema', () => {
     });
   });
 
+  it('should validate time format (HH:MM:SS) as emitted by generateTimeOptions', () => {
+    // The picker emits HH:MM:SS (see utils/dateFormatters.generateTimeOptions)
+    // and the backend DTO is TimeSpan? which is serialized as HH:MM:SS.
+    // The schema must accept both HH:MM and HH:MM:SS to allow the picker
+    // output to round-trip through create/edit.
+    const validTimes = ['00:00:00', '09:00:00', '12:30:45', '23:59:59'];
+    validTimes.forEach((timeOfDay) => {
+      const result = scheduleFormSchema.safeParse({
+        ...validSchedule,
+        timeOfDay,
+      });
+      expect(result.success).toBe(true);
+    });
+  });
+
   it('should reject invalid time formats', () => {
-    const invalidTimes = ['9:00', '25:00', '12:60', '12:00 AM', 'invalid'];
+    const invalidTimes = ['9:00', '25:00', '12:60', '12:00 AM', 'invalid', '12:00:60', '12:00:'];
     invalidTimes.forEach((timeOfDay) => {
       const result = scheduleFormSchema.safeParse({
         ...validSchedule,
@@ -301,5 +316,67 @@ describe('scheduleFormSchema', () => {
       name: 'Test Schedule',
     });
     expect(result.success).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Weekly schedule pairing (day-of-week + time-of-day) — #689 regression
+  // -------------------------------------------------------------------------
+  describe('weekly schedule pairing (dayOfWeek + timeOfDay)', () => {
+    const baseSchedule = {
+      name: 'Pairing Test Schedule',
+    };
+
+    it('accepts a schedule with BOTH dayOfWeek and timeOfDay set', () => {
+      const result = scheduleFormSchema.safeParse({
+        ...baseSchedule,
+        dayOfWeek: 0,
+        timeOfDay: '09:00:00',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a schedule with NEITHER dayOfWeek nor timeOfDay set (non-weekly)', () => {
+      const result = scheduleFormSchema.safeParse(baseSchedule);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects a schedule when dayOfWeek is set but timeOfDay is missing', () => {
+      const result = scheduleFormSchema.safeParse({
+        ...baseSchedule,
+        dayOfWeek: 0,
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find((i) => i.path[0] === 'timeOfDay');
+        expect(issue).toBeDefined();
+        expect(issue?.message).toContain('day of week and a time of day');
+      }
+    });
+
+    it('rejects a schedule when dayOfWeek is set but timeOfDay is an empty string', () => {
+      const result = scheduleFormSchema.safeParse({
+        ...baseSchedule,
+        dayOfWeek: 3,
+        timeOfDay: '',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find((i) => i.path[0] === 'timeOfDay');
+        expect(issue).toBeDefined();
+      }
+    });
+
+    it('rejects a schedule when timeOfDay is set but dayOfWeek is missing', () => {
+      const result = scheduleFormSchema.safeParse({
+        ...baseSchedule,
+        timeOfDay: '09:00:00',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find((i) => i.path[0] === 'dayOfWeek');
+        expect(issue).toBeDefined();
+        expect(issue?.message).toContain('day of week and a time of day');
+      }
+    });
   });
 });

--- a/src/web/src/schemas/schedule.schema.ts
+++ b/src/web/src/schemas/schedule.schema.ts
@@ -20,7 +20,10 @@ export const scheduleFormSchema = z.object({
     .optional(),
 
   timeOfDay: z.union([
-    z.string().regex(/^([01]\d|2[0-3]):([0-5]\d)$/, 'Time must be in HH:MM format (e.g., 09:00)'),
+    z.string().regex(
+      /^([01]\d|2[0-3]):([0-5]\d)(:([0-5]\d))?$/,
+      'Time must be in HH:MM or HH:MM:SS format (e.g., 09:00 or 09:00:00)',
+    ),
     z.literal(''),
   ]).optional(),
 
@@ -68,13 +71,15 @@ export const scheduleFormSchema = z.object({
     }
   }
 
-  // Validate that at least one of dayOfWeek or timeOfDay is set for weekly schedules
-  if ((data.dayOfWeek !== undefined || data.timeOfDay) &&
-      (data.dayOfWeek === undefined && !data.timeOfDay)) {
+  // Weekly schedules require BOTH day-of-week and time-of-day to be paired.
+  // Valid: both set OR both unset. Invalid: exactly one set (XOR).
+  const hasDay = data.dayOfWeek !== undefined;
+  const hasTime = !!data.timeOfDay;
+  if (hasDay !== hasTime) {
     ctx.addIssue({
       code: z.ZodIssueCode.custom,
-      message: 'Both day of week and time must be set for weekly schedules',
-      path: ['timeOfDay'],
+      message: 'Weekly schedules require both a day of week and a time of day.',
+      path: hasTime ? ['dayOfWeek'] : ['timeOfDay'],
     });
   }
 });

--- a/src/web/src/utils/__tests__/dateFormatters.test.ts
+++ b/src/web/src/utils/__tests__/dateFormatters.test.ts
@@ -73,4 +73,16 @@ describe('generateTimeOptions', () => {
       expect(t).toMatch(/^\d{2}:\d{2}:00$/);
     }
   });
+
+  it('produces values that the schedule schema regex accepts (#689)', () => {
+    // Regression guard for #689 bug A/B: the picker emits HH:MM:SS values
+    // and the schedule schema's timeOfDay regex must accept that exact
+    // format. If these ever drift, the form cannot submit. The regex
+    // source-of-truth lives in src/schemas/schedule.schema.ts.
+    const scheduleTimeRegex = /^([01]\d|2[0-3]):([0-5]\d)(:([0-5]\d))?$/;
+    const times = generateTimeOptions();
+    for (const t of times) {
+      expect(t).toMatch(scheduleTimeRegex);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #689. The weekly schedule admin form couldn't submit because of three cooperating bugs in the frontend layer:

### Bug A — picker emits `HH:MM:SS`
`src/web/src/utils/dateFormatters.ts` `generateTimeOptions` produces `HH:MM:00` values. **Kept as-is** — see decision below.

### Bug B — schema regex only accepts `HH:MM`
`src/web/src/schemas/schedule.schema.ts` `timeOfDay` regex was `^([01]\d|2[0-3]):([0-5]\d)$`. It rejected every value the picker emitted. **Broadened to `HH:MM(:SS)?`**.

### Bug C — tautological `superRefine`
`src/web/src/schemas/schedule.schema.ts` weekly-pair predicate `(A||B) && (!A && !B)` is always false — it never flagged a mismatched submission, so a partially-filled weekly form would 400 from the server without user-visible feedback. **Replaced with a correct XOR predicate**: both set is valid, both unset is valid, exactly one set fails inline on the missing field.

## Decision rationale: broaden regex (not normalize picker)

Leaned toward the opposite initially per the issue guidance, but the backend contract settles it:

- `CreateScheduleRequest.WeeklyTimeOfDay` is `TimeSpan?`
- System.Text.Json deserializes `TimeSpan` with the strict `"c"` format, which requires `HH:MM:SS` — `"09:00"` would fail to deserialize server-side
- The backend **returns** `TimeSpan` as `09:00:00` on reads, so on edit the server value already flows into state as `HH:MM:SS`

Normalizing the picker to `HH:MM` would have broken both POST (bad time on wire) and edit-mode round-trips (option mismatch in `<select>`). Broadening the regex keeps the whole create→read→edit cycle consistent with the wire format.

## Before/after

| | Before | After |
|---|---|---|
| A: picker output | `09:00:00` | `09:00:00` (unchanged — matches BE `TimeSpan` format) |
| B: schema regex | `HH:MM` only | `HH:MM(:SS)?` |
| C: superRefine | `(A\|\|B) && (!A && !B)` → always false | `hasDay !== hasTime` (XOR) — blocks mismatched pair |

## Files touched

- `src/web/src/schemas/schedule.schema.ts` — regex + superRefine
- `src/web/src/schemas/__tests__/schedule.schema.test.ts` — new XOR-pairing tests + `HH:MM:SS` format tests
- `src/web/src/utils/__tests__/dateFormatters.test.ts` — new picker↔schema regex compatibility guard
- `src/web/e2e/tests/admin/schedules/feat-679-schedules-admin.spec.ts` — promoted the skip-and-flag picker test to a real weekly create-and-submit flow, plus a "submit blocked when pair incomplete" guard for Bug C; module doc updated from "NEW BUG" to "FIXED, #689"

No backend, entity, seeder, graph-baseline, or other-E2E-spec changes.

## Unit + E2E confirmation

- `npx tsc --noEmit` — 0 errors
- `npx vitest run` — **1343/1343 passed** (includes 5 new pairing tests + `HH:MM:SS` coverage + picker/schema compatibility guard)
- `dotnet build` — 0 errors, 0 warnings (no backend changes)
- Playwright: the create-and-submit test and the pair-incomplete block test are added to `feat-679-schedules-admin.spec.ts`; the existing picker-interactivity test is retained as a regression guard

## Test plan

- [ ] Review the XOR superRefine — confirm the path toggles between `dayOfWeek` and `timeOfDay` correctly
- [ ] Review the regex broadening — `HH:MM(:SS)?` matches what the picker emits and what `TimeSpan` serializes to
- [ ] Manually smoke `/admin/schedules/new`: pick Weekly → day → time → submit → lands on detail page
- [ ] Run `npx playwright test e2e/tests/admin/schedules/feat-679-schedules-admin.spec.ts --project=chromium`

Do not close #689 on merge — PM will close it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)