### PR TITLE
fix(tracking): persist entity mutations on update paths (#685)

### DIFF
--- a/src/Koinon.Application/Services/CampusService.cs
+++ b/src/Koinon.Application/Services/CampusService.cs
@@ -83,7 +83,10 @@ public class CampusService(
             return Result<CampusDto>.Failure(Error.NotFound("Campus", idKey));
         }
 
+        // AsTracking required: global QueryTrackingBehavior is NoTracking (see PostgreSqlProvider),
+        // so without it SaveChanges would not persist the mutations below. (fixes #685)
         var entity = await context.Campuses
+            .AsTracking()
             .FirstOrDefaultAsync(c => c.Id == id, ct);
 
         if (entity == null)
@@ -114,7 +117,9 @@ public class CampusService(
             return Result.Failure(Error.NotFound("Campus", idKey));
         }
 
+        // AsTracking required for soft-delete mutation (global QueryTrackingBehavior is NoTracking). (fixes #685)
         var entity = await context.Campuses
+            .AsTracking()
             .FirstOrDefaultAsync(c => c.Id == id, ct);
 
         if (entity == null)

--- a/src/Koinon.Application/Services/CommunicationPreferenceService.cs
+++ b/src/Koinon.Application/Services/CommunicationPreferenceService.cs
@@ -108,8 +108,10 @@ public class CommunicationPreferenceService(
                 communicationType);
         }
 
-        // Find or create preference
+        // Find or create preference. AsTracking required: global QueryTrackingBehavior is NoTracking
+        // (see PostgreSqlProvider), so without it SaveChanges would not persist the update-branch mutations below. (fixes #685)
         var preference = await context.CommunicationPreferences
+            .AsTracking()
             .FirstOrDefaultAsync(cp => cp.PersonId == personId && cp.CommunicationType == commType, ct);
 
         if (preference == null)
@@ -197,8 +199,10 @@ public class CommunicationPreferenceService(
             updates.Add((commType, item.IsOptedOut, item.OptOutReason));
         }
 
-        // Load all existing preferences for this person
+        // Load all existing preferences for this person. AsTracking required: global QueryTrackingBehavior
+        // is NoTracking, so without it SaveChanges would not persist the update-branch mutations below. (fixes #685)
         var existingPreferences = await context.CommunicationPreferences
+            .AsTracking()
             .Where(cp => cp.PersonId == personId)
             .ToListAsync(ct);
 

--- a/src/Koinon.Application/Services/CommunicationService.cs
+++ b/src/Koinon.Application/Services/CommunicationService.cs
@@ -276,7 +276,10 @@ public class CommunicationService(
             return Result<CommunicationDto>.Failure(Error.NotFound("Communication", idKey));
         }
 
+        // AsTracking required: global QueryTrackingBehavior is NoTracking (see PostgreSqlProvider),
+        // so without it SaveChanges would not persist the mutations below. (fixes #685)
         var communication = await context.Communications
+            .AsTracking()
             .Include(c => c.Recipients)
             .FirstOrDefaultAsync(c => c.Id == id, ct);
 
@@ -406,7 +409,9 @@ public class CommunicationService(
             return Result<CommunicationDto>.Failure(Error.NotFound("Communication", idKey));
         }
 
+        // AsTracking required for status mutation (global QueryTrackingBehavior is NoTracking). (fixes #685)
         var communication = await context.Communications
+            .AsTracking()
             .Include(c => c.Recipients)
             .FirstOrDefaultAsync(c => c.Id == id, ct);
 
@@ -477,7 +482,9 @@ public class CommunicationService(
             return Result<CommunicationDto>.Failure(Error.NotFound("Communication", idKey));
         }
 
+        // AsTracking required for schedule mutation (global QueryTrackingBehavior is NoTracking). (fixes #685)
         var communication = await context.Communications
+            .AsTracking()
             .Include(c => c.Recipients)
             .FirstOrDefaultAsync(c => c.Id == id, ct);
 
@@ -565,7 +572,9 @@ public class CommunicationService(
             return Result<CommunicationDto>.Failure(Error.NotFound("Communication", idKey));
         }
 
+        // AsTracking required for cancel mutation (global QueryTrackingBehavior is NoTracking). (fixes #685)
         var communication = await context.Communications
+            .AsTracking()
             .Include(c => c.Recipients)
             .FirstOrDefaultAsync(c => c.Id == id, ct);
 

--- a/src/Koinon.Application/Services/CommunicationTemplateService.cs
+++ b/src/Koinon.Application/Services/CommunicationTemplateService.cs
@@ -175,7 +175,10 @@ public class CommunicationTemplateService(
             return Result<CommunicationTemplateDto>.Failure(Error.NotFound("CommunicationTemplate", idKey));
         }
 
+        // AsTracking required: global QueryTrackingBehavior is NoTracking (see PostgreSqlProvider),
+        // so without it SaveChanges would not persist the mutations below. (fixes #685)
         var template = await context.CommunicationTemplates
+            .AsTracking()
             .FirstOrDefaultAsync(t => t.Id == id, ct);
 
         if (template is null)

--- a/src/Koinon.Application/Services/DefinedTypeService.cs
+++ b/src/Koinon.Application/Services/DefinedTypeService.cs
@@ -166,7 +166,10 @@ public class DefinedTypeService(
             return Result<DefinedValueManagementDto>.Failure(Error.NotFound("DefinedValue", valueIdKey));
         }
 
+        // AsTracking required: global QueryTrackingBehavior is NoTracking (see PostgreSqlProvider),
+        // so without it SaveChanges would not persist the mutations below. (fixes #685)
         var entity = await context.DefinedValues
+            .AsTracking()
             .Include(v => v.DefinedType)
             .FirstOrDefaultAsync(v => v.Id == id, ct);
 
@@ -203,7 +206,9 @@ public class DefinedTypeService(
             return Result.Failure(Error.NotFound("DefinedValue", valueIdKey));
         }
 
+        // AsTracking required for soft-delete mutation (global QueryTrackingBehavior is NoTracking). (fixes #685)
         var entity = await context.DefinedValues
+            .AsTracking()
             .FirstOrDefaultAsync(v => v.Id == id, ct);
 
         if (entity == null)
@@ -258,7 +263,9 @@ public class DefinedTypeService(
 
         var itemIds = decodedItems.Select(i => i.Id).ToArray();
 
+        // AsTracking required for reorder mutations (global QueryTrackingBehavior is NoTracking). (fixes #685)
         var values = await context.DefinedValues
+            .AsTracking()
             .Where(v => v.DefinedTypeId == typeId && itemIds.Contains(v.Id))
             .ToListAsync(ct);
 

--- a/src/Koinon.Application/Services/FollowUpService.cs
+++ b/src/Koinon.Application/Services/FollowUpService.cs
@@ -148,7 +148,10 @@ public class FollowUpService(
             return Result<FollowUpDto>.Failure(Error.NotFound("FollowUp", idKey));
         }
 
+        // AsTracking required: global QueryTrackingBehavior is NoTracking (see PostgreSqlProvider),
+        // so without it SaveChanges would not persist the status and notes mutations below. (fixes #685)
         var followUp = await context.FollowUps
+            .AsTracking()
             .Include(f => f.Person)
             .Include(f => f.AssignedToPerson)
             .Include(f => f.Attendance)
@@ -228,7 +231,9 @@ public class FollowUpService(
             return Result.Failure(Error.NotFound("Person", assignedToIdKey));
         }
 
+        // AsTracking required for assignment mutation (global QueryTrackingBehavior is NoTracking). (fixes #685)
         var followUp = await context.FollowUps
+            .AsTracking()
             .FirstOrDefaultAsync(f => f.Id == id, ct);
 
         if (followUp == null)

--- a/src/Koinon.Application/Services/GroupTypeService.cs
+++ b/src/Koinon.Application/Services/GroupTypeService.cs
@@ -130,8 +130,9 @@ public class GroupTypeService(
             return Result<GroupTypeDto>.Failure(Error.NotFound("GroupType", idKey));
         }
 
-        // Find group type
-        var groupType = await context.GroupTypes.FindAsync([id], ct);
+        // Find group type. AsTracking required: global QueryTrackingBehavior is NoTracking
+        // (see PostgreSqlProvider), so without it SaveChanges would not persist mutations below. (fixes #685)
+        var groupType = await context.GroupTypes.AsTracking().FirstOrDefaultAsync(g => g.Id == id, ct);
         if (groupType == null)
         {
             return Result<GroupTypeDto>.Failure(Error.NotFound("GroupType", idKey));
@@ -239,8 +240,8 @@ public class GroupTypeService(
             return Result<bool>.Failure(Error.NotFound("GroupType", idKey));
         }
 
-        // Find group type
-        var groupType = await context.GroupTypes.FindAsync([id], ct);
+        // Find group type. AsTracking required for archive mutation (global QueryTrackingBehavior is NoTracking). (fixes #685)
+        var groupType = await context.GroupTypes.AsTracking().FirstOrDefaultAsync(g => g.Id == id, ct);
         if (groupType == null)
         {
             return Result<bool>.Failure(Error.NotFound("GroupType", idKey));

--- a/src/Koinon.Application/Services/LocationService.cs
+++ b/src/Koinon.Application/Services/LocationService.cs
@@ -262,7 +262,9 @@ public class LocationService : ILocationService
             return Result<LocationDto>.Failure(Error.NotFound("Location", idKey));
         }
 
-        var location = await _context.Locations.FirstOrDefaultAsync(l => l.Id == id, ct);
+        // AsTracking required: global QueryTrackingBehavior is NoTracking (see PostgreSqlProvider),
+        // so without it SaveChanges would not persist the mutations below. (fixes #685)
+        var location = await _context.Locations.AsTracking().FirstOrDefaultAsync(l => l.Id == id, ct);
         if (location == null)
         {
             return Result<LocationDto>.Failure(Error.NotFound("Location", idKey));
@@ -471,7 +473,8 @@ public class LocationService : ILocationService
             return Result.Failure(Error.NotFound("Location", idKey));
         }
 
-        var location = await _context.Locations.FirstOrDefaultAsync(l => l.Id == id, ct);
+        // AsTracking required for soft-delete mutation (global QueryTrackingBehavior is NoTracking). (fixes #685)
+        var location = await _context.Locations.AsTracking().FirstOrDefaultAsync(l => l.Id == id, ct);
         if (location == null)
         {
             return Result.Failure(Error.NotFound("Location", idKey));

--- a/src/Koinon.Application/Services/NotificationService.cs
+++ b/src/Koinon.Application/Services/NotificationService.cs
@@ -170,8 +170,11 @@ public class NotificationService(
             return false;
         }
 
-        // Ownership validation: notification must belong to the specified person
+        // Ownership validation: notification must belong to the specified person.
+        // AsTracking required: global QueryTrackingBehavior is NoTracking (see PostgreSqlProvider),
+        // so without it SaveChanges would not persist the IsRead mutation below. (fixes #685)
         var notification = await context.Notifications
+            .AsTracking()
             .FirstOrDefaultAsync(n => n.Id == id && n.PersonId == personId, cancellationToken);
 
         if (notification == null)
@@ -353,8 +356,10 @@ public class NotificationService(
             throw new ArgumentException($"Person not found: {personIdKey}", nameof(personIdKey));
         }
 
-        // Check if preference already exists
+        // Check if preference already exists. AsTracking required: global QueryTrackingBehavior is
+        // NoTracking, so without it SaveChanges would not persist the update-branch mutations below. (fixes #685)
         var existing = await context.NotificationPreferences
+            .AsTracking()
             .FirstOrDefaultAsync(
                 np => np.PersonId == personId && np.NotificationType == dto.NotificationType,
                 cancellationToken);

--- a/src/Koinon.Application/Services/ScheduleService.cs
+++ b/src/Koinon.Application/Services/ScheduleService.cs
@@ -133,8 +133,9 @@ public class ScheduleService(
             return Result<ScheduleDto>.Failure(Error.NotFound("Schedule", idKey));
         }
 
-        // Find schedule
-        var schedule = await context.Schedules.FindAsync([id], ct);
+        // Find schedule. AsTracking required: global QueryTrackingBehavior is NoTracking
+        // (see PostgreSqlProvider), so without it SaveChanges would not persist mutations below. (fixes #685)
+        var schedule = await context.Schedules.AsTracking().FirstOrDefaultAsync(s => s.Id == id, ct);
         if (schedule == null)
         {
             return Result<ScheduleDto>.Failure(Error.NotFound("Schedule", idKey));
@@ -227,8 +228,8 @@ public class ScheduleService(
             return Result.Failure(Error.NotFound("Schedule", idKey));
         }
 
-        // Find schedule
-        var schedule = await context.Schedules.FindAsync([id], ct);
+        // Find schedule. AsTracking required for soft-delete mutation (global QueryTrackingBehavior is NoTracking). (fixes #685)
+        var schedule = await context.Schedules.AsTracking().FirstOrDefaultAsync(s => s.Id == id, ct);
         if (schedule == null)
         {
             return Result.Failure(Error.NotFound("Schedule", idKey));

--- a/src/Koinon.Application/Services/SecurityRoleService.cs
+++ b/src/Koinon.Application/Services/SecurityRoleService.cs
@@ -225,7 +225,10 @@ public class SecurityRoleService(
             return Result<SecurityRoleDto>.Failure(Error.FromFluentValidation(validation));
         }
 
+        // AsTracking required: global QueryTrackingBehavior is NoTracking (see PostgreSqlProvider),
+        // so without it SaveChanges would not persist the mutations below. (fixes #685)
         var entity = await context.SecurityRoles
+            .AsTracking()
             .FirstOrDefaultAsync(r => r.Id == roleId, ct);
 
         if (entity == null)

--- a/tests/Koinon.Application.Tests/Services/CommunicationTemplateServiceTests.cs
+++ b/tests/Koinon.Application.Tests/Services/CommunicationTemplateServiceTests.cs
@@ -1,0 +1,268 @@
+using AutoMapper;
+using FluentAssertions;
+using Koinon.Application.Common;
+using Koinon.Application.DTOs;
+using Koinon.Application.Interfaces;
+using Koinon.Application.Mapping;
+using Koinon.Application.Services;
+using Koinon.Domain.Entities;
+using Koinon.Domain.Enums;
+using Koinon.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Koinon.Application.Tests.Services;
+
+/// <summary>
+/// Tests for CommunicationTemplateService.
+///
+/// IMPORTANT: The in-memory DbContext is configured with
+/// <see cref="QueryTrackingBehavior.NoTracking"/> to mirror the production
+/// PostgreSqlProvider default. This is critical: without it, these tests
+/// would silently pass even if the service forgot to call
+/// <c>AsTracking()</c> — which was the root cause of bug #685 (PUT
+/// appearing to succeed but subsequent GET returning stale data because
+/// the mutations were never persisted to the database).
+/// </summary>
+public class CommunicationTemplateServiceTests : IDisposable
+{
+    private readonly KoinonDbContext _context;
+    private readonly IMapper _mapper;
+    private readonly Mock<IMergeFieldService> _mockMergeFieldService;
+    private readonly Mock<ILogger<CommunicationTemplateService>> _mockLogger;
+    private readonly CommunicationTemplateService _service;
+
+    public CommunicationTemplateServiceTests()
+    {
+        var options = new DbContextOptionsBuilder<KoinonDbContext>()
+            .UseInMemoryDatabase(databaseName: $"KoinonTestDb_{Guid.NewGuid()}")
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+            .ConfigureWarnings(w => w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning))
+            .Options;
+
+        _context = new KoinonDbContext(options);
+        _context.Database.EnsureCreated();
+
+        var mapperConfig = new MapperConfiguration(cfg =>
+        {
+            cfg.AddProfile<CommunicationTemplateMappingProfile>();
+        });
+        _mapper = mapperConfig.CreateMapper();
+
+        _mockMergeFieldService = new Mock<IMergeFieldService>();
+        _mockMergeFieldService
+            .Setup(m => m.ValidateMergeFields(It.IsAny<string>()))
+            .Returns(Result.Success());
+
+        _mockLogger = new Mock<ILogger<CommunicationTemplateService>>();
+
+        _service = new CommunicationTemplateService(
+            _context,
+            _mapper,
+            _mockMergeFieldService.Object,
+            _mockLogger.Object
+        );
+
+        SeedTestData();
+    }
+
+    private void SeedTestData()
+    {
+        _context.CommunicationTemplates.Add(new CommunicationTemplate
+        {
+            Id = 1,
+            Name = "Welcome Email",
+            CommunicationType = CommunicationType.Email,
+            Subject = "Welcome!",
+            Body = "Hello {{FirstName}}",
+            Description = "Initial welcome email",
+            IsActive = true,
+            CreatedDateTime = DateTime.UtcNow
+        });
+
+        _context.CommunicationTemplates.Add(new CommunicationTemplate
+        {
+            Id = 2,
+            Name = "Event Reminder",
+            CommunicationType = CommunicationType.Sms,
+            Body = "Reminder: event tonight",
+            IsActive = true,
+            CreatedDateTime = DateTime.UtcNow
+        });
+
+        _context.SaveChanges();
+        // Detach all seeded entities so they behave like rows loaded fresh from the DB.
+        // Critical for a NoTracking context: without this, DbSet.Remove(detachedCopy) on an
+        // entity whose seed copy is still tracked throws an identity-conflict exception.
+        _context.ChangeTracker.Clear();
+    }
+
+    // ---------------------------------------------------------------------
+    // Bug #685 — UpdateAsync must persist mutations to the database.
+    //
+    // Before the fix, CommunicationTemplateService.UpdateAsync loaded the
+    // entity without .AsTracking(). Because the global QueryTrackingBehavior
+    // is NoTracking (see PostgreSqlProvider), the returned entity was
+    // detached; subsequent property mutations and SaveChanges were no-ops.
+    // The PUT response reflected the (in-memory) mutations, but the DB
+    // retained the original values — so the next GET returned stale data.
+    //
+    // These tests fail against the pre-fix code and pass against the fixed
+    // code.
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public async Task UpdateAsync_Name_PersistsToDatabase()
+    {
+        // Arrange
+        var existing = await _context.CommunicationTemplates.AsNoTracking().FirstAsync(t => t.Id == 1);
+        var idKey = existing.IdKey;
+        var dto = new UpdateCommunicationTemplateDto { Name = "Renamed Welcome" };
+
+        // Act
+        var result = await _service.UpdateAsync(idKey, dto);
+
+        // Assert — response reflects new name
+        result.IsSuccess.Should().BeTrue();
+        result.Value!.Name.Should().Be("Renamed Welcome");
+
+        // Assert — DB actually has the new name (fresh read bypasses any local tracking)
+        var reloaded = await _context.CommunicationTemplates.AsNoTracking().FirstAsync(t => t.Id == 1);
+        reloaded.Name.Should().Be("Renamed Welcome");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Body_PersistsToDatabase()
+    {
+        // Arrange
+        var existing = await _context.CommunicationTemplates.AsNoTracking().FirstAsync(t => t.Id == 1);
+        var idKey = existing.IdKey;
+        var dto = new UpdateCommunicationTemplateDto { Body = "Updated body content" };
+
+        // Act
+        var result = await _service.UpdateAsync(idKey, dto);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var reloaded = await _context.CommunicationTemplates.AsNoTracking().FirstAsync(t => t.Id == 1);
+        reloaded.Body.Should().Be("Updated body content");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_Name_IsReflectedInSubsequentGetByIdKey()
+    {
+        // Reproduces the end-to-end symptom reported in #685: PUT then GET must show fresh data.
+        // Arrange
+        var existing = await _context.CommunicationTemplates.AsNoTracking().FirstAsync(t => t.Id == 2);
+        var idKey = existing.IdKey;
+        var dto = new UpdateCommunicationTemplateDto { Name = "Event Reminder v2" };
+
+        // Act
+        var updateResult = await _service.UpdateAsync(idKey, dto);
+        updateResult.IsSuccess.Should().BeTrue();
+
+        var getResult = await _service.GetByIdKeyAsync(idKey);
+
+        // Assert
+        getResult.Should().NotBeNull();
+        getResult!.Name.Should().Be("Event Reminder v2");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_IsActiveFalse_PersistsToDatabase()
+    {
+        // Arrange
+        var existing = await _context.CommunicationTemplates.AsNoTracking().FirstAsync(t => t.Id == 1);
+        var idKey = existing.IdKey;
+        var dto = new UpdateCommunicationTemplateDto { IsActive = false };
+
+        // Act
+        var result = await _service.UpdateAsync(idKey, dto);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var reloaded = await _context.CommunicationTemplates.AsNoTracking().FirstAsync(t => t.Id == 1);
+        reloaded.IsActive.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ModifiedDateTime_IsSet()
+    {
+        // Arrange
+        var existing = await _context.CommunicationTemplates.AsNoTracking().FirstAsync(t => t.Id == 1);
+        var idKey = existing.IdKey;
+        var before = DateTime.UtcNow;
+        var dto = new UpdateCommunicationTemplateDto { Name = "Stamp test" };
+
+        // Act
+        var result = await _service.UpdateAsync(idKey, dto);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var reloaded = await _context.CommunicationTemplates.AsNoTracking().FirstAsync(t => t.Id == 1);
+        reloaded.ModifiedDateTime.Should().NotBeNull();
+        reloaded.ModifiedDateTime!.Value.Should().BeOnOrAfter(before);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_InvalidIdKey_ReturnsNotFound()
+    {
+        // Arrange
+        var dto = new UpdateCommunicationTemplateDto { Name = "Ignored" };
+
+        // Act
+        var result = await _service.UpdateAsync("not-a-real-idkey", dto);
+
+        // Assert
+        result.IsFailure.Should().BeTrue();
+        result.Error!.Code.Should().Be("NOT_FOUND");
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesTemplateFromDatabase()
+    {
+        // Arrange
+        var existing = await _context.CommunicationTemplates.AsNoTracking().FirstAsync(t => t.Id == 1);
+        var idKey = existing.IdKey;
+
+        // Act
+        var result = await _service.DeleteAsync(idKey);
+
+        // Assert
+        result.IsSuccess.Should().BeTrue();
+        var reloaded = await _context.CommunicationTemplates.AsNoTracking().FirstOrDefaultAsync(t => t.Id == 1);
+        reloaded.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task CreateAsync_NewTemplate_IsPersistedAndRetrievable()
+    {
+        // Arrange
+        var dto = new CreateCommunicationTemplateDto
+        {
+            Name = "New Template",
+            CommunicationType = "Email",
+            Subject = "Hi",
+            Body = "Test body",
+            IsActive = true
+        };
+
+        // Act
+        var createResult = await _service.CreateAsync(dto);
+
+        // Assert
+        createResult.IsSuccess.Should().BeTrue();
+        var getResult = await _service.GetByIdKeyAsync(createResult.Value!.IdKey);
+        getResult.Should().NotBeNull();
+        getResult!.Name.Should().Be("New Template");
+        getResult.Body.Should().Be("Test body");
+    }
+
+    public void Dispose()
+    {
+        _context.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #685 (PM will close after merge).

The reported bug (`PUT /api/v1/communication-templates/{idKey}` appearing to succeed but subsequent GETs returning stale data) was misdiagnosed as a Redis read-through cache invalidation issue. There is no read-through cache on the template path. Investigation found the **actual root cause** is identical to #694/#695: services load entities with `FirstOrDefaultAsync`/`FindAsync` without `.AsTracking()`, and the global `QueryTrackingBehavior.NoTracking` (set in `PostgreSqlProvider`) returns **detached** entities. Subsequent mutations + `SaveChangesAsync` are silently dropped. The PUT response reflects the in-memory mutation (so the response looks correct), but the DB row is unchanged and the next GET returns the original value.

## Before / after curl (live verified)

```
# Before
PUT {"name":"renamed-27836"} → response {"name":"renamed-27836", ...}
GET .../HgAAAA              → {"name":"cache-test-8495", ...}   ← stale!
psql SELECT ... → cache-test-8495                                ← DB unchanged

# After (this PR)
PUT {"name":"renamed-verify-29520"} → response {"name":"renamed-verify-29520", ...}
GET .../HwAAAA                      → {"name":"renamed-verify-29520", ...}   ✓ fresh
DELETE .../HwAAAA                   → 204 No Content
GET .../HwAAAA                      → 404                                    ✓
```

## Per-entity bugs fixed

| Service | Methods fixed |
|---|---|
| CommunicationTemplateService | UpdateAsync |
| CommunicationService | UpdateAsync, SendAsync, ScheduleAsync, CancelScheduleAsync |
| CommunicationPreferenceService | UpdateAsync, BulkUpdateAsync |
| DefinedTypeService | UpdateValueAsync, DeleteValueAsync, ReorderValuesAsync |
| CampusService | UpdateAsync, DeleteAsync |
| LocationService | UpdateAsync, DeleteAsync |
| ScheduleService | UpdateAsync, DeleteAsync |
| GroupTypeService | UpdateGroupTypeAsync, ArchiveGroupTypeAsync |
| SecurityRoleService | UpdateAsync |
| FollowUpService | UpdateStatusAsync, AssignFollowUpAsync |
| NotificationService | MarkAsReadAsync, UpdatePreferenceAsync |

Already OK (confirmed, not changed):
- **FundService** uses `ExecuteUpdateAsync` (bypasses the change tracker)
- **DeviceService** already fixed in #694/#695; pattern borrowed from there

### No helper method added

The existing convention (explicit `.AsTracking()` with a comment pointing to `PostgreSqlProvider`) is already established by the #694/#695 fix in DeviceService. Adding an abstraction layer here would duplicate EF's own API without providing additional safety; the clearer fix is to apply the existing convention consistently. A base class or attribute-based solution would be over-engineering for alpha.

### Audit scope honesty

A full sweep for the same pattern found ~25 services with latent instances of the same bug (load-and-mutate + `SaveChangesAsync` without `AsTracking`). Given the 60-minute budget, I fixed the #685 target plus the highest-impact admin/config entities listed above (covers everything the issue flagged as expected candidates). Remaining services (e.g., `PersonService.UpdatePhotoAsync`, `UserSettingsService.*`, `MyProfileService.*`, `AuthorizedPickupService.*`, several Check-in and Giving services) still carry the latent pattern. Recommend a follow-up issue for a full sweep using the same surgical fix — no architectural rewrite needed.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet test tests/Koinon.Application.Tests` — **746 passed** (includes 8 new tests in `CommunicationTemplateServiceTests` that fail against pre-fix code and pass after)
- [x] Live curl — PUT+GET returns fresh data; DELETE+GET returns 404
- [x] `git diff --name-only` restricted to allowed paths (11 `src/Koinon.Application/Services/*.cs` + 1 new test file)
- [ ] CI green

### New unit tests

`CommunicationTemplateServiceTests` (8 tests) uses a NoTracking in-memory context (mirroring production) to verify:
- `UpdateAsync` Name / Body / IsActive / ModifiedDateTime are actually written to the DB (reproduces #685)
- `UpdateAsync` result is reflected in a subsequent `GetByIdKeyAsync` call
- `DeleteAsync` hard-deletes the row
- `CreateAsync` inserts the row
- Invalid IdKey returns NotFound

🤖 Generated with [Claude Code](https://claude.com/claude-code)